### PR TITLE
feat: 推送渠道独立开关 + Web UI 可视化控制

### DIFF
--- a/daily_report.py
+++ b/daily_report.py
@@ -34,6 +34,9 @@ import ddl_checker as dc
 def _send_telegram(text: str) -> None:
     """向所有 allowed_ids 分块推送 Telegram 消息。"""
     cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    if not cfg.get("telegram_enabled", True):
+        print("[daily_report] Telegram 推送已关闭，跳过")
+        return
     token = cfg.get("telegram_token", "")
     allowed_ids = cfg.get("telegram_allowed_ids", [])
     if not token or not allowed_ids:

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -225,6 +225,9 @@ def _extract_text(content_json: str) -> str:
 
 
 def _handle_message(data: P2ImMessageReceiveV1) -> None:
+    cfg = _load_cfg()
+    if not cfg.get("feishu_enabled", True):
+        return
     try:
         ev = data.event
         msg = ev.message

--- a/remind_check.py
+++ b/remind_check.py
@@ -240,6 +240,8 @@ def _send_notification(title: str, subtitle: str, body: str) -> None:
     # ── Telegram 推送 ─────────────────────────────────────────────────────
     try:
         cfg = _load_cfg()
+        if not cfg.get("telegram_enabled", True):
+            return
         token       = cfg.get("telegram_token", "")
         allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
         if not token or not allowed_ids:

--- a/sjtu_agent/config.py
+++ b/sjtu_agent/config.py
@@ -211,6 +211,19 @@ class ConfigStore:
     def shuiyuan_cookies(self) -> dict:
         return self.get("shuiyuan_cookies", {})
 
+    # ── 推送渠道开关 ────────────────────────────────────────────────────
+    @property
+    def telegram_enabled(self) -> bool:
+        return bool(self.get("telegram_enabled", True))
+
+    @property
+    def wechat_enabled(self) -> bool:
+        return bool(self.get("wechat_enabled", True))
+
+    @property
+    def feishu_enabled(self) -> bool:
+        return bool(self.get("feishu_enabled", True))
+
     # ── DDL 紧急保底 ────────────────────────────────────────────────────
     @property
     def ddl_deadline_guard_enabled(self) -> bool:

--- a/sjtu_agent/news_aggregator/aggregator.py
+++ b/sjtu_agent/news_aggregator/aggregator.py
@@ -90,6 +90,9 @@ class NewsAggregator:
         import requests
 
         cfg = read_json_safe(_paths.CONFIG_PATH, default={})
+        if not cfg.get("telegram_enabled", True):
+            print("[news] Telegram 推送已关闭，跳过", flush=True)
+            return False
         token = cfg.get("telegram_token", "")
         allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
         if not token or not allowed_ids:
@@ -129,6 +132,9 @@ class NewsAggregator:
         import sys, os
 
         cfg = read_json_safe(_paths.CONFIG_PATH, default={})
+        if not cfg.get("wechat_enabled", True):
+            print("[news] 微信推送已关闭，跳过", flush=True)
+            return False
         token    = cfg.get("wechat_bot_token", "")
         to_user  = cfg.get("wechat_to_user_id", "")
         ctx_tok  = cfg.get("wechat_context_token", "")

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -18,6 +18,24 @@ import sys
 from pathlib import Path
 
 
