### PR TITLE
fix: Windows daemon popup + update rebase fallback + Feishu whitelist agent config

### DIFF
--- a/sjtu_agent/agent/tools.py
+++ b/sjtu_agent/agent/tools.py
@@ -728,6 +728,11 @@ TOOLS = [
                         "type": "string",
                         "description": "飞书应用的 App Secret",
                     },
+                    "feishu_allowed_open_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "（可选）允许使用 Bot 的飞书用户 open_id 列表。留空则允许所有人。用户在飞书中给 Bot 发消息后，日志会显示其 open_id。",
+                    },
                 },
                 "required": ["feishu_app_id", "feishu_app_secret"],
             },
@@ -3532,10 +3537,11 @@ def tool_setup_telegram(telegram_token: str, allowed_ids: list | None = None) ->
     return result
 
 
-def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "") -> dict:
+def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "", allowed_open_ids: list | None = None) -> dict:
     """
     将飞书 App ID 和 App Secret 保存到 config.json 并验证凭证有效性。
     用户在 https://open.feishu.cn/app 创建企业自建应用后可获取这些凭据。
+    可选传入 allowed_open_ids 设置白名单。
     """
     cfg: dict = {}
     if CONFIG_PATH.exists():
@@ -3548,6 +3554,8 @@ def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "") -> d
         cfg["feishu_app_id"] = feishu_app_id.strip()
     if feishu_app_secret:
         cfg["feishu_app_secret"] = feishu_app_secret.strip()
+    if allowed_open_ids is not None:
+        cfg["feishu_allowed_open_ids"] = allowed_open_ids
 
     CONFIG_PATH.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
 
@@ -3581,6 +3589,7 @@ def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "") -> d
     result: dict = {
         "saved": True,
         "valid": valid,
+        "allowed_open_ids_set": allowed_open_ids or [],
         "next_steps": [
             "运行 `sjtu-agent feishu-bot` 启动 Bot（WebSocket 长连接模式）。",
             "在飞书搜索你的应用名称，进入对话即可使用。",
@@ -3588,6 +3597,12 @@ def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "") -> d
             "如尚未创建飞书应用，前往 https://open.feishu.cn/app 创建企业自建应用。",
         ],
     }
+    if not allowed_open_ids:
+        result["tip"] = (
+            "当前白名单为空，Bot 启动后允许所有人对话。"
+            "如需限制，在飞书给 Bot 发一条消息后查看日志中的 open_id，"
+            "再用 setup_feishu 补填 allowed_open_ids 白名单。"
+        )
     if app_info:
         result["app_info"] = app_info
     return result

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -48,41 +48,133 @@ def _cmd_update(args: argparse.Namespace) -> int:
     if not pip.exists():
         pip = Path(sys.executable).parent / "pip3"
 
-    print(f"[sjtu-agent update] 当前版本：{__version__}")
-    print(f"[sjtu-agent update] 项目目录：{PROJECT_ROOT}")
+    print(f"sjtu-agent 更新工具")
+    print(f"  当前版本：{__version__}")
+    print(f"  项目目录：{PROJECT_ROOT}")
 
-    # ── 1. git pull ────────────────────────────────────────────────────────
+    # ── 0. 前置检查 ────────────────────────────────────────────────────────
+    git = shutil.which("git")
+    if not git:
+        print("[!] 未找到 git，无法更新代码。请安装 Git 后重试。")
+        return 1
+
+    is_git_repo = False
+    try:
+        r = subprocess.run(
+            [git, "rev-parse", "--is-inside-work-tree"],
+            cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+        )
+        is_git_repo = r.returncode == 0
+    except Exception:
+        pass
+
+    if not is_git_repo:
+        print(f"[!] {PROJECT_ROOT} 不是 Git 仓库，无法自动更新。")
+        print("   请确认项目是通过 git clone 安装的。")
+        return 1
+
+    # ── 1. 显示待更新内容 ──────────────────────────────────────────────────
     if not args.skip_git:
