### PR TITLE
feat: add psmux as Windows daemon backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,49 @@ sjtu-agent install-daemons --daily-report-time 21:30 --remind-interval 120
 
 这些后台服务会使用当前选定的 Python 解释器，以运行时数据目录为工作目录，并把日志写到 `~/Library/Application Support/sjtu-agent/logs`。
 
+## Windows 后台服务
+
+Windows 提供两种后端选择：**Task Scheduler**（默认，适合定时任务）和 **psmux**（适合常驻进程）。
+
+### 通用方式（默认 Task Scheduler）
+
+```powershell
+sjtu-agent install-daemons
+```
+
+每天 22:00 日报 + 每 60s 提醒检查 + 登录时启动 Telegram/飞书/微信 Bot + Web UI。
+
+### 用 psmux 管理常驻进程
+
+[psmux](https://github.com/psmux/psmux) 是 Windows 上的 tmux，可以创建后台分离会话来运行常驻 Bot，**不会弹出终端窗口**，启动/停止/检查方便。
+
+```powershell
+# 安装 psmux
+winget install psmux
+
+# 只用 psmux 启动常驻 Bot（feishu/telegram/wechat）
+sjtu-agent install-daemons --backend psmux --services feishu-bot telegram-bot
+
+# 定时任务（daily-report、remind-check）仍用 Task Scheduler
+sjtu-agent install-daemons --backend taskschd --services daily-report remind-check
+
+# 查看 psmux 服务状态
+psmux -L sjtu-agent ls
+```
+
+**两种后端的对比：**
+
+| | Task Scheduler (`taskschd`) | psmux |
+|---|---|---|
+| 适合 | 定时任务、开机启动 | 常驻进程守护 |
+| 弹窗 | `pythonw.exe` 无弹窗 | 无弹窗 |
+| 崩溃重启 | 手动 | 需手动重拉会话 |
+| 开机自启 | ✅ | ❌ |
+| 查看状态 | `schtasks /Query` | `psmux -L sjtu-agent ls` |
+| 停止服务 | `schtasks /Delete` | `psmux kill-session -t <name>` |
+
+> **推荐组合**：`daily-report`、`remind-check` 用 taskschd（定时）；`feishu-bot`、`telegram-bot`、`wechat-bot`、`web` 用 psmux（常驻）。
+
 ## 在飞书中使用 Bot
 
 > 每位用户需要**自建一个飞书应用**作为 bot 的"外壳"（飞书不支持公共多租户 bot，必须挂在你自己的组织/账号下）。整个过程约 5 分钟。
@@ -206,7 +249,7 @@ sjtu-agent install-daemons --daily-report-time 21:30 --remind-interval 120
 
 | 现象 | 原因 / 解决 |
 |---|---|
-| WebUI 里点启动报错 | macOS 才支持一键启动；其他系统手动 `sjtu-agent feishu-bot` |
+| WebUI 里点启动报错 | macOS 支持一键启动；Windows 用 `sjtu-agent install-daemons --backend psmux --services feishu-bot`；其他系统手动 `sjtu-agent feishu-bot` |
 | 在飞书搜不到自己的 bot | 版本没发布 / 审批没通过 / 可见范围没包含你自己 |
 | bot 在线但不回消息 | 「事件与回调」没切到**长连接**，或没订阅 `im.message.receive_v1` |
 | 回 "permission denied" / 报权限错 | 权限管理里漏申请了 `im:message:send_as_bot` |

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -309,6 +309,7 @@ def _cmd_install_daemons(args: argparse.Namespace) -> int:
             daily_report_time=args.daily_report_time,
             remind_interval=args.remind_interval,
             load=not args.write_only,
+            backend=getattr(args, "backend", "taskschd"),
             **platform_kwargs,
         )
     except (RuntimeError, ValueError) as exc:
@@ -418,6 +419,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=10,
         help="(macOS) launchd throttle interval for telegram bot restarts, default 10",
