### PR TITLE
fix: passthrough 子命令支持传递 --login 等选项参数

### DIFF
--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -342,9 +342,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(argv)
+    args, unknown = parser.parse_known_args(argv)
     if not getattr(args, "command", None):
         return _cmd_chat(argparse.Namespace(script_args=[]))
+    if unknown:
+        if hasattr(args, "script_args"):
+            args.script_args = list(getattr(args, "script_args", [])) + unknown
+        else:
+            parser.parse_args(argv)
     return args.func(args)
 
 


### PR DESCRIPTION
将 parse_args 改为 parse_known_args，对 passthrough 命令把 未被识别的参数合并到 script_args，使 --login、--test 等
选项能正确透传给底层脚本。