-        git = shutil.which("git")
-        if not git:
-            print("[sjtu-agent update] ⚠️  未找到 git，跳过代码更新")
+        # 获取当前 HEAD 和远端 HEAD 的差异
+        local_hash = subprocess.run(
+            [git, "rev-parse", "HEAD"],
+            cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+        ).stdout.decode().strip()
+
+        # 尝试获取远端最新
+        print("\n正在检查远端更新…")
+        fetch_result = subprocess.run(
+            [git, "fetch", "--quiet", "--no-tags", "origin"],
+            cwd=str(PROJECT_ROOT), capture_output=True, timeout=30,
+        )
+        if fetch_result.returncode != 0:
+            print("[!] 无法连接到远端仓库，请检查网络。")
+            if not args.upgrade_deps and not args.update_playwright:
+                return 1
         else:
-            print("[sjtu-agent update] 正在 git pull…")
-            result = subprocess.run(
-                [git, "pull", "--ff-only"],
+            # 确定远端分支
+            remote_ref = ""
+            for ref in ["@{u}", "origin/main", "origin/master"]:
+                r = subprocess.run(
+                    [git, "rev-parse", ref],
+                    cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+                )
+                if r.returncode == 0:
+                    remote_ref = ref
+                    break
+
+            if remote_ref:
+                remote_hash = subprocess.run(
+                    [git, "rev-parse", remote_ref],
+                    cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+                ).stdout.decode().strip()
+
+                if local_hash == remote_hash:
+                    print("[OK] 已是最新版本，无需更新。")
+                    if not args.upgrade_deps and not args.update_playwright:
+                        return 0
+                else:
+                    # 显示最近几个 commit
+                    behind = subprocess.run(
+                        [git, "rev-list", "--count", f"{local_hash}..{remote_hash}"],
+                        cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+                    ).stdout.decode().strip()
+                    print(f"\n发现 {behind} 个新提交：")
+                    log_result = subprocess.run(
+                        [git, "log", "--oneline", f"{local_hash}..{remote_hash}", "-10"],
+                        cwd=str(PROJECT_ROOT), capture_output=True, timeout=5,
+                    )
+                    if log_result.returncode == 0:
+                        for line in log_result.stdout.decode().strip().split("\n"):
+                            if line:
+                                print(f"  • {line}")
+
+    # ── 2. git pull ────────────────────────────────────────────────────────
+    if not args.skip_git:
+        print("\n正在拉取最新代码…")
+        # 先尝试 fast-forward（最简单，无冲突）
+        result = subprocess.run(
+            [git, "pull", "--ff-only"],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            print("[OK] 代码已更新。")
+        else:
+            # fast-forward 失败 → 可能是本地有提交导致分叉，尝试 rebase
+            print("  (fast-forward 不可用，尝试 rebase…)")
+            rebase_result = subprocess.run(
+                [git, "pull", "--rebase"],
                 cwd=str(PROJECT_ROOT),
                 capture_output=False,
             )
-            if result.returncode != 0:
-                print("[sjtu-agent update] ⚠️  git pull 失败，请手动解决冲突后重试")
+            if rebase_result.returncode == 0:
+                print("[OK] 代码已更新（rebase 方式）。")
+            else:
+                print("[!] 自动更新失败，请手动处理：")
+                print(f"    cd {PROJECT_ROOT}")
+                print("    git status    # 查看当前状态")
+                print("    git log --oneline -5   # 查看本地提交")
+                print("    如有未推送的本地提交，可尝试: git pull --rebase")
+                print("    或放弃本地修改: git reset --hard origin/main")
                 return 1
 
-    # ── 2. pip install -e . ────────────────────────────────────────────────
-    print("[sjtu-agent update] 正在重新安装依赖…")
+    # ── 3. pip install -e . ────────────────────────────────────────────────
+    print("\n正在重新安装…")
     pip_cmd = [sys.executable, "-m", "pip", "install", "-e", str(PROJECT_ROOT), "--quiet"]
     if args.upgrade_deps:
         pip_cmd.append("--upgrade")
     result = subprocess.run(pip_cmd)
     if result.returncode != 0:
-        print("[sjtu-agent update] ⚠️  依赖安装失败")
+        print("[!] 依赖安装失败，请手动运行: pip install -e " + str(PROJECT_ROOT))
         return 1
 
-    # ── 3. 可选：更新 Playwright Chromium ─────────────────────────────────
+    # ── 4. 可选：更新 Playwright Chromium ─────────────────────────────────
     if args.update_playwright:
-        print("[sjtu-agent update] 正在更新 Playwright Chromium…")
+        print("正在更新 Playwright Chromium…")
         subprocess.run([sys.executable, "-m", "playwright", "install", "chromium"])
 
-    # ── 3b. Windows 上写兜底 .pth 确保 editable install 路径不丢失 ────
+    # ── 5. Windows 上写兜底 .pth 确保 editable install 路径不丢失 ────
     if sys.platform == "win32":
         try:
             import site as _site
@@ -90,12 +182,11 @@ def _cmd_update(args: argparse.Namespace) -> int:
             if sp_dirs:
                 pth_path = Path(sp_dirs[0]) / "sjtu_agent_editable_path.pth"
                 pth_path.write_text(str(PROJECT_ROOT) + "\n", encoding="utf-8")
-                print(f"[sjtu-agent update] 已刷新 .pth 文件：{pth_path}")
+                print(f"已刷新 .pth 文件：{pth_path}")
         except Exception as _e:
-            print(f"[sjtu-agent update] （写 .pth 失败，非致命：{_e}）")
+            print(f"（写 .pth 失败，非致命：{_e}）")
 
-    # ── 4. 打印新版本 ────────────────────────────────────────────────────
-    # 重新导入以获取更新后的版本号
+    # ── 6. 打印新版本 ────────────────────────────────────────────────────
     try:
         import importlib
         import sjtu_agent as _pkg
@@ -103,7 +194,8 @@ def _cmd_update(args: argparse.Namespace) -> int:
         new_version = _pkg.__version__
     except Exception:
         new_version = "（重新打开终端后生效）"
-    print(f"[sjtu-agent update] ✅ 更新完成！新版本：{new_version}")
+    print(f"\n[OK] 更新完成！当前版本：{new_version}")
+    print("  如果 feishu-bot 等功能未生效，请重新打开终端。")
     return 0
 
 
@@ -334,22 +426,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     update_parser = subparsers.add_parser(
         "update",
-        help="pull latest code from git and reinstall the package",
+        help="从远端仓库拉取最新代码并重装",
     )
     update_parser.add_argument(
         "--skip-git",
         action="store_true",
-        help="skip git pull (only reinstall dependencies)",
+        help="跳过 git pull，仅重装依赖",
     )
     update_parser.add_argument(
         "--upgrade-deps",
         action="store_true",
-        help="also upgrade all Python dependencies to their latest versions",
+        help="同时升级所有 Python 依赖至最新版",
     )
     update_parser.add_argument(
         "--update-playwright",
         action="store_true",
-        help="also update Playwright Chromium browser",
+        help="同时更新 Playwright Chromium 浏览器",
     )
     update_parser.set_defaults(func=_cmd_update)
 

--- a/sjtu_agent/config.py
+++ b/sjtu_agent/config.py
@@ -202,6 +202,10 @@ class ConfigStore:
     def feishu_app_secret(self) -> str:
         return self.get("feishu_app_secret", "")
 
+    @property
+    def feishu_allowed_open_ids(self) -> list[str]:
+        return self.get("feishu_allowed_open_ids", [])
+
     # ── 水源 ────────────────────────────────────────────────────────────
     @property
     def shuiyuan_user_api_key(self) -> str:

--- a/sjtu_agent/scheduler/taskschd.py
+++ b/sjtu_agent/scheduler/taskschd.py
@@ -43,6 +43,12 @@ _SERVICE_SPECS = {
         "log": "wechat_bot.task.log",
         "schedule": "onlogon",  # 登录时启动
     },
+    "feishu-bot": {
+        "task_name": f"{_TASK_PREFIX}-FeishuBot",
+        "subcommand": "feishu-bot",
+        "log": "feishu_bot.task.log",
+        "schedule": "onlogon",  # 登录时启动
+    },
     "web": {
         "task_name": f"{_TASK_PREFIX}-Web",
         "subcommand": "web --no-browser",
@@ -104,9 +110,10 @@ def install(
         subcommand = spec["subcommand"]
         log_path = LOG_DIR / spec["log"]
 
-        # 构建运行命令：python -m sjtu_agent <subcommand> >> log 2>&1
-        program = py
-        arguments = f"-m sjtu_agent {subcommand} >> \"{log_path}\" 2>&1"
+        # pythonw.exe 无控制台窗口，日志由各子命令的 logging 模块写入文件
+        pyw = str(Path(py).with_name("pythonw.exe"))
+        program = pyw
+        arguments = f"-m sjtu_agent {subcommand}"
 
         # 先删除已存在的同名任务
         _delete_task(task_name)
@@ -150,7 +157,7 @@ def install(
         })
 
         # 立即触发一次（telegram-bot / wechat-bot / web，类似 run_at_load）
-        if load and success and name in ("telegram-bot", "wechat-bot", "web"):
+        if load and success and name in ("telegram-bot", "wechat-bot", "feishu-bot", "web"):
             subprocess.run(["schtasks", "/Run", "/TN", task_name], capture_output=True)
 
     return {


### PR DESCRIPTION
## Summary

Three fixes in this PR:

### 1. Windows Task Scheduler: use pythonw.exe to suppress terminal popups

**Problem**: Every time a scheduled task runs (especially `remind-check` every 60s), `cmd.exe` pops up a terminal window that immediately closes. This happens because Task Scheduler `/TR` commands use `python.exe` (console subsystem) with shell redirections (`>>` `2>&1`).

**Fix**: Replace `python.exe` with `pythonw.exe` (GUI subsystem, no console window). Remove shell redirections from `/TR` command — each subcommand already logs via the `logging` module. Also add missing `feishu-bot` to `_SERVICE_SPECS`.

### 2. `sjtu-agent update`: fall back to rebase when fast-forward fails

**Problem**: After a user's PR gets merged upstream, local branch diverges from origin. `git pull --ff-only` fails with "Not possible to fast-forward", and the update command exits with an error.

**Fix**: When `--ff-only` fails, automatically try `git pull --rebase`. If that also fails, print clear manual recovery instructions.

### 3. Feishu bot whitelist: agent-side config support

**Problem**: The upstream `feishu_bot.py` already has whitelist logic (`feishu_allowed_open_ids`, `--whoami` mode, per-user sessions), but the Agent config layer (`ConfigStore`, `tool_setup_feishu`) had no way to set these.

**Fix**: Add `feishu_allowed_open_ids` property to `ConfigStore`, extend `tool_setup_feishu` with optional `allowed_open_ids` parameter, and update the TOOLS definition.

## Files changed

| File | Change |
|------|--------|
| `sjtu_agent/scheduler/taskschd.py` | `python.exe` → `pythonw.exe`, remove `>>` `2>&1`, add `feishu-bot` spec |
| `sjtu_agent/cli.py` | `git pull --ff-only` → fallback `--rebase` on failure |
| `sjtu_agent/config.py` | Add `feishu_allowed_open_ids` property |
| `sjtu_agent/agent/tools.py` | `tool_setup_feishu` accepts `allowed_open_ids`, update TOOLS JSON schema |

## Test plan

- [x] `pytest tests/test_config.py -v` — 12/12 passed
- [x] `python -m sjtu_agent update` — fast-forward works; rebase fallback tested with diverged branches
- [x] `python -m sjtu_agent feishu-bot --help` — works
- [x] `cfg.feishu_allowed_open_ids` — returns saved values
- [x] `tool_setup_feishu(app_id, app_secret, allowed_open_ids=["ou_xxx"])` — saves correctly