+    )
+    install_daemons_parser.add_argument(
+        "--backend",
+        choices=["taskschd", "psmux"],
+        default="taskschd",
+        help="(Windows) 后端选择：taskschd（任务计划程序，默认）或 psmux（分离会话）",
     )
     install_daemons_parser.set_defaults(func=_cmd_install_daemons)
 

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -25,18 +25,20 @@ def install_daemons(
     remind_interval: int = 60,
     telegram_throttle: int = 10,
     load: bool = True,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
     安装后台守护进程。
 
     参数：
-        service_names       要安装的服务子集，默认全部（daily-report / remind-check / telegram-bot）
+        service_names       要安装的服务子集，默认全部
         python_executable   使用的 Python 解释器路径，默认当前解释器
         daily_report_time   日报发送时间 (hour, minute)，默认 (22, 0)
         remind_interval     提醒检查间隔秒数（macOS/Linux 适用），默认 60
         telegram_throttle   Telegram bot 重启节流秒数（macOS 适用），默认 10
         load                是否立即加载/启动服务，默认 True
+        backend             Windows 后端选择：taskschd（默认）或 psmux
         **platform_kwargs   各平台专属参数（如 macOS 的 output_dir）
 
     返回包含安装结果的字典。
@@ -44,7 +46,10 @@ def install_daemons(
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import install as _install
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import install as _install
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import install as _install
+        else:
+            from sjtu_agent.scheduler.taskschd import install as _install
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import install as _install
     else:
@@ -66,6 +71,7 @@ def install_daemons(
 
 def uninstall_daemons(
     service_names: tuple[str, ...] | None = None,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
@@ -73,11 +79,15 @@ def uninstall_daemons(
 
     参数：
         service_names  要卸载的服务子集，默认全部
+        backend        Windows 后端选择：taskschd（默认）或 psmux
     """
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import uninstall as _uninstall
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import uninstall as _uninstall
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import uninstall as _uninstall
+        else:
+            from sjtu_agent.scheduler.taskschd import uninstall as _uninstall
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import uninstall as _uninstall
     else:
@@ -88,17 +98,24 @@ def uninstall_daemons(
 
 def daemon_status(
     service_names: tuple[str, ...] | None = None,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
     查询后台守护进程状态。
 
+    参数：
+        service_names  要查询的服务子集，默认全部
+        backend        Windows 后端选择：taskschd（默认）或 psmux
     返回包含各服务状态的字典。
     """
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import status as _status
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import status as _status
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import status as _status
+        else:
+            from sjtu_agent.scheduler.taskschd import status as _status
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import status as _status
     else:

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -134,7 +134,7 @@ def current_platform_name() -> str:
     if sys.platform == "darwin":
         return "macOS (launchd)"
     elif sys.platform == "win32":
-        return "Windows (Task Scheduler)"
+        return "Windows (psmux / Task Scheduler)"
     elif sys.platform.startswith("linux"):
         return "Linux (systemd)"
     else:

--- a/sjtu_agent/scheduler/psmuxd.py
+++ b/sjtu_agent/scheduler/psmuxd.py
@@ -1,0 +1,180 @@
+"""
+sjtu_agent/scheduler/psmuxd.py — Windows psmux 后端实现
+
+使用 psmux (tmux on Windows) 的分离会话管理后台服务。
+psmux 会话在 psmux 服务端进程存活期间保持运行，适合常驻进程管理。
+命名空间统一为 sjtu-agent（-L sjtu-agent），避免与用户的日常 psmux 会话混淆。
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from sjtu_agent.paths import DATA_DIR, LOG_DIR
+
+_NAMESPACE = "sjtu-agent"
+
+_SERVICE_SPECS = {
+    "daily-report": {
+        "session_name": "daily-report",
+        "subcommand": "daily-report",
+    },
+    "remind-check": {
+        "session_name": "remind-check",
+        "subcommand": "remind-check",
+    },
+    "telegram-bot": {
+        "session_name": "telegram-bot",
+        "subcommand": "telegram-bot",
+    },
+    "wechat-bot": {
+        "session_name": "wechat-bot",
+        "subcommand": "wechat-bot",
+    },
+    "feishu-bot": {
+        "session_name": "feishu-bot",
+        "subcommand": "feishu-bot",
+    },
+    "web": {
+        "session_name": "web",
+        "subcommand": "web --no-browser",
+    },
+}
+
+
+def _find_psmux() -> str | None:
+    return shutil.which("psmux")
+
+
+def _run_psmux(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [_find_psmux(), "-L", _NAMESPACE, *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def install(
+    service_names: tuple[str, ...] | None = None,
+    python_executable: Path | None = None,
+    daily_report_time: tuple[int, int] = (22, 0),
+    remind_interval: int = 60,
+    load: bool = True,
+    **_,
+) -> dict:
+    """启动 psmux 分离会话来运行后台服务。"""
+    if not _find_psmux():
+        raise RuntimeError("未找到 psmux，请先安装：winget install psmux")
+
+    py = str(python_executable or Path(sys.executable))
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        subcommand = spec["subcommand"]
+        log_path = LOG_DIR / f"{name}.psmux.log"
+
+        # 如果会话已存在，先 kill 再重建
+        if not load:
+            continue
+
+        # 尝试 kill 已有会话（忽略失败）
+        subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "kill-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+
+        # 启动新会话：psmux -L sjtu-agent new -s <name> -d -- python -m sjtu_agent <sub>
+        result = subprocess.run(
+            [
+                _find_psmux(), "-L", _NAMESPACE,
+                "new-session", "-s", session, "-d",
+                "--", py, "-m", "sjtu_agent", subcommand,
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        success = result.returncode == 0
+        results.append({
+            "name": name,
+            "session_name": session,
+            "log_path": str(log_path),
+            "success": success,
+            "error": result.stderr.strip() if not success else "",
+        })
+
+    return {
+        "platform": "Windows (psmux)",
+        "namespace": _NAMESPACE,
+        "python_executable": py,
+        "services": results,
+    }
+
+
+def uninstall(
+    service_names: tuple[str, ...] | None = None,
+    **_,
+) -> dict:
+    """终止 psmux 会话（停止后台服务）。"""
+    if not _find_psmux():
+        return {"platform": "Windows (psmux)", "removed": []}
+
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    removed: list[dict] = []
+
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        result = subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "kill-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+        removed.append({
+            "name": name,
+            "session_name": session,
+            "success": result.returncode == 0,
+        })
+
+    return {"platform": "Windows (psmux)", "removed": removed}
+
+
+def status(
+    service_names: tuple[str, ...] | None = None,
+    **_,
+) -> dict:
+    """检查 psmux 会话是否存在（即服务是否运行中）。"""
+    if not _find_psmux():
+        return {"platform": "Windows (psmux)", "services": [], "all_installed": False}
+
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    services: list[dict] = []
+
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        result = subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "has-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+        running = result.returncode == 0
+        services.append({
+            "name": name,
+            "session_name": session,
+            "running": running,
+        })
+
+    return {
+        "platform": "Windows (psmux)",
+        "services": services,
+        "all_running": bool(services) and all(s["running"] for s in services),
+    }


### PR DESCRIPTION
## Summary
Add psmux (tmux for Windows) as an alternative daemon backend for managing persistent services like feishu-bot and telegram-bot.

## Usage
sjtu-agent install-daemons --backend psmux --services feishu-bot telegram-bot
sjtu-agent install-daemons --backend taskschd --services daily-report remind-check  # default

## Changes
- New: sjtu_agent/scheduler/psmuxd.py
- Modified: scheduler/__init__.py (backend param)
- Modified: cli.py (--backend option)  
- Modified: README.md (Windows daemon docs)
