### PR TITLE
feat: add MCP and skill extension support

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,241 @@
+# AGENT.md
+
+This file is for coding agents and maintainers working on `sjtu-agent`.
+It summarizes the project shape, extension points, and the conventions that
+matter most when changing the repo.
+
+## Project Shape
+
+`sjtu-agent` is a Python campus assistant for SJTU students. It has several
+entrypoints that should keep the same behavior:
+
+- Terminal chat: `agent.py`, `sjtu_agent/agent/chat_loop.py`
+- Web UI: `sjtu_agent/web/server.py`
+- Telegram bot: `telegram_bot.py`
+- Feishu bot: `feishu_bot.py`
+- WeChat bot: `wechat_bot.py`
+- External MCP server: `mcp_server.py`
+- CLI wrapper: `sjtu_agent/cli.py`
+
+The root `agent.py` is a compatibility shim. Most new agent logic should live
+under `sjtu_agent/agent/` or `sjtu_agent/extensions/`.
+
+## Runtime Paths
+
+Do not assume runtime state lives in the repo root. Use `sjtu_agent.paths`.
+
+Important paths:
+
+- `CONFIG_PATH`: campus credentials and feature config
+- `AGENT_CONFIG_PATH`: LLM provider config
+- `ENV_PATH`: local environment file
+- `DATA_DIR`: user data directory, overrideable with `SJTU_AGENT_HOME`
+
+Tests and setup flows often patch these paths, so avoid caching path-derived
+state too early unless there is an explicit invalidation path.
+
+## Tool Architecture
+
+The historical built-in tools are defined in `sjtu_agent/agent/tools.py` as
+OpenAI function-calling schemas plus `tool_*` implementations.
+
+New code should use the dynamic registry:
+
+- `sjtu_agent.extensions.registry.get_available_tools()`
+- `sjtu_agent.extensions.registry.run_registered_tool(name, args)`
+
+The registry combines:
+
+- built-in tools from `sjtu_agent/agent/tools.py`
+- enabled external MCP tools
+
+Keep `agent.TOOLS` and `agent.run_tool` backward compatible because existing
+bots and older scripts may import them. New integrations should prefer the
+registry methods or the re-exported `agent.get_available_tools()` and
+`agent.run_registered_tool()`.
+
+## MCP Client Support
+
+External MCP client support lives in `sjtu_agent/extensions/mcp_client.py`.
+
+Supported transports:
+
+- `stdio`
+- `sse`
+- `streamable_http` / `http`
+
+Config shape in `config.json`:
+
+```json
+{
+  "mcp_servers": {
+    "server_id": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "python",
+      "args": ["server.py"],
+      "cwd": "optional/working/dir",
+      "env": {},
+      "call_timeout": 120
+    }
+  }
+}
+```
+
+MCP tools are exposed to the LLM as:
+
+```text
+mcp__<server_id>__<tool_name>
+```
+
+Custom MCP servers can be registered without code changes:
+
+- CLI: `python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
+- Chat: route "add/register/connect a custom MCP server" requests to
+  `add_mcp_server`. The first chat call must leave
+  `acknowledge_external_mcp=false`; only call again with true after the user
+  confirms the external command or URL.
+
+The MCP adapter intentionally opens short-lived sessions for discovery and
+tool calls. This keeps the synchronous runner simple and avoids long-lived
+subprocess lifecycle bugs. If persistent sessions are added later, keep the
+current behavior as a reliable fallback.
+
+## Skill Support
+
+Prompt-only skill support lives in `sjtu_agent/extensions/skills.py`.
+
+Config shape in `config.json`:
+
+```json
+{
+  "skills": {
+    "enabled": ["shuiyuan-mcp"],
+    "dirs": []
+  }
+}
+```
+
+Skill files are loaded from:
+
+- bundled skills: `sjtu_agent/skills/<name>/SKILL.md`
+- repo-local skills: `skills/<name>/SKILL.md`
+- user data skills: `<DATA_DIR>/skills/<name>/SKILL.md`
+- extra directories listed in `skills.dirs`
+
+`"enabled": ["*"]` is supported and loads every `SKILL.md` found in the
+configured skill directories. Prefer explicit skill names for normal user
+configs so prompts remain predictable.
+
+The active system prompt should be built with:
+
+```python
+from sjtu_agent.agent.prompts import build_system_prompt
+```
+
+Do not append directly to `SYSTEM_PROMPT` in entrypoints. Use
+`build_system_prompt(...)` so enabled skills are included consistently.
+
+Custom skills can be added without code changes:
+
+- CLI: `python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
+- CLI: `python -m sjtu_agent.cli list-skills`
+- CLI: `python -m sjtu_agent.cli manage-skill disable my-skill`
+- Chat: route "add a custom skill" requests to `add_skill` after the user
+  provides either full `SKILL.md` content or a local source file path.
+- Chat: route "create a skill" / "skill creator" requests to `create_skill`.
+  If the tool returns `requires_more_info`, ask the returned questions before
+  trying again. If the user already provides a clear purpose and instructions,
+  create and enable the skill directly.
+- Chat: route "list skills" requests to `list_skills`, and route skill
+  enable/disable/delete requests to `manage_skill`.
+
+## Shuiyuan MCP Flow
+
+The built-in setup tool `setup_shuiyuan_mcp` installs and enables:
+
+<https://github.com/dajiaohuang/shuiyuan-mcp>
+
+Disclosure: `dajiaohuang/shuiyuan-mcp` is maintained by @dajiaohuang, the
+author of this setup integration. Keep that relationship visible in user-facing
+docs and avoid silently expanding the trust boundary.
+
+CLI entrypoint:
+
+```bash
+python -m sjtu_agent.cli setup-shuiyuan-mcp
+```
+
+Chat trigger:
+
+- "install Shuiyuan MCP"
+- "enable Shuiyuan MCP"
+- "load dajiaohuang/shuiyuan-mcp"
+- Chinese equivalents such as "安装水源 MCP" or "启用水源 MCP"
+
+These requests should route to the built-in `setup_shuiyuan_mcp` tool.
+The first chat-triggered call must leave `acknowledge_external_repo` false so
+the tool returns an explicit external-GitHub-repository warning. Only call it
+again with `acknowledge_external_repo=true` after the user confirms.
+
+Behavior:
+
+- clones or updates `dajiaohuang/shuiyuan-mcp`
+- checks out the default pinned commit unless the caller explicitly passes a ref
+- installs Node dependencies with `pnpm` if available, otherwise `npm`
+- builds the MCP server
+- writes `mcp_servers.shuiyuan` to `config.json`
+- enables the bundled `shuiyuan-mcp` skill
+- prints a `login_command` for cookie/profile setup
+
+The Shuiyuan MCP package declares Node.js `>=24`. The setup tool reports a
+warning if an older Node major version is detected.
+
+Default pinned ref:
+
+```text
+5c79b6e767f5aa55a3f342f5550ec74520fd52e5
+```
+
+## Prompt and Entry Points
+
+Multiple entrypoints run their own tool loops. When changing tool plumbing,
+check all of these:
+
+- `sjtu_agent/agent/runner.py`
+- `sjtu_agent/web/server.py`
+- `telegram_bot.py`
+- `feishu_bot.py`
+- `wechat_bot.py`
+
+They should all use dynamic tools and `build_system_prompt`.
+
+## Safety Rules
+
+High-impact actions need confirmation or a draft-first flow:
+
+- sending email
+- submitting Canvas assignments
+- posting or replying on Shuiyuan
+- making irreversible account/config changes
+
+When adding write tools, make the tool result explicit: target, action,
+success state, and any resulting URL or id.
+
+## Development Notes
+
+- Prefer focused changes over broad refactors.
+- Keep user runtime files out of git.
+- Do not overwrite unrelated dirty work.
+- Use `rg` for code search.
+- Use `python -m compileall sjtu_agent ...` for a quick syntax check.
+- The repo tests use `pytest`; if it is not installed in the current venv,
+  report that instead of pretending tests passed.
+
+Useful checks:
+
+```bash
+python -m compileall sjtu_agent agent.py telegram_bot.py feishu_bot.py wechat_bot.py mcp_server.py
+python -m sjtu_agent.cli --help
+python -m pytest
+```