+def _default_service_names() -> tuple[str, ...]:
+    """根据 config.json 中的推送渠道开关返回默认服务列表。"""
+    try:
+        from sjtu_agent.paths import CONFIG_PATH
+        import json
+        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8")) if CONFIG_PATH.exists() else {}
+    except Exception:
+        cfg = {}
+    names = list(available_service_names()) + ["web", "news-digest"]
+    if not cfg.get("telegram_enabled", True) and "telegram-bot" in names:
+        names.remove("telegram-bot")
+    if not cfg.get("wechat_enabled", True) and "wechat-bot" in names:
+        names.remove("wechat-bot")
+    if not cfg.get("feishu_enabled", True) and "feishu-bot" in names:
+        names.remove("feishu-bot")
+    return tuple(names)
+
+
 def install_daemons(
     service_names: tuple[str, ...] | None = None,
     python_executable: Path | None = None,
@@ -52,6 +70,9 @@ def install_daemons(
             f"不支持的平台: {sys.platform}。"
             "目前支持 macOS (darwin)、Windows (win32)、Linux。"
         )
+
+    if service_names is None:
+        service_names = _default_service_names()
 
     return _install(
         service_names=service_names,

--- a/sjtu_agent/scheduler/launchd.py
+++ b/sjtu_agent/scheduler/launchd.py
@@ -129,6 +129,20 @@ def install(
     py = Path(os.path.abspath(python_executable or sys.executable))
     selected = set(service_names or _SERVICE_SPECS.keys())
 
+    # ── 卸载不再需要的已知服务 ────────────────────────────────────────────
+    uid = os.getuid()
+    for name in _SERVICE_SPECS:
+        if name in selected:
+            continue
+        label = _SERVICE_SPECS[name]["label"]
+        plist_path = out_dir / f"{label}.plist"
+        if plist_path.exists():
+            if load:
+                for domain in (f"gui/{uid}", f"user/{uid}"):
+                    subprocess.run(["launchctl", "bootout", f"{domain}/{label}"],
+                                   capture_output=True)
+            plist_path.unlink()
+
     written: list[dict] = []
     for name in _SERVICE_SPECS:
         if name not in selected:

--- a/sjtu_agent/scheduler/systemd.py
+++ b/sjtu_agent/scheduler/systemd.py
@@ -140,6 +140,26 @@ def install(
 
     py = str(python_executable or sys.executable)
     selected = set(service_names or _SERVICE_SPECS.keys())
+
+    # ── 卸载不再需要的已知服务 ────────────────────────────────────────────
+    for name, spec in _SERVICE_SPECS.items():
+        if name in selected:
+            continue
+        unit_name = spec["unit_name"]
+        if spec["has_timer"]:
+            _systemctl(["stop", f"{unit_name}.timer"])
+            _systemctl(["disable", f"{unit_name}.timer"])
+            timer_path = _SYSTEMD_USER_DIR / f"{unit_name}.timer"
+            if timer_path.exists():
+                timer_path.unlink()
+        else:
+            _systemctl(["stop", f"{unit_name}.service"])
+            _systemctl(["disable", f"{unit_name}.service"])
+        service_path = _SYSTEMD_USER_DIR / f"{unit_name}.service"
+        if service_path.exists():
+            service_path.unlink()
+    _systemctl(["daemon-reload"])
+
     written: list[dict] = []
 
     for name, spec in _SERVICE_SPECS.items():

--- a/sjtu_agent/scheduler/taskschd.py
+++ b/sjtu_agent/scheduler/taskschd.py
@@ -95,6 +95,14 @@ def install(
     # remind_interval 转换为分钟，向上取整，最小 1 分钟
     remind_minutes = max(1, (remind_interval + 59) // 60)
 
+    # ── 卸载不再需要的已知服务 ────────────────────────────────────────────
+    for name, spec in _SERVICE_SPECS.items():
+        if name in selected:
+            continue
+        task_name = spec["task_name"]
+        if _task_exists(task_name):
+            _delete_task(task_name)
+
     written: list[dict] = []
     for name, spec in _SERVICE_SPECS.items():
         if name not in selected:

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -177,6 +177,11 @@ def _get_status() -> dict:
     # WeChat (ilink) — token is auto-saved after QR scan
     has_wechat = bool(cfg.get("wechat_bot_token"))
 
+    # Push channel toggles
+    telegram_enabled = bool(cfg.get("telegram_enabled", True))
+    wechat_enabled = bool(cfg.get("wechat_enabled", True))
+    feishu_enabled = bool(cfg.get("feishu_enabled", True))
+
     return {
         "api": has_api,
         "canvas": has_canvas,
@@ -190,6 +195,9 @@ def _get_status() -> dict:
         "zhiyuan": has_zhiyuan,
         "openai": has_openai,
         "anthropic": has_anthropic,
+        "telegram_enabled": telegram_enabled,
+        "wechat_enabled": wechat_enabled,
+        "feishu_enabled": feishu_enabled,
     }
 
 
@@ -255,6 +263,9 @@ def _get_config_values() -> dict:
         "feishu_app_secret_set": bool(cfg.get("feishu_app_secret")),
         "feishu_allowed_open_ids": cfg.get("feishu_allowed_open_ids", []),
         "wechat_set": bool(cfg.get("wechat_bot_token")),
+        "telegram_enabled": bool(cfg.get("telegram_enabled", True)),
+        "wechat_enabled": bool(cfg.get("wechat_enabled", True)),
+        "feishu_enabled": bool(cfg.get("feishu_enabled", True)),
         "presets": PRESETS,
     }
 
@@ -832,6 +843,8 @@ class _Handler(BaseHTTPRequestHandler):
                 self._save_telegram(body)
             elif section == "feishu":
                 self._save_feishu(body)
+            elif section == "push_channels":
+                self._save_push_channels(body)
             else:
                 self._send_json({"ok": False, "error": f"未知 section: {section}"}, 400)
                 return
@@ -925,6 +938,76 @@ class _Handler(BaseHTTPRequestHandler):
                 cfg_updates["feishu_allowed_open_ids"] = raw_ids
         if cfg_updates:
             _write_config(cfg_updates)
+
+    def _save_push_channels(self, body: dict) -> None:
+        cfg_updates: dict = {}
+        if "telegram_enabled" in body:
+            cfg_updates["telegram_enabled"] = bool(body["telegram_enabled"])
+        if "wechat_enabled" in body:
+            cfg_updates["wechat_enabled"] = bool(body["wechat_enabled"])
+        if "feishu_enabled" in body:
+            cfg_updates["feishu_enabled"] = bool(body["feishu_enabled"])
+        if cfg_updates:
+            _write_config(cfg_updates)
+
+        # 后台同步守护进程状态（macOS 上自动启停 bot 服务）
+        # 注意：不能调用 install_daemons，因为它会处理 web 服务并触发
+        # launchctl bootout，导致当前 Web Server 进程被自杀。
+        def _sync() -> None:
+            import sys as _sys, os, subprocess, plistlib
+            if _sys.platform != "darwin":
+                return
+            try:
+                from pathlib import Path as _P
+                from sjtu_agent.scheduler.launchd import (
+                    _SERVICE_SPECS, _build_plist, _DEFAULT_OUTPUT_DIR,
+                )
+
+                out_dir = _P(_DEFAULT_OUTPUT_DIR).expanduser().resolve()
+                py = _P(_sys.executable).absolute()
+                uid = os.getuid()
+
+                for key, enabled in cfg_updates.items():
+                    name = {
+                        "telegram_enabled": "telegram-bot",
+                        "wechat_enabled": "wechat-bot",
+                        "feishu_enabled": "feishu-bot",
+                    }.get(key)
+                    if name is None or name not in _SERVICE_SPECS:
+                        continue
+                    spec = _SERVICE_SPECS[name]
+                    label = spec["label"]
+                    plist_path = out_dir / f"{label}.plist"
+
+                    if enabled:
+                        payload = _build_plist(
+                            name, py, (22, 0), 60, 10, (10, 0),
+                        )
+                        with plist_path.open("wb") as f:
+                            plistlib.dump(payload, f, sort_keys=False)
+                        for domain in (f"gui/{uid}", f"user/{uid}"):
+                            subprocess.run(
+                                ["launchctl", "bootout", f"{domain}/{label}"],
+                                capture_output=True,
+                            )
+                            r = subprocess.run(
+                                ["launchctl", "bootstrap", domain, str(plist_path)],
+                                capture_output=True, text=True,
+                            )
+                            if r.returncode == 0:
+                                break
+                    else:
+                        for domain in (f"gui/{uid}", f"user/{uid}"):
+                            subprocess.run(
+                                ["launchctl", "bootout", f"{domain}/{label}"],
+                                capture_output=True,
+                            )
+                        if plist_path.exists():
+                            plist_path.unlink()
+            except Exception:
+                pass
+
+        threading.Thread(target=_sync, daemon=True).start()
 
 
 # ── 启动入口 ──────────────────────────────────────────────────────────────────

--- a/sjtu_agent/web/static/index.html
+++ b/sjtu_agent/web/static/index.html
@@ -336,6 +336,62 @@
       margin: 20px 0;
     }
 
+    /* ── Toggle switch ── */
+    .toggle-wrap {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-left: auto;
+    }
+    .toggle-wrap label {
+      font-size: 13px;
+      color: var(--text2);
+      margin: 0;
+    }
+    .toggle-switch {
+      position: relative;
+      width: 40px;
+      height: 22px;
+      flex-shrink: 0;
+    }
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      inset: 0;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 22px;
+      transition: background .2s, border-color .2s;
+    }
+    .toggle-slider::before {
+      position: absolute;
+      content: "";
+      height: 16px;
+      width: 16px;
+      left: 2px;
+      bottom: 2px;
+      background: var(--text2);
+      border-radius: 50%;
+      transition: transform .2s, background .2s;
+    }
+    .toggle-switch input:checked + .toggle-slider {
+      background: var(--accent);
+      border-color: var(--accent);
+    }
+    .toggle-switch input:checked + .toggle-slider::before {
+      transform: translateX(18px);
+      background: #fff;
+    }
+    .card.disabled-channel {
+      opacity: .6;
+      border-color: var(--border);
+    }
+
     /* ── Chat ── */
     #page-chat {
       display: none;
@@ -821,7 +877,15 @@
 
       <!-- 微信 ilink Bot -->
       <div class="card" id="wechat-card">
-        <div class="card-title" id="wechat-card-title">💬 微信 Bot（ilink）</div>
+        <div class="card-title" id="wechat-card-title">
+          💬 微信 Bot（ilink）
+          <div class="toggle-wrap">
+            <label class="toggle-switch">
+              <input type="checkbox" id="wechat-enabled" checked onchange="savePushChannels()">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
         <div id="wechat-unconfigured">
           <div class="info-box">
             基于 ilink 协议，无需第三方微信框架。配置步骤：<br>
@@ -843,7 +907,15 @@
 
       <!-- Telegram Bot -->
       <div class="card" id="telegram-card">
-        <div class="card-title" id="telegram-card-title">✈️ Telegram Bot</div>
+        <div class="card-title" id="telegram-card-title">
+          ✈️ Telegram Bot
+          <div class="toggle-wrap">
+            <label class="toggle-switch">
+              <input type="checkbox" id="telegram-enabled" checked onchange="savePushChannels()">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
         <div class="info-box">
           <strong>如何获取 Bot Token：</strong>在 Telegram 中搜索 <code>@BotFather</code>，
           发送 <code>/newbot</code>，按提示创建后复制 Token。<br><br>
@@ -867,7 +939,15 @@
 
       <!-- Feishu Bot -->
       <div class="card" id="feishu-card">
-        <div class="card-title" id="feishu-card-title">🪶 飞书 Bot（Lark）</div>
+        <div class="card-title" id="feishu-card-title">
+          🪶 飞书 Bot（Lark）
+          <div class="toggle-wrap">
+            <label class="toggle-switch">
+              <input type="checkbox" id="feishu-enabled" checked onchange="savePushChannels()">
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+        </div>
         <div class="info-box">
           <strong>如何获取 App ID / App Secret：</strong>
           打开 <code>open.feishu.cn</code> → 开发者后台 → 自建应用 → 凭证与基础信息。<br><br>
@@ -1119,6 +1199,36 @@ async function saveFeishu() {
   else showToast(data.error || '保存失败', 'error');
 }
 
+let _pushChannelState = { telegram: true, wechat: true, feishu: true };
+
+async function savePushChannels() {
+  const telegramEnabled = document.getElementById('telegram-enabled').checked;
+  const wechatEnabled   = document.getElementById('wechat-enabled').checked;
+  const feishuEnabled   = document.getElementById('feishu-enabled').checked;
+
+  document.getElementById('telegram-card').classList.toggle('disabled-channel', !telegramEnabled);
+  document.getElementById('wechat-card').classList.toggle('disabled-channel', !wechatEnabled);
+  document.getElementById('feishu-card').classList.toggle('disabled-channel', !feishuEnabled);
+
+  const payload = { section: 'push_channels' };
+  if (telegramEnabled !== _pushChannelState.telegram) payload.telegram_enabled = telegramEnabled;
+  if (wechatEnabled   !== _pushChannelState.wechat)   payload.wechat_enabled   = wechatEnabled;
+  if (feishuEnabled   !== _pushChannelState.feishu)   payload.feishu_enabled   = feishuEnabled;
+
+  if (Object.keys(payload).length <= 1) {
+    showToast('推送配置已保存');
+    return;
+  }
+
+  const data = await postSave(payload);
+  if (data.ok) {
+    _pushChannelState = { telegram: telegramEnabled, wechat: wechatEnabled, feishu: feishuEnabled };
+    showToast('推送配置已保存');
+  } else {
+    showToast(data.error || '保存失败', 'error');
+  }
+}
+
 async function startFeishuBot() {
   showToast('正在启动飞书 bot…');
   try {
@@ -1187,16 +1297,28 @@ async function loadConfig() {
     if (c.wechat_set) {
       document.getElementById('wechat-unconfigured').style.display = 'none';
       document.getElementById('wechat-configured').style.display = '';
-      document.getElementById('wechat-card-title').innerHTML =
-        '💬 微信 Bot（ilink） <span style="font-size:12px;font-weight:400;color:var(--green);margin-left:6px;">✅ 已配置</span>';
+      let title = document.getElementById('wechat-card-title');
+      if (!title.querySelector('.cfg-status')) {
+        let sp = document.createElement('span');
+        sp.className = 'cfg-status';
+        sp.style.cssText = 'font-size:12px;font-weight:400;color:var(--green);margin-left:6px;';
+        sp.textContent = '✅ 已配置';
+        title.insertBefore(sp, title.querySelector('.toggle-wrap'));
+      }
       document.getElementById('wechat-card').style.borderColor = 'rgba(52,211,153,.25)';
     }
 
     // Push page — Telegram
     if (c.telegram_token_set) {
       document.getElementById('telegram-token').placeholder = c.telegram_token_masked + ' （已配置）';
-      document.getElementById('telegram-card-title').innerHTML =
-        '✈️ Telegram Bot <span style="font-size:12px;font-weight:400;color:var(--green);margin-left:6px;">✅ 已配置</span>';
+      let title = document.getElementById('telegram-card-title');
+      if (!title.querySelector('.cfg-status')) {
+        let sp = document.createElement('span');
+        sp.className = 'cfg-status';
+        sp.style.cssText = 'font-size:12px;font-weight:400;color:var(--green);margin-left:6px;';
+        sp.textContent = '✅ 已配置';
+        title.insertBefore(sp, title.querySelector('.toggle-wrap'));
+      }
       document.getElementById('telegram-card').style.borderColor = 'rgba(52,211,153,.25)';
     }
     if (c.telegram_allowed_ids && c.telegram_allowed_ids.length) {
@@ -1211,12 +1333,35 @@ async function loadConfig() {
       document.getElementById('feishu-app-secret').placeholder = c.feishu_app_secret_masked + ' （已配置）';
     }
     if (c.feishu_app_id_set && c.feishu_app_secret_set) {
-      document.getElementById('feishu-card-title').innerHTML =
-        '🪶 飞书 Bot（Lark） <span style="font-size:12px;font-weight:400;color:var(--green);margin-left:6px;">✅ 已配置</span>';
+      let title = document.getElementById('feishu-card-title');
+      if (!title.querySelector('.cfg-status')) {
+        let sp = document.createElement('span');
+        sp.className = 'cfg-status';
+        sp.style.cssText = 'font-size:12px;font-weight:400;color:var(--green);margin-left:6px;';
+        sp.textContent = '✅ 已配置';
+        title.insertBefore(sp, title.querySelector('.toggle-wrap'));
+      }
       document.getElementById('feishu-card').style.borderColor = 'rgba(52,211,153,.25)';
     }
     if (c.feishu_allowed_open_ids && c.feishu_allowed_open_ids.length) {
       document.getElementById('feishu-allowed-open-ids').value = c.feishu_allowed_open_ids.join(', ');
+    }
+
+    // Push channel toggles
+    if (typeof c.telegram_enabled === 'boolean') {
+      document.getElementById('telegram-enabled').checked = c.telegram_enabled;
+      document.getElementById('telegram-card').classList.toggle('disabled-channel', !c.telegram_enabled);
+      _pushChannelState.telegram = c.telegram_enabled;
+    }
+    if (typeof c.wechat_enabled === 'boolean') {
+      document.getElementById('wechat-enabled').checked = c.wechat_enabled;
+      document.getElementById('wechat-card').classList.toggle('disabled-channel', !c.wechat_enabled);
+      _pushChannelState.wechat = c.wechat_enabled;
+    }
+    if (typeof c.feishu_enabled === 'boolean') {
+      document.getElementById('feishu-enabled').checked = c.feishu_enabled;
+      document.getElementById('feishu-card').classList.toggle('disabled-channel', !c.feishu_enabled);
+      _pushChannelState.feishu = c.feishu_enabled;
     }
   } catch (e) {}
   refreshStatus();

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1132,6 +1132,9 @@ def handle_photo(msg):
 @bot.message_handler(func=lambda m: True)
 def handle_text(msg):
     chat_id = msg.chat.id
+    cfg = _load_cfg()
+    if not cfg.get("telegram_enabled", True):
+        return
     if not _is_authorized(chat_id, msg):
         return
     if not msg.text:

--- a/wechat_bot.py
+++ b/wechat_bot.py
@@ -326,6 +326,10 @@ _reply_lock = threading.Lock()
 
 def handle_message(client: ILinkClient, msg: dict) -> None:
     """处理一条收到的微信消息，调用 agent 并回复。"""
+    cfg = _load_cfg()
+    if not cfg.get("wechat_enabled", True):
+        return
+
     ctx_token   = msg.get("context_token", "")
     from_user   = msg.get("from_user_id", "")
     item_list   = msg.get("item_list", [])


### PR DESCRIPTION
实现各推送渠道（微信、Telegram、飞书）的独立启用/禁用开关：

1. Config 层：新增 telegram_enabled / wechat_enabled / feishu_enabled 布尔配置项
2. Web UI：推送配置页面增加可视化 toggle 开关，支持单渠道控制
3. Scheduler：install_daemons 默认根据配置开关自动过滤 bot 服务
4. 执行层：daily_report / remind_check / news_aggregator / 各 bot 脚本在发送/处理前检查对应开关
5. 后台同步：Web UI 切换开关后自动启停对应 launchd 服务（macOS），无需手动运行 CLI
<img width="924" height="802" alt="截屏2026-05-20 20 33 02" src="https://github.com/user-attachments/assets/6b4e5858-802b-44d1-8cdc-d10a44456088" />
如果与其他 PR 有冲突请 @ 我 rebase