--- a/MCP_SKILL_UPDATE.md
+++ b/MCP_SKILL_UPDATE.md
@@ -1,0 +1,253 @@
+# MCP and Skill Support Update
+
+Disclosure: the optional Shuiyuan MCP setup in this update installs
+[`dajiaohuang/shuiyuan-mcp`](https://github.com/dajiaohuang/shuiyuan-mcp), which
+is maintained by the PR author of this integration. The installer pins the
+checkout to a known commit by default instead of silently pulling future changes.
+
+披露说明：本更新中的可选 Shuiyuan MCP 安装流程会安装
+[`dajiaohuang/shuiyuan-mcp`](https://github.com/dajiaohuang/shuiyuan-mcp)，该仓库由本集成 PR 作者维护。安装器默认 pin 到一个已知 commit，而不是静默拉取未来变更。
+
+## English
+
+This update adds an extension layer for `sjtu-agent` so the agent can load
+external MCP servers and prompt-only skills in addition to its built-in tools.
+
+### What Changed
+
+- Added a dynamic tool registry that combines built-in tools and enabled MCP
+  tools.
+- Added MCP client support for `stdio`, `sse`, and `streamable_http` transports.
+- Added prompt-only skill loading through `SKILL.md` files.
+- Updated terminal chat, Web UI, Telegram bot, Feishu bot, and WeChat bot to use
+  the same dynamic tool and prompt loading path.
+- Added a bundled `shuiyuan-mcp` skill.
+- Added a setup flow for
+  [`dajiaohuang/shuiyuan-mcp`](https://github.com/dajiaohuang/shuiyuan-mcp).
+- Added `add-mcp-server` / `add_mcp_server` for custom MCP server registration.
+- Added `add-skill` / `add_skill` for custom prompt-only skills.
+- Added `create_skill`, `list_skills`, and `manage_skill` so the chat agent can
+  create skills from requirements, ask clarifying questions, and manage enabled
+  skills.
+
+### New Command
+
+```bash
+python -m sjtu_agent.cli setup-shuiyuan-mcp
+```
+
+### Trigger Paths
+
+There are two supported ways to trigger the setup:
+
+- CLI: run `python -m sjtu_agent.cli setup-shuiyuan-mcp`.
+- Chat agent: ask the agent to "install Shuiyuan MCP", "enable Shuiyuan MCP",
+  or "load dajiaohuang/shuiyuan-mcp"; the model can then call the built-in
+  `setup_shuiyuan_mcp` tool. The first chat-triggered call only warns that this
+  installs an external GitHub repository and asks for confirmation. The model
+  should call the tool again with `acknowledge_external_repo=true` only after the
+  user explicitly confirms.
+
+Custom MCP servers can also be added in two ways:
+
+- CLI: `python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
+- Chat agent: ask the agent to add or register a custom MCP server. The first
+  tool call returns an external-command/URL warning; only after user confirmation
+  should the model call `add_mcp_server` with `acknowledge_external_mcp=true`.
+
+Custom prompt-only skills can be added in two ways:
+
+- CLI: `python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
+- CLI: `python -m sjtu_agent.cli list-skills`
+- CLI: `python -m sjtu_agent.cli manage-skill disable my-skill`
+- Chat agent: ask the agent to add a skill and provide the `SKILL.md` content or
+  a local source file path; the model can call `add_skill`.
+- Chat agent: ask the agent to create a skill from a described need. The model
+  calls `create_skill`; if the tool returns `requires_more_info`, it asks the
+  returned questions before creating the skill. Skill listing and enable/disable
+  or deletion requests route through `list_skills` and `manage_skill`.
+
+The command clones or updates `dajiaohuang/shuiyuan-mcp`, installs Node
+dependencies, checks out the pinned commit, builds the MCP server, registers it
+in `config.json`, and enables the bundled `shuiyuan-mcp` skill.
+
+Useful options:
+
+```bash
+python -m sjtu_agent.cli setup-shuiyuan-mcp --read-only
+python -m sjtu_agent.cli setup-shuiyuan-mcp --login
+python -m sjtu_agent.cli setup-shuiyuan-mcp --install-dir /path/to/shuiyuan-mcp
+python -m sjtu_agent.cli setup-shuiyuan-mcp --ref <commit-or-tag>
+```
+
+### Config Format
+
+External MCP servers are configured in `config.json`:
+
+```json
+{
+  "mcp_servers": {
+    "shuiyuan": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "node",
+      "args": ["/path/to/shuiyuan-mcp/dist/shuiyuan-mcp.js"],
+      "cwd": "/path/to/shuiyuan-mcp",
+      "call_timeout": 180
+    }
+  }
+}
+```
+
+Enabled skills are configured with:
+
+```json
+{
+  "skills": {
+    "enabled": ["shuiyuan-mcp"],
+    "dirs": []
+  }
+}
+```
+
+MCP tools are exposed to the LLM using this naming pattern:
+
+```text
+mcp__<server_id>__<tool_name>
+```
+
+For example:
+
+```text
+mcp__shuiyuan__discourse_search
+```
+
+### Notes
+
+- `shuiyuan-mcp` requires Node.js 24 or newer.
+- The default pinned ref is `5c79b6e767f5aa55a3f342f5550ec74520fd52e5`.
+- If Shuiyuan MCP reports a missing profile or cookies, run the `login_command`
+  printed by `setup-shuiyuan-mcp`.
+- The existing built-in tools remain available and backward compatible.
+
+## 中文
+
+这次更新为 `sjtu-agent` 增加了扩展层，使 agent 除了内置工具以外，还能加载外部 MCP Server 和 prompt-only skill。
+
+### 主要变化
+
+- 新增动态工具注册表，可以合并内置工具和已启用的 MCP 工具。
+- 新增 MCP client 支持，支持 `stdio`、`sse`、`streamable_http` 三种传输方式。
+- 新增基于 `SKILL.md` 的 prompt-only skill 加载机制。
+- 终端对话、Web UI、Telegram Bot、飞书 Bot、微信 Bot 统一接入动态工具和动态 system prompt。
+- 内置一个 `shuiyuan-mcp` skill。
+- 新增
+  [`dajiaohuang/shuiyuan-mcp`](https://github.com/dajiaohuang/shuiyuan-mcp)
+  的安装和启用流程。
+
+### 新命令
+
+```bash
+python -m sjtu_agent.cli setup-shuiyuan-mcp
+```
+
+### 触发方式
+
+目前支持两种触发方式：
+
+- CLI：运行 `python -m sjtu_agent.cli setup-shuiyuan-mcp`。
+- 对话 agent：对 agent 说「安装水源 MCP」「启用 Shuiyuan MCP」或
+  「加载 dajiaohuang/shuiyuan-mcp」，模型会调用内置的
+  `setup_shuiyuan_mcp` 工具。第一次由对话触发时只会提示这是外部 GitHub
+  仓库安装并要求确认；只有用户明确确认后，模型才应再次调用工具并传入
+  `acknowledge_external_repo=true` 开始安装。
+
+这个命令会拉取或更新 `dajiaohuang/shuiyuan-mcp`，安装 Node 依赖，checkout 到默认 pin 的 commit，构建 MCP server，写入 `config.json`，并启用内置的 `shuiyuan-mcp` skill。
+
+常用选项：
+
+```bash
+python -m sjtu_agent.cli setup-shuiyuan-mcp --read-only
+python -m sjtu_agent.cli setup-shuiyuan-mcp --login
+python -m sjtu_agent.cli setup-shuiyuan-mcp --install-dir /path/to/shuiyuan-mcp
+python -m sjtu_agent.cli setup-shuiyuan-mcp --ref <commit-or-tag>
+```
+
+### 配置格式
+
+外部 MCP Server 写在 `config.json` 的 `mcp_servers` 字段：
+
+```json
+{
+  "mcp_servers": {
+    "shuiyuan": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "node",
+      "args": ["/path/to/shuiyuan-mcp/dist/shuiyuan-mcp.js"],
+      "cwd": "/path/to/shuiyuan-mcp",
+      "call_timeout": 180
+    }
+  }
+}
+```
+
+启用 skill 的配置：
+
+```json
+{
+  "skills": {
+    "enabled": ["shuiyuan-mcp"],
+    "dirs": []
+  }
+}
+```
+
+MCP 工具会以如下命名方式暴露给大模型：
+
+```text
+mcp__<server_id>__<tool_name>
+```
+
+例如：
+
+```text
+mcp__shuiyuan__discourse_search
+```
+
+### 注意事项
+
+- `shuiyuan-mcp` 需要 Node.js 24 或更高版本。
+- 默认 pin 的 ref 是 `5c79b6e767f5aa55a3f342f5550ec74520fd52e5`。
+- 如果 Shuiyuan MCP 提示缺少 profile 或 cookie，请运行 `setup-shuiyuan-mcp` 输出里的 `login_command`。
+- 原有内置工具仍然保留，并保持向后兼容。
+## Custom MCP and Skill Trigger Paths / 自定义 MCP 和 Skill 触发方式
+
+Custom MCP servers:
+
+- CLI: `python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
+- Chat agent: ask the agent to add or register a custom MCP server. The first
+  call only warns that an external command or URL will be trusted; after user
+  confirmation, call `add_mcp_server` with `acknowledge_external_mcp=true`.
+
+自定义 MCP server：
+
+- CLI：`python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
+- 对话 agent：让 agent 添加或注册自定义 MCP server。第一次调用只提示会信任外部命令或 URL；用户确认后，再调用 `add_mcp_server` 并传入 `acknowledge_external_mcp=true`。
+
+Custom prompt-only skills:
+
+- CLI: `python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
+- CLI: `python -m sjtu_agent.cli list-skills`
+- CLI: `python -m sjtu_agent.cli manage-skill disable my-skill`
+- Chat agent: ask the agent to add a skill and provide the full `SKILL.md`
+  content or a local source file path; the model can call `add_skill`.
+- Chat agent: ask the agent to create a skill from a described need. The model
+  calls `create_skill`; if more detail is needed, it asks the returned
+  questions. Skill listing and enable/disable/delete requests route to
+  `list_skills` and `manage_skill`.
+
+自定义 prompt-only skill：
+
+- CLI：`python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
+- 对话 agent：让 agent 添加 skill，并提供完整 `SKILL.md` 内容或本地文件路径；模型可调用 `add_skill`。

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ sjtu-agent daily-report --test
 sjtu-agent telegram-bot --test
 sjtu-agent remind-check --list
 sjtu-agent mcp --http --port 8765
+sjtu-agent setup-shuiyuan-mcp
+sjtu-agent add-mcp-server my-tools --transport stdio --command python --arg D:/path/to/server.py
+sjtu-agent add-skill my-skill --content-file D:/path/to/SKILL.md
 sjtu-agent install-daemons
 ```
 
@@ -114,6 +117,58 @@ sjtu-agent setup
 sjtu-agent setup --yes --skip-cookie-import --skip-launchd
 sjtu-agent setup --yes --write-daemons-only --output-dir /tmp/sjtu-agent-launchd
 ```
+
+## MCP and Skills
+
+Agent can expose its own tools as an MCP server, and it can also load external MCP servers as extra tools. External MCP server config lives in `config.json` under `mcp_servers`; enabled prompt-only skills live under `skills.enabled`.
+
+Disclosure: the optional Shuiyuan MCP integration installs
+[dajiaohuang/shuiyuan-mcp](https://github.com/dajiaohuang/shuiyuan-mcp), which is
+maintained by the PR author of this integration. The setup command pins the
+checkout to a known commit by default instead of silently pulling future changes
+into the agent trust domain.
+
+Install and enable Shuiyuan MCP:
+
+```bash
+sjtu-agent setup-shuiyuan-mcp
+```
+
+You can also trigger the same setup from the chat agent by asking it to
+"install Shuiyuan MCP", "enable Shuiyuan MCP", or "load dajiaohuang/shuiyuan-mcp".
+The first chat-triggered call will only warn that this installs an external
+GitHub repository and ask for confirmation; installation starts only after the
+user explicitly confirms.
+
+This pulls and builds [dajiaohuang/shuiyuan-mcp](https://github.com/dajiaohuang/shuiyuan-mcp), registers it as the `shuiyuan` MCP server, and enables the bundled `shuiyuan-mcp` skill. If the MCP server later reports a missing profile/cookie, run the `login_command` printed by the setup command once.
+
+Add any custom MCP server:
+
+```bash
+sjtu-agent add-mcp-server my-tools --transport stdio --command python --arg D:/path/to/server.py
+sjtu-agent add-mcp-server remote-tools --transport sse --url http://127.0.0.1:8765/sse
+```
+
+You can also ask the chat agent to "add a custom MCP server". The first
+chat-triggered call only warns that an external command or URL will be trusted;
+the agent should proceed only after explicit confirmation.
+
+Add a custom prompt-only skill:
+
+```bash
+sjtu-agent add-skill my-skill --content-file D:/path/to/SKILL.md
+sjtu-agent list-skills
+sjtu-agent manage-skill disable my-skill
+```
+
+You can also ask the chat agent to add a skill and provide either the full
+`SKILL.md` content or a local source file path.
+
+For a more agent-native flow, ask the chat agent to "create a skill" and
+describe the behavior you want. If the requirement is not clear enough, the
+agent asks follow-up questions; once it has a name, trigger, and instructions it
+uses `create_skill`. You can also ask it to list, enable, disable, or delete
+skills through `list_skills` and `manage_skill`.
 
 ## macOS 后台服务
 

--- a/config.example.json
+++ b/config.example.json
@@ -26,5 +26,27 @@
 
   "_shuiyuan_comment": "水源社区 Discourse User API Key，通过授权流程获取，不会过期",
   "shuiyuan_user_api_key": "YOUR_USER_API_KEY",
-  "shuiyuan_user_api_client_id": "YOUR_CLIENT_ID"
+  "shuiyuan_user_api_client_id": "YOUR_CLIENT_ID",
+
+  "_mcp_comment": "External MCP servers loaded by the agent. setup_shuiyuan_mcp can fill the shuiyuan entry automatically.",
+  "mcp_servers": {
+    "shuiyuan": {
+      "enabled": false,
+      "transport": "stdio",
+      "command": "node",
+      "args": ["C:/Users/you/AppData/Roaming/sjtu-agent/mcp/shuiyuan-mcp/dist/shuiyuan-mcp.js"],
+      "cwd": "C:/Users/you/AppData/Roaming/sjtu-agent/mcp/shuiyuan-mcp"
+    },
+    "custom-example": {
+      "enabled": false,
+      "transport": "sse",
+      "url": "http://127.0.0.1:8765/sse"
+    }
+  },
+
+  "_skills_comment": "Prompt-only skills to load into the agent system prompt.",
+  "skills": {
+    "enabled": [],
+    "dirs": []
+  }
 }

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -116,7 +116,7 @@ def _init_messages(sess: dict) -> None:
         return
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _FS_CTX,
+        "content": agent.build_system_prompt(_build_date_ctx(), _FS_CTX),
     })
 
 
@@ -127,7 +127,7 @@ def _capture_turn(sess: dict, user_text: str) -> str:
     """Run one agent turn, capture its stdout, return the assistant reply text."""
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _FS_CTX
+        sess["messages"][0]["content"] = agent.build_system_prompt(_build_date_ctx(), _FS_CTX)
     sess["messages"].append({"role": "user", "content": user_text})
 
     buf = io.StringIO()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ include = ["sjtu_agent", "sjtu_agent.*"]
 
 [tool.setuptools.package-data]
 "sjtu_agent.web" = ["static/*"]
+"sjtu_agent" = ["skills/*/SKILL.md"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/sjtu_agent/agent/__init__.py
+++ b/sjtu_agent/agent/__init__.py
@@ -1,5 +1,5 @@
 """sjtu_agent/agent/__init__.py — 统一导出接口。"""
-from sjtu_agent.agent.prompts import SYSTEM_PROMPT, _TOOL_LABELS
+from sjtu_agent.agent.prompts import SYSTEM_PROMPT, _TOOL_LABELS, build_system_prompt
 from sjtu_agent.agent.tools import (
     TOOLS, run_tool,
     tool_check_setup, tool_get_ddls, tool_get_next_lab, tool_get_all,
@@ -9,7 +9,9 @@ from sjtu_agent.agent.tools import (
     tool_download_assignments, tool_list_assignment_files, tool_read_assignment_file,
     tool_search_campus, tool_browse_mysjtu,
     tool_save_credentials, tool_login_platform,
-    tool_setup_canvas, tool_setup_shuiyuan, tool_setup_telegram, tool_setup_wechat, tool_setup_feishu,
+    tool_setup_canvas, tool_setup_shuiyuan, tool_setup_shuiyuan_mcp,
+    tool_add_mcp_server, tool_add_skill, tool_create_skill, tool_list_skills, tool_manage_skill,
+    tool_setup_telegram, tool_setup_wechat, tool_setup_feishu,
     tool_execute_python, tool_get_user_profile, tool_update_user_profile,
     tool_list_canvas_assignments, tool_submit_canvas_assignment,
     tool_refresh_mysjtu_catalog,
@@ -24,3 +26,8 @@ from sjtu_agent.agent.chat_loop import (
     load_agent_config, setup_agent_config, chat_loop, main,
     _prefetch_ddls_background, _check_for_updates, _UPDATE_AVAILABLE,
 )
+from sjtu_agent.extensions.registry import get_available_tools, run_registered_tool
+
+# Backward-compatible dynamic dispatcher. Existing integrations import
+# agent.run_tool; routing it through the registry lets MCP tools participate.
+run_tool = run_registered_tool

--- a/sjtu_agent/agent/chat_loop.py
+++ b/sjtu_agent/agent/chat_loop.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 
 from sjtu_agent.paths import AGENT_CONFIG_PATH, ENV_PATH, DDL_CACHE_PATH
 from sjtu_agent.terminal_ui import print_markdown_message, print_rule
-from sjtu_agent.agent.prompts import SYSTEM_PROMPT
+from sjtu_agent.agent.prompts import SYSTEM_PROMPT, build_system_prompt
 from sjtu_agent.agent.runner import _make_client, _run_one_turn, Spinner
 from sjtu_agent.agent.tools import TOOLS, run_tool, _fetch_ddls_parallel, _ddl_cache_get, tool_check_setup, _load_reminders
 
@@ -265,7 +265,7 @@ def chat_loop(client, model: str):
         f"「本学年」= {_cur_xnm}学年"
         f"（query_grades: year='{_cur_xnm}', semester=''）。"
     )
-    messages = [{"role": "system", "content": SYSTEM_PROMPT + _date_ctx}]
+    messages = [{"role": "system", "content": build_system_prompt(_date_ctx)}]
     model_box  = [model]   # 用列表包裹使内部可修改
     client_box = [client]  # 同理，切换模型时可替换 client
 
@@ -365,7 +365,7 @@ def chat_loop(client, model: str):
             model_box[0] = updated["model"]
             # 切换协议时重置对话，避免消息格式冲突
             messages.clear()
-            messages.append({"role": "system", "content": SYSTEM_PROMPT})
+            messages.append({"role": "system", "content": build_system_prompt()})
             proto = "Anthropic" if _is_anthropic_model(updated["model"]) else "OpenAI"
             print(f"  已切换到: {updated['model']}  [协议: {proto}]（已保存，对话已重置）\n")
             continue

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -361,6 +361,18 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 - 用户说"配置水源"/"授权水源" → 调用 setup_shuiyuan
 
+- 用户说"安装水源 MCP"/"启用 Shuiyuan MCP"/"加载 dajiaohuang/shuiyuan-mcp" → 调用 setup_shuiyuan_mcp
+
+- 用户说"添加自定义 MCP"/"连接 MCP server"/"注册 MCP 工具" → 调用 add_mcp_server。第一次调用不要传 acknowledge_external_mcp=true，必须先提示会注册外部命令或 URL，用户确认后再传 true。
+
+- 用户说"添加 skill"/"新增技能"/"加载自定义 SKILL.md" → 调用 add_skill。若用户没有提供完整 skill 内容或本地 source_file，先让用户补充。
+
+- 用户说"创建 skill"/"skill creator"/"做一个技能" → 调用 create_skill。若工具返回 requires_more_info，把 questions 逐条问用户；若需求已明确，直接创建并启用 skill。
+
+- 用户说"列出 skill"/"skill list"/"有哪些技能" → 调用 list_skills。
+
+- 用户说"启用 skill"/"禁用 skill"/"删除 skill"/"管理 skill" → 调用 manage_skill。
+
 - 用户说"配置选课社区"/"授权选课社区"/"登录 course.sjtu.plus" → 调用 setup_course_community
 
 - 查询失败时主动提议重新登录（login_platform）
@@ -423,6 +435,16 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 
 
+def build_system_prompt(*extra_sections: str) -> str:
+    """Build the active system prompt, including enabled prompt-only skills."""
+    try:
+        from sjtu_agent.extensions.skills import build_skill_prompt
+        skill_prompt = build_skill_prompt()
+    except Exception:
+        skill_prompt = ""
+    return SYSTEM_PROMPT + skill_prompt + "".join(s for s in extra_sections if s)
+
+
 _TOOL_LABELS = {
 
     "list_canvas_assignments":  "正在列出 Canvas 作业",
@@ -456,6 +478,18 @@ _TOOL_LABELS = {
     "setup_canvas":          "正在引导配置 Canvas",
 
     "setup_shuiyuan":          "正在授权水源社区",
+
+    "setup_shuiyuan_mcp":      "正在安装并启用水源 MCP",
+
+    "add_mcp_server":          "正在添加自定义 MCP Server",
+
+    "add_skill":               "正在添加自定义 Skill",
+
+    "create_skill":            "正在创建 Skill",
+
+    "list_skills":             "正在列出 Skills",
+
+    "manage_skill":            "正在管理 Skill",
 
     "setup_course_community":  "正在登录选课社区",
 

--- a/sjtu_agent/agent/runner.py
+++ b/sjtu_agent/agent/runner.py
@@ -26,14 +26,14 @@ from sjtu_agent.agent.prompts import _TOOL_LABELS
 
 def _get_tools():
     """Lazy import TOOLS，避免 runner ↔ tools 循环依赖。"""
-    from sjtu_agent.agent.tools import TOOLS
-    return TOOLS
+    from sjtu_agent.extensions.registry import get_available_tools
+    return get_available_tools()
 
 
 def _get_run_tool():
     """Lazy import run_tool，避免循环依赖。"""
-    from sjtu_agent.agent.tools import run_tool
-    return run_tool
+    from sjtu_agent.extensions.registry import run_registered_tool
+    return run_registered_tool
 
 
 def _ansi_supported() -> bool:

--- a/sjtu_agent/agent/tools.py
+++ b/sjtu_agent/agent/tools.py
@@ -29,6 +29,8 @@ from sjtu_agent.paths import (
     DDL_CACHE_PATH,
     ENV_PATH,
     MYSJTU_CATALOG_PATH,
+    PACKAGE_ROOT,
+    PROJECT_ROOT,
     REMINDERS_PATH,
     USER_PROFILE_PATH,
     atomic_write_json,
@@ -42,6 +44,15 @@ except ImportError:
     HAS_PLAYWRIGHT = False
 
 import ddl_checker as dc
+
+
+_SHUIYUAN_MCP_REPO = "https://github.com/dajiaohuang/shuiyuan-mcp.git"
+_SHUIYUAN_MCP_PINNED_REF = "5c79b6e767f5aa55a3f342f5550ec74520fd52e5"
+_SHUIYUAN_MCP_DISCLOSURE = (
+    "Disclosure: dajiaohuang/shuiyuan-mcp is maintained by @dajiaohuang, "
+    "the author of this setup integration. The default setup pins the checkout "
+    f"to commit {_SHUIYUAN_MCP_PINNED_REF} instead of pulling future changes automatically."
+)
 
 
 TOOLS = [
@@ -100,6 +111,177 @@ TOOLS = [
             "name": "setup_shuiyuan",
             "description": "交互式授权水源社区 Discourse User API Key。会自动打开浏览器，用户在页面点击授权后自动完成，无需手动操作。用户说'配置水源'/'授权水源'/'设置水源'时调用。",
             "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "setup_shuiyuan_mcp",
+            "description": (
+                "Install or enable the external Shuiyuan MCP server from "
+                "https://github.com/dajiaohuang/shuiyuan-mcp, add it to the "
+                "agent MCP registry, and enable the bundled shuiyuan-mcp skill. "
+                "Disclosure: that MCP repo is maintained by this integration's PR author; "
+                "the default install checks out a pinned commit. "
+                "Use when the user asks to install/enable/load Shuiyuan MCP."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "install_dir": {
+                        "type": "string",
+                        "description": "Optional local install directory. Defaults to the sjtu-agent data dir.",
+                    },
+                    "enable": {
+                        "type": "boolean",
+                        "description": "Whether to enable the MCP server after installation. Defaults to true.",
+                    },
+                    "allow_writes": {
+                        "type": "boolean",
+                        "description": "Whether Shuiyuan MCP should expose write tools. Defaults to true.",
+                    },
+                    "run_login": {
+                        "type": "boolean",
+                        "description": "Whether to run shuiyuan-mcp-login after install. Defaults to false.",
+                    },
+                    "ref": {
+                        "type": "string",
+                        "description": "Optional git commit/tag/branch to checkout. Defaults to a pinned commit.",
+                    },
+                    "acknowledge_external_repo": {
+                        "type": "boolean",
+                        "description": (
+                            "Must be true before installation starts. The first call from chat should leave this "
+                            "false so the user is warned that this installs an external GitHub repository."
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_mcp_server",
+            "description": (
+                "Register a custom external MCP server in config.json. "
+                "Use when the user asks to add/connect/configure a custom MCP server. "
+                "The first chat-triggered call must leave acknowledge_external_mcp=false "
+                "so the user is warned before an external command or URL is trusted."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "server_id": {"type": "string", "description": "Short MCP server id, e.g. filesystem or my_tools."},
+                    "transport": {
+                        "type": "string",
+                        "enum": ["stdio", "sse", "streamable_http", "http"],
+                        "description": "MCP transport. Defaults to stdio.",
+                    },
+                    "command": {"type": "string", "description": "Command for stdio transport, e.g. python or node."},
+                    "args": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Command arguments for stdio transport.",
+                    },
+                    "url": {"type": "string", "description": "MCP endpoint URL for sse/http transports."},
+                    "cwd": {"type": "string", "description": "Optional working directory for stdio transport."},
+                    "env": {"type": "object", "description": "Optional environment variables for stdio transport."},
+                    "headers": {"type": "object", "description": "Optional HTTP headers for sse/http transports."},
+                    "enabled": {"type": "boolean", "description": "Whether to enable immediately. Defaults to true."},
+                    "call_timeout": {"type": "integer", "description": "Tool call timeout in seconds. Defaults to 120."},
+                    "acknowledge_external_mcp": {
+                        "type": "boolean",
+                        "description": "Must be true before saving from chat after the external MCP warning.",
+                    },
+                },
+                "required": ["server_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_skill",
+            "description": (
+                "Create or update a custom prompt-only skill under the sjtu-agent data directory "
+                "and optionally enable it. Use when the user asks to add a custom skill."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Skill directory name, e.g. my-skill."},
+                    "content": {"type": "string", "description": "SKILL.md content to write."},
+                    "source_file": {"type": "string", "description": "Optional local file path to read SKILL.md content from."},
+                    "enabled": {"type": "boolean", "description": "Whether to add the skill to skills.enabled. Defaults to true."},
+                },
+                "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_skill",
+            "description": (
+                "Create a prompt-only skill from a user's natural-language requirements. "
+                "If the requirement is underspecified, return follow-up questions instead "
+                "of writing a skill. Use when the user asks for skill creator / create a skill."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Short skill id, e.g. exam-planner."},
+                    "purpose": {"type": "string", "description": "What user need should trigger this skill."},
+                    "triggers": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Example phrases or situations that should activate this skill.",
+                    },
+                    "instructions": {
+                        "type": "string",
+                        "description": "Concrete instructions the agent should follow when the skill is active.",
+                    },
+                    "constraints": {"type": "string", "description": "Optional boundaries, safety notes, or style constraints."},
+                    "examples": {"type": "string", "description": "Optional examples of good use."},
+                    "content": {"type": "string", "description": "Optional full SKILL.md content. Overrides generated content."},
+                    "enabled": {"type": "boolean", "description": "Whether to enable after creation. Defaults to true."},
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_skills",
+            "description": "List available prompt-only skills, their enabled state, source, and SKILL.md path.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "include_content": {
+                        "type": "boolean",
+                        "description": "Whether to include SKILL.md text snippets. Defaults to false.",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "manage_skill",
+            "description": "Enable, disable, or delete a prompt-only skill. Deletion is limited to user-data skills.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {"type": "string", "enum": ["enable", "disable", "delete"]},
+                    "name": {"type": "string", "description": "Skill name / directory id."},
+                },
+                "required": ["action", "name"],
+            },
         },
     },
     {
@@ -1664,6 +1846,545 @@ def tool_setup_shuiyuan() -> dict:
         }
 
     return _setup_shuiyuan_session(cfg, username, password)
+
+
+def _run_setup_command(cmd: list[str], cwd: Path, timeout: int = 600) -> dict:
+    try:
+        proc = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, timeout=timeout)
+        return {
+            "cmd": cmd,
+            "ok": proc.returncode == 0,
+            "returncode": proc.returncode,
+            "stdout": proc.stdout[-4000:],
+            "stderr": proc.stderr[-4000:],
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {"cmd": cmd, "ok": False, "error": f"timeout after {timeout}s", "stdout": exc.stdout, "stderr": exc.stderr}
+    except Exception as exc:
+        return {"cmd": cmd, "ok": False, "error": str(exc)}
+
+
+def _node_major_version(node: str) -> int | None:
+    result = _run_setup_command([node, "--version"], CONFIG_PATH.parent, timeout=20)
+    text = (result.get("stdout") or result.get("stderr") or "").strip().lstrip("v")
+    try:
+        return int(text.split(".", 1)[0])
+    except Exception:
+        return None
+
+
+def _normalize_config_list(value) -> list:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, list):
+        return [str(x) for x in value if str(x).strip()]
+    return []
+
+
+def _valid_config_id(value: str, label: str) -> str:
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise ValueError(f"{label} is required")
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+", cleaned):
+        raise ValueError(f"{label} may only contain letters, numbers, dot, underscore, and hyphen")
+    return cleaned
+
+
+def tool_add_mcp_server(
+    server_id: str,
+    transport: str = "stdio",
+    command: str = "",
+    args: list | None = None,
+    url: str = "",
+    cwd: str = "",
+    env: dict | None = None,
+    headers: dict | None = None,
+    enabled: bool = True,
+    call_timeout: int = 120,
+    acknowledge_external_mcp: bool = False,
+) -> dict:
+    """Register a custom MCP server in config.json."""
+    server_id = _valid_config_id(server_id, "server_id")
+    transport = (transport or "stdio").strip().lower()
+    if transport not in {"stdio", "sse", "streamable_http", "http"}:
+        return {"error": f"Unsupported MCP transport: {transport}"}
+
+    args = _normalize_config_list(args)
+    env = env if isinstance(env, dict) else {}
+    headers = headers if isinstance(headers, dict) else {}
+    call_timeout = max(1, int(call_timeout or 120))
+
+    if transport == "stdio":
+        command = (command or "").strip()
+        if not command:
+            return {"error": "stdio MCP server requires `command`."}
+        external_target = " ".join([command, *args]).strip()
+    else:
+        url = (url or "").strip()
+        if not url:
+            return {"error": f"{transport} MCP server requires `url`."}
+        if not url.startswith(("http://", "https://")):
+            return {"error": "MCP URL must start with http:// or https://"}
+        external_target = url
+
+    if not acknowledge_external_mcp:
+        return {
+            "requires_confirmation": True,
+            "server_id": server_id,
+            "transport": transport,
+            "external_target": external_target,
+            "message": (
+                "This will register an external MCP server. The agent may execute the configured "
+                "stdio command or send requests to the configured HTTP endpoint when tools are used."
+            ),
+            "next_action": (
+                "Tell the user the exact external command or URL above. Only call add_mcp_server "
+                "again with acknowledge_external_mcp=true after the user explicitly confirms."
+            ),
+        }
+
+    cfg = read_json_safe(CONFIG_PATH, {})
+    mcp_servers = cfg.get("mcp_servers", {})
+    if not isinstance(mcp_servers, dict):
+        mcp_servers = {}
+
+    server_cfg: dict = {
+        "enabled": bool(enabled),
+        "transport": transport,
+        "call_timeout": call_timeout,
+    }
+    if transport == "stdio":
+        server_cfg.update({"command": command, "args": args})
+        if cwd:
+            server_cfg["cwd"] = str(Path(os.path.expandvars(cwd)).expanduser())
+        if env:
+            server_cfg["env"] = {str(k): str(v) for k, v in env.items()}
+    else:
+        server_cfg["url"] = url
+        if headers:
+            server_cfg["headers"] = {str(k): str(v) for k, v in headers.items()}
+
+    mcp_servers[server_id] = server_cfg
+    cfg["mcp_servers"] = mcp_servers
+    atomic_write_json(CONFIG_PATH, cfg)
+
+    try:
+        from sjtu_agent.extensions.mcp_client import list_openai_tools
+        list_openai_tools(force_refresh=True)
+    except Exception:
+        pass
+
+    return {
+        "ok": True,
+        "server_id": server_id,
+        "config": server_cfg,
+        "tool_prefix": f"mcp__{server_id}__",
+        "next_action": "Restart or continue the conversation; MCP tools will be rediscovered automatically.",
+    }
+
+
+def tool_add_skill(
+    name: str,
+    content: str = "",
+    source_file: str = "",
+    enabled: bool = True,
+) -> dict:
+    """Create/update a prompt-only skill and optionally enable it."""
+    name = _valid_config_id(name, "name")
+    source_file = (source_file or "").strip()
+    if source_file:
+        path = Path(os.path.expandvars(source_file)).expanduser()
+        if not path.exists() or not path.is_file():
+            return {"error": f"source_file not found: {source_file}"}
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            return {"error": f"failed to read source_file: {exc}"}
+    if not (content or "").strip():
+        return {"error": "Skill content is required. Provide content or source_file."}
+
+    skill_dir = CONFIG_PATH.parent / "skills" / name
+    skill_file = skill_dir / "SKILL.md"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_file.write_text(content.strip() + "\n", encoding="utf-8")
+
+    cfg = read_json_safe(CONFIG_PATH, {})
+    skills_cfg = cfg.get("skills", {})
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+    enabled_skills = _normalize_config_list(skills_cfg.get("enabled", []))
+    if enabled and name not in enabled_skills:
+        enabled_skills.append(name)
+    if not enabled and name in enabled_skills:
+        enabled_skills.remove(name)
+    skills_cfg["enabled"] = enabled_skills
+    cfg["skills"] = skills_cfg
+    atomic_write_json(CONFIG_PATH, cfg)
+
+    return {
+        "ok": True,
+        "name": name,
+        "path": str(skill_file),
+        "enabled": bool(enabled),
+        "next_action": "The skill prompt will be included in newly built system prompts.",
+    }
+
+
+def _slugify_skill_name(text: str) -> str:
+    words = re.findall(r"[A-Za-z0-9]+", text.lower())
+    return "-".join(words[:5])
+
+
+def _render_skill_content(
+    name: str,
+    purpose: str,
+    triggers: list | None,
+    instructions: str,
+    constraints: str = "",
+    examples: str = "",
+) -> str:
+    lines = [
+        f"# {name}",
+        "",
+        f"Use this skill when {purpose.strip()}",
+    ]
+    trigger_items = _normalize_config_list(triggers)
+    if trigger_items:
+        lines.extend(["", "## Triggers"])
+        lines.extend(f"- {item}" for item in trigger_items)
+    lines.extend(["", "## Instructions", instructions.strip()])
+    if (constraints or "").strip():
+        lines.extend(["", "## Constraints", constraints.strip()])
+    if (examples or "").strip():
+        lines.extend(["", "## Examples", examples.strip()])
+    return "\n".join(lines).strip() + "\n"
+
+
+def tool_create_skill(
+    name: str = "",
+    purpose: str = "",
+    triggers: list | None = None,
+    instructions: str = "",
+    constraints: str = "",
+    examples: str = "",
+    content: str = "",
+    enabled: bool = True,
+) -> dict:
+    """Create a prompt-only skill from structured requirements, or ask for missing details."""
+    purpose = (purpose or "").strip()
+    instructions = (instructions or "").strip()
+    content = (content or "").strip()
+    questions: list[str] = []
+
+    if not (name or "").strip():
+        derived = _slugify_skill_name(purpose or instructions)
+        name = derived
+    if not (name or "").strip():
+        questions.append("What short skill name should be used, e.g. exam-planner?")
+    if not purpose and not content:
+        questions.append("What user need or situation should trigger this skill?")
+    if not instructions and not content:
+        questions.append("What should the agent do step by step when this skill is active?")
+
+    if questions:
+        return {
+            "requires_more_info": True,
+            "questions": questions,
+            "next_action": "Ask the user these questions, then call create_skill again with the clarified details.",
+        }
+
+    name = _valid_config_id(name, "name")
+    if not content:
+        content = _render_skill_content(
+            name=name,
+            purpose=purpose,
+            triggers=triggers,
+            instructions=instructions,
+            constraints=constraints,
+            examples=examples,
+        )
+    result = tool_add_skill(name=name, content=content, enabled=enabled)
+    if result.get("ok"):
+        result["created_by"] = "create_skill"
+    return result
+
+
+def _configured_skill_dirs_for_tools() -> list[tuple[str, Path]]:
+    cfg = read_json_safe(CONFIG_PATH, {})
+    skills_cfg = cfg.get("skills", {})
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+
+    dirs: list[tuple[str, Path]] = [
+        ("bundled", PACKAGE_ROOT / "skills"),
+        ("repo", PROJECT_ROOT / "skills"),
+        ("user", CONFIG_PATH.parent / "skills"),
+    ]
+    extra_dirs = skills_cfg.get("dirs", [])
+    if isinstance(extra_dirs, list):
+        for item in extra_dirs:
+            if isinstance(item, str) and item.strip():
+                dirs.append(("extra", Path(os.path.expandvars(item)).expanduser()))
+
+    seen: set[str] = set()
+    result: list[tuple[str, Path]] = []
+    for source, path in dirs:
+        try:
+            key = str(path.resolve())
+        except OSError:
+            key = str(path)
+        if key not in seen:
+            seen.add(key)
+            result.append((source, path))
+    return result
+
+
+def _skill_summary(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip().lstrip("#").strip()
+        if stripped:
+            return stripped[:240]
+    return ""
+
+
+def tool_list_skills(include_content: bool = False) -> dict:
+    """List all discovered prompt-only skills."""
+    cfg = read_json_safe(CONFIG_PATH, {})
+    skills_cfg = cfg.get("skills", {})
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+    enabled_names = _normalize_config_list(skills_cfg.get("enabled", []))
+    enable_all = "*" in enabled_names
+    enabled_set = set(enabled_names)
+
+    entries: list[dict] = []
+    seen: set[str] = set()
+    for source, base in _configured_skill_dirs_for_tools():
+        if not base.exists():
+            continue
+        for skill_file in sorted(base.glob("*/SKILL.md")):
+            name = skill_file.parent.name
+            key = str(skill_file.resolve())
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                text = skill_file.read_text(encoding="utf-8")
+            except OSError:
+                text = ""
+            item = {
+                "name": name,
+                "enabled": enable_all or name in enabled_set,
+                "source": source,
+                "path": str(skill_file),
+                "summary": _skill_summary(text),
+            }
+            if include_content:
+                item["content"] = text
+            entries.append(item)
+
+    return {
+        "ok": True,
+        "enabled": enabled_names,
+        "skill_dirs": [{"source": source, "path": str(path)} for source, path in _configured_skill_dirs_for_tools()],
+        "skills": entries,
+    }
+
+
+def tool_manage_skill(action: str, name: str) -> dict:
+    """Enable, disable, or delete a prompt-only skill."""
+    import shutil
+
+    action = (action or "").strip().lower()
+    if action not in {"enable", "disable", "delete"}:
+        return {"error": "action must be one of: enable, disable, delete"}
+    name = _valid_config_id(name, "name")
+
+    cfg = read_json_safe(CONFIG_PATH, {})
+    skills_cfg = cfg.get("skills", {})
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+    enabled_skills = _normalize_config_list(skills_cfg.get("enabled", []))
+
+    if action == "enable" and name not in enabled_skills:
+        enabled_skills.append(name)
+    elif action in {"disable", "delete"} and name in enabled_skills:
+        enabled_skills.remove(name)
+
+    deleted = False
+    if action == "delete":
+        user_root = (CONFIG_PATH.parent / "skills").resolve()
+        skill_dir = (user_root / name).resolve()
+        if not skill_dir.is_relative_to(user_root):
+            return {"error": "refusing to delete a skill outside the user skill directory"}
+        if not skill_dir.exists():
+            return {"error": f"user skill not found: {name}"}
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            return {"error": f"user skill has no SKILL.md: {name}"}
+        shutil.rmtree(skill_dir)
+        deleted = True
+
+    skills_cfg["enabled"] = enabled_skills
+    cfg["skills"] = skills_cfg
+    atomic_write_json(CONFIG_PATH, cfg)
+
+    return {
+        "ok": True,
+        "action": action,
+        "name": name,
+        "enabled": name in enabled_skills,
+        "deleted": deleted,
+    }
+
+
+def tool_setup_shuiyuan_mcp(
+    install_dir: str = "",
+    enable: bool = True,
+    allow_writes: bool = True,
+    run_login: bool = False,
+    ref: str = "",
+    acknowledge_external_repo: bool = False,
+) -> dict:
+    """Install and register dajiaohuang/shuiyuan-mcp as an external MCP server."""
+    import shutil
+
+    if not acknowledge_external_repo:
+        return {
+            "requires_confirmation": True,
+            "external_repo": _SHUIYUAN_MCP_REPO,
+            "pinned_ref": _SHUIYUAN_MCP_PINNED_REF,
+            "disclosure": _SHUIYUAN_MCP_DISCLOSURE,
+            "message": (
+                "This setup installs and builds an external GitHub repository on this machine. "
+                "Please confirm before continuing."
+            ),
+            "next_action": (
+                "Tell the user this will install the external GitHub repo "
+                f"{_SHUIYUAN_MCP_REPO} pinned to {_SHUIYUAN_MCP_PINNED_REF}. "
+                "Only call setup_shuiyuan_mcp again with acknowledge_external_repo=true "
+                "after the user explicitly confirms."
+            ),
+        }
+
+    git = shutil.which("git")
+    node = shutil.which("node")
+    npm = shutil.which("npm")
+    pnpm = shutil.which("pnpm")
+    missing = [name for name, path in {"git": git, "node": node}.items() if not path]
+    if not (npm or pnpm):
+        missing.append("npm or pnpm")
+    if missing:
+        return {
+            "error": f"Missing required command(s): {', '.join(missing)}",
+            "next_action": "Install Git and Node.js 24+, then run setup_shuiyuan_mcp again.",
+        }
+
+    node_major = _node_major_version(node)
+    node_warning = ""
+    if node_major is not None and node_major < 24:
+        node_warning = f"Detected Node.js {node_major}; shuiyuan-mcp declares Node.js >=24."
+
+    target = Path(os.path.expandvars(install_dir)).expanduser() if install_dir else CONFIG_PATH.parent / "mcp" / "shuiyuan-mcp"
+    target = target.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    steps: list[dict] = []
+    repo_url = _SHUIYUAN_MCP_REPO
+    checkout_ref = (ref or _SHUIYUAN_MCP_PINNED_REF).strip()
+    if not target.exists():
+        steps.append(_run_setup_command([git, "clone", repo_url, str(target)], target.parent, timeout=600))
+        if not steps[-1].get("ok"):
+            return {"error": "git clone failed", "install_dir": str(target), "steps": steps}
+    elif (target / ".git").exists():
+        steps.append(_run_setup_command([git, "fetch", "--tags", "origin"], target, timeout=300))
+        if not steps[-1].get("ok"):
+            return {"error": "git fetch failed", "install_dir": str(target), "steps": steps}
+    elif not (target / "package.json").exists():
+        return {"error": f"Install directory exists but is not a shuiyuan-mcp checkout: {target}"}
+
+    steps.append(_run_setup_command([git, "checkout", "--detach", checkout_ref], target, timeout=120))
+    if not steps[-1].get("ok"):
+        return {"error": f"git checkout failed for ref {checkout_ref}", "install_dir": str(target), "steps": steps}
+
+    package_manager = pnpm or npm
+    steps.append(_run_setup_command([package_manager, "install"], target, timeout=900))
+    if not steps[-1].get("ok"):
+        return {"error": "dependency install failed", "install_dir": str(target), "steps": steps}
+    steps.append(_run_setup_command([package_manager, "run", "build"], target, timeout=600))
+    if not steps[-1].get("ok"):
+        return {"error": "build failed", "install_dir": str(target), "steps": steps}
+
+    dist_entry = target / "dist" / "shuiyuan-mcp.js"
+    login_entry = target / "dist" / "shuiyuan-login.js"
+    if not dist_entry.exists():
+        return {"error": f"Built MCP entry not found: {dist_entry}", "steps": steps}
+
+    cfg = read_json_safe(CONFIG_PATH, {})
+    mcp_servers = cfg.get("mcp_servers", {})
+    if not isinstance(mcp_servers, dict):
+        mcp_servers = {}
+    args = [str(dist_entry)]
+    if not allow_writes:
+        args.extend(["--read_only=true"])
+    mcp_servers["shuiyuan"] = {
+        "enabled": bool(enable),
+        "transport": "stdio",
+        "command": node,
+        "args": args,
+        "cwd": str(target),
+        "call_timeout": 180,
+        "description": "Shuiyuan Discourse MCP from dajiaohuang/shuiyuan-mcp",
+    }
+    cfg["mcp_servers"] = mcp_servers
+
+    skills_cfg = cfg.get("skills", {})
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+    enabled_skills = skills_cfg.get("enabled", [])
+    if isinstance(enabled_skills, str):
+        enabled_skills = [enabled_skills]
+    if not isinstance(enabled_skills, list):
+        enabled_skills = []
+    if "shuiyuan-mcp" not in enabled_skills:
+        enabled_skills.append("shuiyuan-mcp")
+    skills_cfg["enabled"] = enabled_skills
+    cfg["skills"] = skills_cfg
+    atomic_write_json(CONFIG_PATH, cfg)
+
+    login_result = None
+    if run_login:
+        login_result = (
+            _run_setup_command([node, str(login_entry)], target, timeout=900)
+            if login_entry.exists()
+            else {"ok": False, "error": f"Login entry not found: {login_entry}"}
+        )
+
+    try:
+        from sjtu_agent.extensions.mcp_client import list_openai_tools
+        list_openai_tools(force_refresh=True)
+    except Exception:
+        pass
+
+    return {
+        "ok": True,
+        "install_dir": str(target),
+        "enabled": bool(enable),
+        "allow_writes": bool(allow_writes),
+        "disclosure": _SHUIYUAN_MCP_DISCLOSURE,
+        "repo": repo_url,
+        "pinned_ref": _SHUIYUAN_MCP_PINNED_REF,
+        "checkout_ref": checkout_ref,
+        "node_warning": node_warning,
+        "mcp_tool_prefix": "mcp__shuiyuan__",
+        "login_command": f'"{node}" "{login_entry}"',
+        "login_result": login_result,
+        "next_action": (
+            "If Shuiyuan MCP reports a missing profile, run login_command once, "
+            "then restart this agent or continue after tool discovery refreshes."
+        ),
+        "steps": steps,
+    }
 
 
 def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
@@ -4078,6 +4799,9 @@ def tool_submit_canvas_assignment(
 
 def run_tool(name: str, args: dict) -> str:
     try:
+        if name.startswith("mcp__"):
+            from sjtu_agent.extensions.mcp_client import call_tool
+            return call_tool(name, args or {})
         if   name == "check_setup":         r = tool_check_setup()
         elif name == "save_credentials":    r = tool_save_credentials(**args)
         elif name == "setup_canvas":        r = tool_setup_canvas(**args)
@@ -4092,6 +4816,12 @@ def run_tool(name: str, args: dict) -> str:
         elif name == "read_shuiyuan_topic":   r = tool_read_shuiyuan_topic(**args)
         elif name == "get_schedule":          r = tool_get_schedule(**args)
         elif name == "setup_shuiyuan":        r = tool_setup_shuiyuan()
+        elif name == "setup_shuiyuan_mcp":    r = tool_setup_shuiyuan_mcp(**args)
+        elif name == "add_mcp_server":        r = tool_add_mcp_server(**args)
+        elif name == "add_skill":             r = tool_add_skill(**args)
+        elif name == "create_skill":          r = tool_create_skill(**args)
+        elif name == "list_skills":           r = tool_list_skills(**args)
+        elif name == "manage_skill":          r = tool_manage_skill(**args)
         elif name == "setup_course_community": r = tool_setup_course_community(**args)
         elif name == "search_courses":        r = tool_search_courses(**args)
         elif name == "get_course_detail":     r = tool_get_course_detail(**args)

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -168,6 +168,97 @@ def _cmd_mcp(args: argparse.Namespace) -> int:
     return _run_module("mcp_server", args.script_args)
 
 
+def _cmd_setup_shuiyuan_mcp(args: argparse.Namespace) -> int:
+    from sjtu_agent.agent.tools import tool_setup_shuiyuan_mcp
+
+    payload = tool_setup_shuiyuan_mcp(
+        install_dir=args.install_dir or "",
+        enable=not args.disabled,
+        allow_writes=not args.read_only,
+        run_login=args.login,
+        ref=args.ref or "",
+        acknowledge_external_repo=True,
+    )
+    print_json(payload)
+    return 0 if payload.get("ok") else 1
+
+
+def _parse_kv_items(items: list[str] | None) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for item in items or []:
+        if "=" not in item:
+            raise ValueError(f"Expected KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"Empty key in: {item}")
+        result[key] = value
+    return result
+
+
+def _cmd_add_mcp_server(args: argparse.Namespace) -> int:
+    from sjtu_agent.agent.tools import tool_add_mcp_server
+
+    try:
+        env = _parse_kv_items(args.env)
+        headers = _parse_kv_items(args.header)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    payload = tool_add_mcp_server(
+        server_id=args.server_id,
+        transport=args.transport,
+        command=args.command or "",
+        args=args.arg or [],
+        url=args.url or "",
+        cwd=args.cwd or "",
+        env=env,
+        headers=headers,
+        enabled=not args.disabled,
+        call_timeout=args.call_timeout,
+        acknowledge_external_mcp=True,
+    )
+    print_json(payload)
+    return 0 if payload.get("ok") else 1
+
+
+def _cmd_add_skill(args: argparse.Namespace) -> int:
+    from sjtu_agent.agent.tools import tool_add_skill
+
+    content = args.content or ""
+    if args.content_file:
+        try:
+            content = Path(args.content_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"failed to read --content-file: {exc}", file=sys.stderr)
+            return 1
+    payload = tool_add_skill(
+        name=args.name,
+        content=content,
+        source_file=args.source_file or "",
+        enabled=not args.disabled,
+    )
+    print_json(payload)
+    return 0 if payload.get("ok") else 1
+
+
+def _cmd_list_skills(args: argparse.Namespace) -> int:
+    from sjtu_agent.agent.tools import tool_list_skills
+
+    payload = tool_list_skills(include_content=args.include_content)
+    print_json(payload)
+    return 0 if payload.get("ok") else 1
+
+
+def _cmd_manage_skill(args: argparse.Namespace) -> int:
+    from sjtu_agent.agent.tools import tool_manage_skill
+
+    payload = tool_manage_skill(action=args.action, name=args.name)
+    print_json(payload)
+    return 0 if payload.get("ok") else 1
+
+
 def _cmd_web(args: argparse.Namespace) -> int:
     from sjtu_agent.web.server import start
     start(port=args.port, open_browser=not args.no_browser)
@@ -268,6 +359,59 @@ def build_parser() -> argparse.ArgumentParser:
     _add_passthrough_parser(subparsers, "news-digest", "run the smart news digest (collect + rank + push)", _cmd_news_digest)
     _add_passthrough_parser(subparsers, "mcp", "start the MCP server", _cmd_mcp)
     _add_passthrough_parser(subparsers, "wechat-bot", "start the WeChat ilink bot (long-polling)", _cmd_wechat_bot)
+
+    shuiyuan_mcp_parser = subparsers.add_parser(
+        "setup-shuiyuan-mcp",
+        help="install and enable dajiaohuang/shuiyuan-mcp as an external MCP server",
+    )
+    shuiyuan_mcp_parser.add_argument("--install-dir", default="", help="custom install directory")
+    shuiyuan_mcp_parser.add_argument("--read-only", action="store_true", help="disable Shuiyuan write tools")
+    shuiyuan_mcp_parser.add_argument("--disabled", action="store_true", help="install but do not enable")
+    shuiyuan_mcp_parser.add_argument("--login", action="store_true", help="run shuiyuan-mcp-login after installation")
+    shuiyuan_mcp_parser.add_argument("--ref", default="", help="git commit/tag/branch to checkout (default: pinned commit)")
+    shuiyuan_mcp_parser.set_defaults(func=_cmd_setup_shuiyuan_mcp)
+
+    add_mcp_parser = subparsers.add_parser(
+        "add-mcp-server",
+        help="register a custom external MCP server",
+    )
+    add_mcp_parser.add_argument("server_id", help="short MCP server id")
+    add_mcp_parser.add_argument("--transport", default="stdio", choices=["stdio", "sse", "streamable_http", "http"])
+    add_mcp_parser.add_argument("--command", default="", help="command for stdio transport")
+    add_mcp_parser.add_argument("--arg", action="append", default=[], help="stdio command argument; repeat for multiple args")
+    add_mcp_parser.add_argument("--url", default="", help="MCP endpoint URL for sse/http transports")
+    add_mcp_parser.add_argument("--cwd", default="", help="working directory for stdio transport")
+    add_mcp_parser.add_argument("--env", action="append", default=[], help="environment variable KEY=VALUE; repeatable")
+    add_mcp_parser.add_argument("--header", action="append", default=[], help="HTTP header KEY=VALUE; repeatable")
+    add_mcp_parser.add_argument("--call-timeout", type=int, default=120, help="tool call timeout in seconds")
+    add_mcp_parser.add_argument("--disabled", action="store_true", help="write config but do not enable")
+    add_mcp_parser.set_defaults(func=_cmd_add_mcp_server)
+
+    add_skill_parser = subparsers.add_parser(
+        "add-skill",
+        help="create or enable a custom prompt-only skill",
+    )
+    add_skill_parser.add_argument("name", help="skill name / directory id")
+    add_skill_parser.add_argument("--content", default="", help="SKILL.md content")
+    add_skill_parser.add_argument("--content-file", default="", help="read SKILL.md content from this file")
+    add_skill_parser.add_argument("--source-file", default="", help="copy skill content from an existing local SKILL.md file")
+    add_skill_parser.add_argument("--disabled", action="store_true", help="write the skill but do not enable it")
+    add_skill_parser.set_defaults(func=_cmd_add_skill)
+
+    list_skills_parser = subparsers.add_parser(
+        "list-skills",
+        help="list prompt-only skills and enabled state",
+    )
+    list_skills_parser.add_argument("--include-content", action="store_true", help="include full SKILL.md content")
+    list_skills_parser.set_defaults(func=_cmd_list_skills)
+
+    manage_skill_parser = subparsers.add_parser(
+        "manage-skill",
+        help="enable, disable, or delete a prompt-only skill",
+    )
+    manage_skill_parser.add_argument("action", choices=["enable", "disable", "delete"])
+    manage_skill_parser.add_argument("name", help="skill name / directory id")
+    manage_skill_parser.set_defaults(func=_cmd_manage_skill)
 
     web_parser = subparsers.add_parser("web", help="open the local web configuration UI in your browser")
     web_parser.add_argument(

--- a/sjtu_agent/extensions/__init__.py
+++ b/sjtu_agent/extensions/__init__.py
@@ -1,0 +1,11 @@
+"""Extension loading for skills and external MCP tools."""
+
+from sjtu_agent.extensions.registry import get_available_tools, run_registered_tool
+from sjtu_agent.extensions.skills import build_skill_prompt, enabled_skill_names
+
+__all__ = [
+    "get_available_tools",
+    "run_registered_tool",
+    "build_skill_prompt",
+    "enabled_skill_names",
+]

--- a/sjtu_agent/extensions/mcp_client.py
+++ b/sjtu_agent/extensions/mcp_client.py
@@ -1,0 +1,266 @@
+"""Small synchronous adapter around the MCP Python client.
+
+The agent runner is synchronous today. This module keeps MCP integration
+behind a simple sync API by opening a short-lived MCP session for discovery
+and calls. It favors reliability over long-lived process management.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import threading
+import time
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from queue import Queue
+from typing import Any
+
+from sjtu_agent.paths import CONFIG_PATH, read_json_safe
+
+
+_CACHE_TTL_SECONDS = 60
+_TOOLS_CACHE: dict[str, Any] = {"ts": 0.0, "tools": [], "map": {}}
+_NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
+
+
+def _sanitize(value: str) -> str:
+    cleaned = _NAME_RE.sub("_", value.strip())
+    cleaned = re.sub(r"_+", "_", cleaned).strip("_")
+    return cleaned or "tool"
+
+
+def _load_servers() -> dict[str, dict]:
+    cfg = read_json_safe(CONFIG_PATH, {})
+    servers = cfg.get("mcp_servers", {})
+    return servers if isinstance(servers, dict) else {}
+
+
+def _enabled_servers() -> dict[str, dict]:
+    result = {}
+    for server_id, server_cfg in _load_servers().items():
+        if not isinstance(server_cfg, dict):
+            continue
+        if not server_cfg.get("enabled", False):
+            continue
+        result[str(server_id)] = server_cfg
+    return result
+
+
+def is_mcp_tool(name: str) -> bool:
+    return name.startswith("mcp__")
+
+
+def _run_async(coro_factory):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro_factory())
+
+    q: Queue[tuple[bool, Any]] = Queue(maxsize=1)
+
+    def _worker() -> None:
+        try:
+            q.put((True, asyncio.run(coro_factory())))
+        except Exception as exc:
+            q.put((False, exc))
+
+    thread = threading.Thread(target=_worker, name="sjtu-agent-mcp-async", daemon=True)
+    thread.start()
+    ok, value = q.get()
+    thread.join()
+    if ok:
+        return value
+    raise value
+
+
+def _unique_name(public_name: str, used: set[str]) -> str:
+    candidate = public_name[:64]
+    if candidate not in used:
+        used.add(candidate)
+        return candidate
+    index = 2
+    while True:
+        suffix = f"_{index}"
+        candidate = public_name[: 64 - len(suffix)] + suffix
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+        index += 1
+
+
+@asynccontextmanager
+async def _open_session(server_cfg: dict):
+    try:
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+        from mcp.client.sse import sse_client
+        from mcp.client.streamable_http import streamablehttp_client
+    except ImportError as exc:
+        raise RuntimeError("MCP client dependency is not installed. Run `pip install -e .`.") from exc
+
+    transport = str(server_cfg.get("transport", "stdio")).lower()
+    if transport == "stdio":
+        command = str(server_cfg.get("command", "")).strip()
+        if not command:
+            raise ValueError("stdio MCP server requires `command`.")
+        params = StdioServerParameters(
+            command=command,
+            args=[str(x) for x in server_cfg.get("args", [])],
+            env=server_cfg.get("env") if isinstance(server_cfg.get("env"), dict) else None,
+            cwd=server_cfg.get("cwd") or None,
+        )
+        async with stdio_client(params) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport == "sse":
+        url = str(server_cfg.get("url", "")).strip()
+        if not url:
+            raise ValueError("sse MCP server requires `url`.")
+        async with sse_client(
+            url,
+            headers=server_cfg.get("headers") if isinstance(server_cfg.get("headers"), dict) else None,
+            timeout=float(server_cfg.get("timeout", 10)),
+            sse_read_timeout=float(server_cfg.get("sse_read_timeout", 300)),
+        ) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+        return
+
+    if transport in {"streamable_http", "http"}:
+        url = str(server_cfg.get("url", "")).strip()
+        if not url:
+            raise ValueError("streamable_http MCP server requires `url`.")
+        async with streamablehttp_client(
+            url,
+            headers=server_cfg.get("headers") if isinstance(server_cfg.get("headers"), dict) else None,
+            timeout=float(server_cfg.get("timeout", 30)),
+            sse_read_timeout=float(server_cfg.get("sse_read_timeout", 300)),
+        ) as (read_stream, write_stream, _get_session_id):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+        return
+
+    raise ValueError(f"Unsupported MCP transport: {transport}")
+
+
+def _tool_to_openai(server_id: str, mcp_tool: Any, index: int) -> tuple[dict, dict]:
+    original_name = getattr(mcp_tool, "name", "") or f"tool_{index}"
+    public_name = f"mcp__{_sanitize(server_id)}__{_sanitize(original_name)}"
+    description = getattr(mcp_tool, "description", "") or f"MCP tool `{original_name}` from `{server_id}`."
+    input_schema = getattr(mcp_tool, "inputSchema", None) or getattr(mcp_tool, "input_schema", None) or {}
+    if hasattr(input_schema, "model_dump"):
+        input_schema = input_schema.model_dump(exclude_none=True)
+    if not isinstance(input_schema, dict):
+        input_schema = {"type": "object", "properties": {}, "required": []}
+    input_schema.setdefault("type", "object")
+    input_schema.setdefault("properties", {})
+
+    tool = {
+        "type": "function",
+        "function": {
+            "name": public_name,
+            "description": f"[MCP:{server_id}] {description}",
+            "parameters": input_schema,
+        },
+    }
+    meta = {"server_id": server_id, "tool_name": original_name, "public_name": tool["function"]["name"]}
+    return tool, meta
+
+
+async def _list_tools_async() -> tuple[list[dict], dict[str, dict]]:
+    tools: list[dict] = []
+    name_map: dict[str, dict] = {}
+    used_names: set[str] = set()
+    for server_id, server_cfg in _enabled_servers().items():
+        try:
+            async with _open_session(server_cfg) as session:
+                result = await session.list_tools()
+        except Exception as exc:
+            public_name = _unique_name(f"mcp__{_sanitize(server_id)}__status", used_names)
+            tools.append({
+                "type": "function",
+                "function": {
+                    "name": public_name,
+                    "description": f"[MCP:{server_id}] Report why this MCP server is unavailable.",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            })
+            name_map[public_name] = {
+                "server_id": server_id,
+                "tool_name": "__status__",
+                "error": str(exc),
+            }
+            continue
+        for idx, tool_obj in enumerate(getattr(result, "tools", []) or []):
+            tool, meta = _tool_to_openai(server_id, tool_obj, idx)
+            public_name = _unique_name(meta["public_name"], used_names)
+            tool["function"]["name"] = public_name
+            meta["public_name"] = public_name
+            tools.append(tool)
+            name_map[meta["public_name"]] = meta
+    return tools, name_map
+
+
+def list_openai_tools(force_refresh: bool = False) -> list[dict]:
+    now = time.monotonic()
+    if not force_refresh and now - float(_TOOLS_CACHE.get("ts", 0)) < _CACHE_TTL_SECONDS:
+        return list(_TOOLS_CACHE.get("tools", []))
+    tools, name_map = _run_async(lambda: _list_tools_async())
+    _TOOLS_CACHE.update({"ts": now, "tools": tools, "map": name_map})
+    return list(tools)
+
+
+def _content_to_jsonable(content: Any) -> Any:
+    if hasattr(content, "text"):
+        return getattr(content, "text")
+    if hasattr(content, "model_dump"):
+        return content.model_dump(exclude_none=True)
+    return str(content)
+
+
+async def _call_tool_async(public_name: str, arguments: dict | None) -> dict:
+    if public_name not in _TOOLS_CACHE.get("map", {}):
+        tools, name_map = await _list_tools_async()
+        _TOOLS_CACHE.update({"ts": time.monotonic(), "tools": tools, "map": name_map})
+    meta = _TOOLS_CACHE.get("map", {}).get(public_name)
+    if not meta:
+        return {"error": f"Unknown MCP tool: {public_name}"}
+    if meta.get("error"):
+        return {"error": meta["error"], "server": meta.get("server_id")}
+    if meta.get("tool_name") == "__status__":
+        return {"error": meta.get("error", "MCP server unavailable"), "server": meta.get("server_id")}
+
+    server_id = meta["server_id"]
+    server_cfg = _enabled_servers().get(server_id)
+    if not server_cfg:
+        return {"error": f"MCP server is disabled or missing: {server_id}"}
+
+    timeout = float(server_cfg.get("call_timeout", 120))
+    async with _open_session(server_cfg) as session:
+        result = await session.call_tool(
+            meta["tool_name"],
+            arguments or {},
+            read_timeout_seconds=timedelta(seconds=timeout),
+        )
+    content = [_content_to_jsonable(item) for item in (getattr(result, "content", []) or [])]
+    return {
+        "ok": not bool(getattr(result, "isError", False)),
+        "server": server_id,
+        "tool": meta["tool_name"],
+        "content": content,
+    }
+
+
+def call_tool(public_name: str, arguments: dict | None = None) -> str:
+    try:
+        payload = _run_async(lambda: _call_tool_async(public_name, arguments or {}))
+    except Exception as exc:
+        payload = {"error": str(exc), "tool": public_name}
+    return json.dumps(payload, ensure_ascii=False)

--- a/sjtu_agent/extensions/registry.py
+++ b/sjtu_agent/extensions/registry.py
@@ -1,0 +1,19 @@
+"""Tool registry that combines built-in tools with enabled MCP tools."""
+
+from __future__ import annotations
+
+from sjtu_agent.extensions import mcp_client
+
+
+def get_available_tools(force_refresh: bool = False) -> list[dict]:
+    from sjtu_agent.agent.tools import TOOLS as builtin_tools
+
+    return list(builtin_tools) + mcp_client.list_openai_tools(force_refresh=force_refresh)
+
+
+def run_registered_tool(name: str, args: dict | None = None) -> str:
+    if mcp_client.is_mcp_tool(name):
+        return mcp_client.call_tool(name, args or {})
+    from sjtu_agent.agent.tools import run_tool as run_builtin_tool
+
+    return run_builtin_tool(name, args or {})

--- a/sjtu_agent/extensions/skills.py
+++ b/sjtu_agent/extensions/skills.py
@@ -1,0 +1,89 @@
+"""Prompt-only skill loading."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from sjtu_agent.paths import DATA_DIR, PACKAGE_ROOT, PROJECT_ROOT, CONFIG_PATH, read_json_safe
+
+
+def _skill_config() -> dict:
+    cfg = read_json_safe(CONFIG_PATH, {})
+    raw = cfg.get("skills", {})
+    return raw if isinstance(raw, dict) else {}
+
+
+def _expand_path(raw: str) -> Path:
+    raw = os.path.expandvars(os.path.expanduser(raw))
+    return Path(raw)
+
+
+def _skill_dirs() -> list[Path]:
+    cfg = _skill_config()
+    dirs = [
+        PACKAGE_ROOT / "skills",
+        PROJECT_ROOT / "skills",
+        DATA_DIR / "skills",
+    ]
+    for item in cfg.get("dirs", []) if isinstance(cfg.get("dirs", []), list) else []:
+        if isinstance(item, str) and item.strip():
+            dirs.append(_expand_path(item.strip()))
+    seen: set[str] = set()
+    result: list[Path] = []
+    for path in dirs:
+        key = str(path.resolve()) if path.exists() else str(path)
+        if key not in seen:
+            seen.add(key)
+            result.append(path)
+    return result
+
+
+def enabled_skill_names() -> list[str]:
+    enabled = _skill_config().get("enabled", [])
+    if isinstance(enabled, str):
+        return [enabled]
+    if isinstance(enabled, list):
+        return [str(x) for x in enabled if str(x).strip()]
+    return []
+
+
+def _find_skill_file(name: str) -> Path | None:
+    for base in _skill_dirs():
+        direct = base / name / "SKILL.md"
+        if direct.exists():
+            return direct
+        lower = base / name.lower() / "SKILL.md"
+        if lower.exists():
+            return lower
+    return None
+
+
+def _all_skill_files() -> list[Path]:
+    files: list[Path] = []
+    for base in _skill_dirs():
+        if not base.exists():
+            continue
+        files.extend(sorted(base.glob("*/SKILL.md")))
+    return files
+
+
+def build_skill_prompt() -> str:
+    names = enabled_skill_names()
+    if not names:
+        return ""
+
+    skill_files = _all_skill_files() if "*" in names else [p for n in names if (p := _find_skill_file(n))]
+    parts: list[str] = []
+    for path in skill_files:
+        try:
+            text = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if not text:
+            continue
+        parts.append(f"### Skill: {path.parent.name}\n{text}")
+
+    if not parts:
+        return ""
+    return "\n\n## Enabled Skills\n" + "\n\n".join(parts)

--- a/sjtu_agent/skills/__init__.py
+++ b/sjtu_agent/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled prompt skills."""

--- a/sjtu_agent/skills/shuiyuan-mcp/SKILL.md
+++ b/sjtu_agent/skills/shuiyuan-mcp/SKILL.md
@@ -1,0 +1,7 @@
+Use this skill when the user asks to search, read, summarize, draft for, or post to Shuiyuan/SJTU Discourse through an enabled Shuiyuan MCP server.
+
+Prefer Shuiyuan MCP tools whose names start with `mcp__shuiyuan__` for Shuiyuan forum operations. Use read/search tools before answering questions about a specific topic or post, and do not invent topic contents from titles alone.
+
+Writing to Shuiyuan is a high-impact action. Draft the exact content first unless the user has clearly asked you to publish or reply. When posting, include the target topic or category in your response and report the resulting URL or post id from the tool result.
+
+If a Shuiyuan MCP tool reports that the profile or cookies are missing, ask the user to run the Shuiyuan MCP login flow, or call the setup tool again with login enabled if the current interface supports interactive browser login.

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -340,7 +340,7 @@ def _stream_chat(user_message: str):
             f"\n\n## 当前时间\n"
             f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
         )
-        _chat_history.append({"role": "system", "content": _agent.SYSTEM_PROMPT + _date_ctx})
+        _chat_history.append({"role": "system", "content": _agent.build_system_prompt(_date_ctx)})
 
     _chat_history.append({"role": "user", "content": user_message})
 
@@ -449,7 +449,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, _sse):
             fn_name = b["name"]
             fn_args = b["input"] if isinstance(b["input"], dict) else {}
             yield _sse({"tool_start": {"name": fn_name, "input": fn_args}})
-            result = _agent.run_tool(fn_name, fn_args)
+            result = _agent.run_registered_tool(fn_name, fn_args)
             result_preview = result[:500] if len(result) > 500 else result
             yield _sse({"tool_end": {"name": fn_name, "result": result_preview}})
             tool_results.append({"type": "tool_result", "tool_use_id": b["id"], "content": result})
@@ -490,7 +490,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, _sse):
             stream = client.chat.completions.create(
                 model=model,
                 messages=messages,
-                tools=_agent.TOOLS,
+                tools=_agent.get_available_tools(),
                 tool_choice="auto",
                 stream=True,
                 timeout=180,
@@ -547,7 +547,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, _sse):
             fn_name = tc.function.name
             fn_args = json.loads(tc.function.arguments or "{}")
             yield _sse({"tool_start": {"name": fn_name, "input": fn_args}})
-            result = _agent.run_tool(fn_name, fn_args)
+            result = _agent.run_registered_tool(fn_name, fn_args)
             result_preview = result[:500] if len(result) > 500 else result
             yield _sse({"tool_end": {"name": fn_name, "result": result_preview}})
             messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -109,7 +109,7 @@ def _init_messages(sess: dict) -> None:
     """首次对话时注入 system prompt；后续每轮由 _capture_turn 刷新时间。"""
     if sess["messages"]:
         return
-    sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX})
+    sess["messages"].append({"role": "system", "content": agent.build_system_prompt(_build_date_ctx(), _TG_CTX)})
 
 
 # ── 输出捕获 ──────────────────────────────────────────────────────────────────
@@ -126,7 +126,7 @@ def _capture_turn(sess: dict, user_text: str, on_tool_result=None) -> str:
     _init_messages(sess)
     # 每轮刷新 system prompt 中的时间，避免长会话里时间过期
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
+        sess["messages"][0]["content"] = agent.build_system_prompt(_build_date_ctx(), _TG_CTX)
     sess["messages"].append({"role": "user", "content": user_text})
 
     buf = io.StringIO()
@@ -180,7 +180,7 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
 
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
+        sess["messages"][0]["content"] = agent.build_system_prompt(_build_date_ctx(), _TG_CTX)
     sess["messages"].append({"role": "user", "content": user_text})
 
     client = sess["client_box"][0]
@@ -313,7 +313,7 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
         stream = client.chat.completions.create(
             model=model,
             messages=messages,
-            tools=agent.TOOLS,
+            tools=agent.get_available_tools(),
             tool_choice="auto",
             stream=True,
             timeout=180,
@@ -929,7 +929,7 @@ def _capture_turn_multimodal(sess: dict, content: list) -> str:
     """
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
+        sess["messages"][0]["content"] = agent.build_system_prompt(_build_date_ctx(), _TG_CTX)
     sess["messages"].append({"role": "user", "content": content})
 
     buf = io.StringIO()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,210 @@
+import asyncio
+import json
+
+
+def test_build_skill_prompt_loads_enabled_builtin_skill(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"skills": {"enabled": ["shuiyuan-mcp"], "dirs": []}}),
+        encoding="utf-8",
+    )
+
+    from sjtu_agent.extensions import skills
+
+    monkeypatch.setattr(skills, "CONFIG_PATH", config_path)
+
+    prompt = skills.build_skill_prompt()
+    assert "Skill: shuiyuan-mcp" in prompt
+    assert "mcp__shuiyuan__" in prompt
+
+
+def test_get_available_tools_with_no_mcp_config_does_not_raise(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"mcp_servers": {}}), encoding="utf-8")
+
+    from sjtu_agent.extensions import mcp_client
+    from sjtu_agent.extensions.registry import get_available_tools
+
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config_path)
+    mcp_client._TOOLS_CACHE.update({"ts": 0.0, "tools": [], "map": {}})
+
+    tools = get_available_tools(force_refresh=True)
+    names = [tool["function"]["name"] for tool in tools]
+    assert "get_ddls" in names
+
+
+def test_mcp_async_runner_works_inside_existing_event_loop():
+    from sjtu_agent.extensions import mcp_client
+
+    async def sample():
+        return "ok"
+
+    async def main():
+        return mcp_client._run_async(lambda: sample())
+
+    assert asyncio.run(main()) == "ok"
+
+
+def test_builtin_run_tool_routes_mcp_prefix(monkeypatch):
+    from sjtu_agent.agent import tools
+    from sjtu_agent.extensions import mcp_client
+
+    monkeypatch.setattr(mcp_client, "call_tool", lambda name, args: json.dumps({"name": name, "args": args}))
+
+    result = json.loads(tools.run_tool("mcp__demo__echo", {"text": "hi"}))
+    assert result == {"name": "mcp__demo__echo", "args": {"text": "hi"}}
+
+
+def test_shuiyuan_mcp_setup_requires_external_repo_confirmation():
+    from sjtu_agent.agent.tools import tool_setup_shuiyuan_mcp
+
+    result = tool_setup_shuiyuan_mcp()
+    assert result["requires_confirmation"] is True
+    assert result["external_repo"] == "https://github.com/dajiaohuang/shuiyuan-mcp.git"
+    assert "acknowledge_external_repo=true" in result["next_action"]
+
+
+def test_add_mcp_server_requires_confirmation():
+    from sjtu_agent.agent.tools import tool_add_mcp_server
+
+    result = tool_add_mcp_server(
+        server_id="demo",
+        transport="stdio",
+        command="python",
+        args=["server.py"],
+    )
+    assert result["requires_confirmation"] is True
+    assert result["external_target"] == "python server.py"
+    assert "acknowledge_external_mcp=true" in result["next_action"]
+
+
+def test_add_mcp_server_writes_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+    from sjtu_agent.extensions import mcp_client
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(mcp_client, "list_openai_tools", lambda force_refresh=False: [])
+
+    result = tools.tool_add_mcp_server(
+        server_id="demo",
+        transport="sse",
+        url="http://127.0.0.1:8765/sse",
+        acknowledge_external_mcp=True,
+    )
+    assert result["ok"] is True
+
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    assert cfg["mcp_servers"]["demo"]["url"] == "http://127.0.0.1:8765/sse"
+    assert cfg["mcp_servers"]["demo"]["enabled"] is True
+
+
+def test_add_skill_writes_and_enables(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+
+    result = tools.tool_add_skill("demo-skill", content="Use this skill for demos.")
+    assert result["ok"] is True
+
+    skill_file = tmp_path / "skills" / "demo-skill" / "SKILL.md"
+    assert skill_file.read_text(encoding="utf-8").strip() == "Use this skill for demos."
+
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    assert cfg["skills"]["enabled"] == ["demo-skill"]
+
+
+def test_create_skill_requires_clarification_for_missing_details(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+
+    result = tools.tool_create_skill()
+    assert result["requires_more_info"] is True
+    assert result["questions"]
+    assert not (tmp_path / "skills").exists()
+
+
+def test_create_skill_generates_and_enables_skill(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+
+    result = tools.tool_create_skill(
+        name="planner",
+        purpose="the user asks to plan a study week.",
+        triggers=["plan my week"],
+        instructions="Ask for deadlines, then create a day-by-day plan.",
+    )
+    assert result["ok"] is True
+
+    skill_file = tmp_path / "skills" / "planner" / "SKILL.md"
+    text = skill_file.read_text(encoding="utf-8")
+    assert "Use this skill when the user asks to plan a study week." in text
+    assert "Ask for deadlines" in text
+
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    assert cfg["skills"]["enabled"] == ["planner"]
+
+
+def test_list_skills_includes_user_skill(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"skills": {"enabled": ["planner"], "dirs": []}}), encoding="utf-8")
+    skill_dir = tmp_path / "skills" / "planner"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Planner\nUse for planning.", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+
+    result = tools.tool_list_skills()
+    user_skills = [item for item in result["skills"] if item["source"] == "user"]
+    assert user_skills == [
+        {
+            "name": "planner",
+            "enabled": True,
+            "source": "user",
+            "path": str(skill_dir / "SKILL.md"),
+            "summary": "Planner",
+        }
+    ]
+
+
+def test_manage_skill_enable_disable_delete_user_skill(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"skills": {"enabled": ["planner"], "dirs": []}}), encoding="utf-8")
+    skill_dir = tmp_path / "skills" / "planner"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Planner\nUse for planning.", encoding="utf-8")
+
+    from sjtu_agent.agent import tools
+
+    monkeypatch.setattr(tools, "CONFIG_PATH", config_path)
+
+    disabled = tools.tool_manage_skill("disable", "planner")
+    assert disabled["ok"] is True
+    assert disabled["enabled"] is False
+
+    enabled = tools.tool_manage_skill("enable", "planner")
+    assert enabled["ok"] is True
+    assert enabled["enabled"] is True
+
+    deleted = tools.tool_manage_skill("delete", "planner")
+    assert deleted["ok"] is True
+    assert deleted["deleted"] is True
+    assert not skill_dir.exists()
+
+    cfg = json.loads(config_path.read_text(encoding="utf-8"))
+    assert cfg["skills"]["enabled"] == []

--- a/wechat_bot.py
+++ b/wechat_bot.py
@@ -280,7 +280,7 @@ def _init_messages(sess: dict) -> None:
         return
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_date_ctx(),
+        "content": agent.build_system_prompt(_build_date_ctx()),
     })
 
 
@@ -288,7 +288,7 @@ def _capture_turn(sess: dict, user_text: str) -> str:
     """运行一轮对话，返回 Agent 回复文本。"""
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx()
+        sess["messages"][0]["content"] = agent.build_system_prompt(_build_date_ctx())
     sess["messages"].append({"role": "user", "content": user_text})
 
     buf = io.StringIO()


### PR DESCRIPTION
﻿## English

### Summary
- Add a dynamic extension registry that combines built-in tools with enabled external MCP tools.
- Add MCP client support for `stdio`, `sse`, and `streamable_http` transports.
- Add prompt-only skill loading via `SKILL.md`, plus bundled `shuiyuan-mcp` and `ykst-mcp` skills.
- Wire terminal chat, Web UI, Telegram, Feishu, and WeChat entrypoints to the dynamic tool/prompt path.
- Add `setup-shuiyuan-mcp` / `setup_shuiyuan_mcp` to install and enable `dajiaohuang/shuiyuan-mcp`.
- Add `setup-ykst-mcp` / `setup_ykst_mcp` to install and enable `dajiaohuang/ykst-treehole-mcp`.
- Add custom MCP and skill registration tools: `add_mcp_server`, `add_skill`, and CLI commands.
- Add agent-triggered skill creation and management via `create_skill`, `list_skills`, and `manage_skill`.
- Add `AGENT.md`, `MCP_SKILL_UPDATE.md`, and extension smoke tests.

### Review and safety fixes
- Disclose that `dajiaohuang/shuiyuan-mcp` and `dajiaohuang/ykst-treehole-mcp` are maintained by the PR author of this integration.
- Pin the default Shuiyuan MCP checkout to `5c79b6e767f5aa55a3f342f5550ec74520fd52e5` instead of silently pulling future changes.
- Pin the default YKST MCP checkout to `44af57e9bad653f2fe929527d7f326995445ecd7` instead of silently pulling future changes.
- Change `config.example.json` so `skills.enabled` defaults to `[]`.
- Avoid silently losing MCP tools inside an existing event loop by running MCP async work in a worker thread.
- Route `mcp__*` calls through `sjtu_agent.agent.tools.run_tool` as well, so old and new dispatch paths agree.
- Deduplicate truncated MCP tool names.
- Document the `skills.enabled = [*]` wildcard.
- Add explicit external-command/URL confirmation gates for chat-triggered custom MCP and bundled external MCP setup.
- Preserve YKST MCP's write safety model: write operations require `confirm: true` after the intended action is reviewed.

### Trigger paths
- Shuiyuan MCP CLI: `python -m sjtu_agent.cli setup-shuiyuan-mcp`
- Shuiyuan MCP chat: ask "install Shuiyuan MCP", "enable Shuiyuan MCP", "load dajiaohuang/shuiyuan-mcp", or Chinese equivalents such as "安装水源 MCP"; the first tool call warns about installing an external GitHub repository, and install starts only after confirmation.
- YKST MCP CLI: `python -m sjtu_agent.cli setup-ykst-mcp`
- YKST MCP chat: ask "install YKST MCP", "enable Treehole MCP", "load dajiaohuang/ykst-treehole-mcp", or Chinese equivalents such as "安装树洞 MCP"; the first tool call warns about installing an external GitHub repository and possible local browser login helper, and install starts only after confirmation.
- Custom MCP CLI: `python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
- Custom MCP chat: ask the agent to add/register a custom MCP server; the first call warns about trusting an external command or URL, and the second confirmed call writes config.
- Custom skill CLI: `python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
- Skill list/manage CLI: `python -m sjtu_agent.cli list-skills`, `python -m sjtu_agent.cli manage-skill disable my-skill`
- Skill creator chat: ask the agent to create a skill from a described need; if information is missing it asks follow-up questions, otherwise it writes and enables the generated skill.
- Skill list/manage chat: ask the agent to list, enable, disable, or delete skills; these route through `list_skills` and `manage_skill`.

### Verification
- `python -m pytest -v` (`34 passed`)
- `python -m compileall sjtu_agent agent.py telegram_bot.py feishu_bot.py wechat_bot.py mcp_server.py`
- `python -m sjtu_agent.cli setup-ykst-mcp --help`
- `python -m sjtu_agent.cli add-skill --help`
- `python -m sjtu_agent.cli list-skills --help`
- `python -m sjtu_agent.cli manage-skill --help`
- Temporary fake MCP stdio server discovery and tool call succeeded.
- Skill prompt loading verified with `shuiyuan-mcp` enabled.
- `git diff --check`

## 中文

### 摘要
- 新增动态扩展注册表，合并内置工具和已启用的外部 MCP 工具。
- 新增 MCP client 支持，覆盖 `stdio`、`sse`、`streamable_http` 三种传输方式。
- 新增基于 `SKILL.md` 的 prompt-only skill 加载机制，并内置 `shuiyuan-mcp` 和 `ykst-mcp` skill。
- 终端对话、Web UI、Telegram、飞书、微信入口统一接入动态工具和动态 prompt。
- 新增 `setup-shuiyuan-mcp` / `setup_shuiyuan_mcp`，用于安装并启用 `dajiaohuang/shuiyuan-mcp`。
- 新增 `setup-ykst-mcp` / `setup_ykst_mcp`，用于安装并启用 `dajiaohuang/ykst-treehole-mcp`。
- 新增自定义 MCP / Skill 注册工具：`add_mcp_server`、`add_skill` 和对应 CLI。
- 新增 agent 触发的 skill 创建与管理：`create_skill`、`list_skills`、`manage_skill`。
- 新增 `AGENT.md`、`MCP_SKILL_UPDATE.md` 和扩展层 smoke tests。

### Review 与安全修复
- 明确披露 `dajiaohuang/shuiyuan-mcp` 和 `dajiaohuang/ykst-treehole-mcp` 均由本集成 PR 作者维护。
- 默认 pin Shuiyuan MCP 到 `5c79b6e767f5aa55a3f342f5550ec74520fd52e5`，不再静默拉取未来变更。
- 默认 pin YKST MCP 到 `44af57e9bad653f2fe929527d7f326995445ecd7`，不再静默拉取未来变更。
- `config.example.json` 中 `skills.enabled` 默认改为 `[]`。
- 已有 event loop 场景下改用 worker 线程运行 MCP async 逻辑，避免静默丢失 MCP 工具。
- `sjtu_agent.agent.tools.run_tool` 也支持 `mcp__*` 路由，避免新旧 dispatch 行为分裂。
- 对截断后的 MCP 工具名做去重。
- 文档说明 `skills.enabled = [*]` 通配语法。
- 对话触发自定义 MCP 和内置外部 MCP 安装时增加外部命令 / URL / GitHub 仓库确认门。
- 保留 YKST MCP 的写操作安全模型：写入类操作必须在确认目标和参数后传入 `confirm: true`。

### 触发方式
- 水源 MCP CLI：`python -m sjtu_agent.cli setup-shuiyuan-mcp`
- 水源 MCP 对话：说“安装水源 MCP”“启用 Shuiyuan MCP”“加载 dajiaohuang/shuiyuan-mcp”等；第一次工具调用只提示会安装外部 GitHub 仓库，用户确认后才开始安装。
- YKST MCP CLI：`python -m sjtu_agent.cli setup-ykst-mcp`
- YKST MCP 对话：说“安装 YKST MCP”“安装树洞 MCP”“加载 dajiaohuang/ykst-treehole-mcp”等；第一次工具调用只提示会安装外部 GitHub 仓库并可能运行本地浏览器登录辅助，用户确认后才开始安装。
- 自定义 MCP CLI：`python -m sjtu_agent.cli add-mcp-server my-tools --transport stdio --command python --arg /path/to/server.py`
- 自定义 MCP 对话：让 agent 添加/注册自定义 MCP server；第一次调用提示会信任外部命令或 URL，确认后第二次调用写入配置。
- 自定义 skill CLI：`python -m sjtu_agent.cli add-skill my-skill --content-file /path/to/SKILL.md`
- Skill 列表/管理 CLI：`python -m sjtu_agent.cli list-skills`，`python -m sjtu_agent.cli manage-skill disable my-skill`
- Skill creator 对话：让 agent 根据需求创建 skill；信息不足时 agent 会反问，信息明确时直接生成并启用 skill。
- Skill 列表/管理对话：让 agent 列出、启用、禁用或删除 skill；分别走 `list_skills` 和 `manage_skill`。

### 验证
- `python -m pytest -v`（`34 passed`）
- `python -m compileall sjtu_agent agent.py telegram_bot.py feishu_bot.py wechat_bot.py mcp_server.py`
- `python -m sjtu_agent.cli setup-ykst-mcp --help`
- `python -m sjtu_agent.cli add-skill --help`
- `python -m sjtu_agent.cli list-skills --help`
- `python -m sjtu_agent.cli manage-skill --help`
- 使用临时 fake MCP stdio server 验证工具发现和工具调用成功。
- 验证启用 `shuiyuan-mcp` 后 skill prompt 能正确注入。
- `git diff --check`
