### PR TITLE
docs: add Feishu bot troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,49 @@ sjtu-agent install-daemons --daily-report-time 21:30 --remind-interval 120
 
 这些后台服务会使用当前选定的 Python 解释器，以运行时数据目录为工作目录，并把日志写到 `~/Library/Application Support/sjtu-agent/logs`。
 
+## Windows 后台服务
+
+Windows 提供两种后端选择：**Task Scheduler**（默认，适合定时任务）和 **psmux**（适合常驻进程）。
+
+### 通用方式（默认 Task Scheduler）
+
+```powershell
+sjtu-agent install-daemons
+```
+
+每天 22:00 日报 + 每 60s 提醒检查 + 登录时启动 Telegram/飞书/微信 Bot + Web UI。
+
+### 用 psmux 管理常驻进程
+
+[psmux](https://github.com/psmux/psmux) 是 Windows 上的 tmux，可以创建后台分离会话来运行常驻 Bot，**不会弹出终端窗口**，启动/停止/检查方便。
+
+```powershell
+# 安装 psmux
+winget install psmux
+
+# 只用 psmux 启动常驻 Bot（feishu/telegram/wechat）
+sjtu-agent install-daemons --backend psmux --services feishu-bot telegram-bot
+
+# 定时任务（daily-report、remind-check）仍用 Task Scheduler
+sjtu-agent install-daemons --backend taskschd --services daily-report remind-check
+
+# 查看 psmux 服务状态
+psmux -L sjtu-agent ls
+```
+
+**两种后端的对比：**
+
+| | Task Scheduler (`taskschd`) | psmux |
+|---|---|---|
+| 适合 | 定时任务、开机启动 | 常驻进程守护 |
+| 弹窗 | `pythonw.exe` 无弹窗 | 无弹窗 |
+| 崩溃重启 | 手动 | 需手动重拉会话 |
+| 开机自启 | ✅ | ❌ |
+| 查看状态 | `schtasks /Query` | `psmux -L sjtu-agent ls` |
+| 停止服务 | `schtasks /Delete` | `psmux kill-session -t <name>` |
+
+> **推荐组合**：`daily-report`、`remind-check` 用 taskschd（定时）；`feishu-bot`、`telegram-bot`、`wechat-bot`、`web` 用 psmux（常驻）。
+
 ## 在飞书中使用 Bot
 
 > 每位用户需要**自建一个飞书应用**作为 bot 的"外壳"（飞书不支持公共多租户 bot，必须挂在你自己的组织/账号下）。整个过程约 5 分钟。
@@ -206,7 +249,7 @@ sjtu-agent install-daemons --daily-report-time 21:30 --remind-interval 120
 
 | 现象 | 原因 / 解决 |
 |---|---|
-| WebUI 里点启动报错 | macOS 才支持一键启动；其他系统手动 `sjtu-agent feishu-bot` |
+| WebUI 里点启动报错 | macOS 支持一键启动；Windows 用 `sjtu-agent install-daemons --backend psmux --services feishu-bot`；其他系统手动 `sjtu-agent feishu-bot` |
 | 在飞书搜不到自己的 bot | 版本没发布 / 审批没通过 / 可见范围没包含你自己 |
 | bot 在线但不回消息 | 「事件与回调」没切到**长连接**，或没订阅 `im.message.receive_v1` |
 | 回 "permission denied" / 报权限错 | 权限管理里漏申请了 `im:message:send_as_bot` |

--- a/docs/feishu-bot-troubleshooting.md
+++ b/docs/feishu-bot-troubleshooting.md
@@ -1,0 +1,100 @@
+# 飞书 Bot 常见问题排查
+
+## Bot 无任何回复
+
+按以下顺序逐项排查：
+
+### 1. 检查凭据是否有效
+
+```bash
+sjtu-agent feishu-bot -- --test
+```
+
+或手动验证：
+
+```python
+import requests, json
+r = requests.post('https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+    json={'app_id': 'cli_xxx', 'app_secret': 'xxx'}, timeout=10)
+print(r.json())  # code=0 表示有效
+```
+
+**常见错误码**：
+- `10014 app id not exists` → App ID 错误或应用已删除
+- `10014 app secret invalid` → App Secret 错误
+- `1000040345 app_id or app_secret is invalid` → WebSocket 连接时凭据无效
+
+> 飞书开放平台可能会重置应用凭据。如果凭据突然失效，去 https://open.feishu.cn/app 重新获取。
+
+### 2. 检查 Bot 进程是否存活
+
+```bash
+psmux -L sjtu-agent server-info   # psmux 后端
+schtasks /Query /TN SJTUAgent-FeishuBot  # Task Scheduler 后端
+```
+
+如果进程反复崩溃（启动后几秒内退出），看下一步。
+
+### 3. Windows GBK 终端 emoji 崩溃
+
+**症状**：Bot 启动后立即崩溃，或 `sjtu-agent feishu-bot` 直接报错 `UnicodeEncodeError`
+
+**原因**：Python 代码中的 `✅` `❌` `⚠` 等 emoji 字符在 Windows GBK 控制台打印时抛出 `UnicodeEncodeError`，导致进程在 WebSocket 连接建立前崩溃。
+
+**修复**：将所有 `print()` 中的 emoji 替换为纯文本标记：
+- `✅` → `[OK]`
+- `❌` → `[X]`
+- `⚠` → `[!]`
+- `ℹ` → `[i]`
+
+> `_reply_text()` 中发送给飞书 API 的消息不受影响（API 接受 UTF-8）。
+
+### 4. 白名单被双 JSON 编码
+
+**症状**：Bot 回复"你不在该机器人的允许列表中"，但 `config.json` 里确实有你的 open_id。
+
+**检查**：
+
+```python
+import json
+cfg = json.loads(open('config.json').read())
+v = cfg.get('feishu_allowed_open_ids')
+print(type(v).__name__)  # 应该是 list，如果是 str 就是 bug
+```
+
+**原因**：Web UI 或某些保存路径将 `feishu_allowed_open_ids` 数组双编码为 JSON 字符串（`"[\"ou_xxx\"]"` 而非 `["ou_xxx"]`）。`set("[\"ou_xxx\"]")` 会把每个字符当作一个 open_id，导致匹配失败。
+
+**修复**：
+1. 手动将 config.json 中的值改为真正的 JSON 数组
+2. `feishu_bot.py` 已加入防御：如果值是字符串，自动 `json.loads()` 解析
+
+### 5. 检查事件订阅配置
+
+1. 打开 https://open.feishu.cn/app → 你的应用
+2. 「事件与回调」→ 确认**使用长连接接收事件**（不是回调 URL）
+3. 确认已订阅 `im.message.receive_v1` 事件
+4. 确认应用已发布
+
+### 6. 检查权限
+
+飞书开放平台 → 你的应用 → 「权限管理」：
+- `im:message` ✓
+- `im:message.p2p_msg:readonly` ✓
+- `im:message:send_as_bot` ✓
+
+## 快速诊断命令
+
+```powershell
+# 凭据测试
+sjtu-agent feishu-bot -- --test
+
+# whoami 模式（回显 open_id）
+sjtu-agent feishu-bot -- --whoami
+
+# 检查 psmux 会话
+psmux -L sjtu-agent ls
+psmux -L sjtu-agent server-info
+
+# 重启 bot（psmux 后端）
+sjtu-agent install-daemons --backend psmux --services feishu-bot
+```

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -52,7 +52,13 @@ def _load_cfg() -> dict:
 cfg = _load_cfg()
 APP_ID = cfg.get("feishu_app_id", "").strip()
 APP_SECRET = cfg.get("feishu_app_secret", "").strip()
-ALLOWED_OPEN_IDS: set[str] = set(cfg.get("feishu_allowed_open_ids", []) or [])
+_raw_allowed = cfg.get("feishu_allowed_open_ids", []) or []
+if isinstance(_raw_allowed, str):
+    try:
+        _raw_allowed = json.loads(_raw_allowed)
+    except Exception:
+        _raw_allowed = []
+ALLOWED_OPEN_IDS: set[str] = set(_raw_allowed)
 
 if not APP_ID or not APP_SECRET:
     print("[X] config.json 中未设置 feishu_app_id / feishu_app_secret，请先在 WebUI 或 setup 中配置")

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -23,6 +23,7 @@ import json
 import re
 import sys
 import threading
+import time
 import datetime as _dt
 from pathlib import Path
 
@@ -82,8 +83,11 @@ def _get_session(open_id: str) -> tuple[dict, threading.Lock]:
 _FS_CTX = (
     "\n\n## 当前运行环境：飞书 Bot\n"
     "你正在通过飞书（Lark）与用户交互：\n"
-    "- 回复以纯文本形式发出，飞书会自动渲染基本 markdown。\n"
+    "- 支持 Markdown 格式：**加粗**、*斜体*、`代码`、链接、列表、表格均可正常使用。\n"
+    "- 代码块用三个反引号包裹并标注语言。\n"
+    "- 表格请使用标准 Markdown 表格格式。\n"
     "- 不要在回复中给出本地文件路径或让用户在终端操作的指令。\n"
+    "- 回复以中文为主，适当使用格式提升可读性。\n"
 )
 
 
@@ -158,15 +162,256 @@ def _capture_turn(sess: dict, user_text: str) -> str:
     return clean[idx + len(marker):].strip()
 
 
-# ── 回复与拆包 ───────────────────────────────────────────────────────────────
+# ── 消息去重 ──────────────────────────────────────────────────────────────────
 
-_FS_MSG_MAX = 4000  # 飞书单条文本消息长度上限约 5000，留点余量
+_SEEN_IDS: dict[str, float] = {}
+_SEEN_IDS_LOCK = threading.Lock()
+_SEEN_TTL = 300  # 5 分钟
+
+
+def _is_duplicate(message_id: str) -> bool:
+    """检查 message_id 是否已处理过，防止飞书重发导致重复回复。"""
+    now = time.time()
+    with _SEEN_IDS_LOCK:
+        expired = [mid for mid, ts in _SEEN_IDS.items() if now - ts > _SEEN_TTL]
+        for mid in expired:
+            del _SEEN_IDS[mid]
+        if message_id in _SEEN_IDS:
+            return True
+        _SEEN_IDS[message_id] = now
+        return False
+
+
+# ── Markdown → 飞书 post / interactive 转换 ───────────────────────────────────
+
+_FS_MSG_MAX = 4000  # 飞书单条消息长度上限约 5000，留点余量
+
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MD_ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)")
+_MD_CODE_RE = re.compile(r"`([^`\n]+?)`")
+_MD_TABLE_SEP_RE = re.compile(r"^\|?\s*[-:]{3,}\s*(\|\s*[-:]{3,}\s*)*\|?\s*$")
+
+# 飞书 post 格式中的元素类型
+_PostElement = dict  # {"tag": "text"|"a", "text": str, ...}
+_PostParagraph = list  # list[_PostElement]
+_PostContent = list  # list[_PostParagraph]
+
+
+def _has_table(md_text: str) -> bool:
+    """检测 Markdown 文本是否包含表格。"""
+    lines = md_text.strip().split("\n")
+    for i, line in enumerate(lines):
+        if i > 0 and _MD_TABLE_SEP_RE.match(line.strip()):
+            return True
+    return False
+
+
+def _build_post_content(md_text: str) -> _PostContent:
+    """将 Markdown 文本转换为飞书 post 格式的 content 二维数组。"""
+    paragraphs: _PostContent = []
+    lines = md_text.strip().split("\n")
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            paragraphs.append([])  # 空行
+            continue
+
+        # 标题 → 去掉 # 前缀，加粗整行
+        header_match = re.match(r"^(#{1,3})\s+(.+)$", stripped)
+        if header_match:
+            level = len(header_match.group(1))
+            text = header_match.group(2)
+            if level <= 2:
+                paragraphs.append([_el_text(text, ["bold"])])
+            else:
+                paragraphs.append([_el_text(text, ["bold"])])
+            continue
+
+        # 无序列表 → 去掉 - 前缀
+        list_match = re.match(r"^[-*]\s+(.+)$", stripped)
+        if list_match:
+            paragraphs.append([_el_text("• " + list_match.group(1))])
+            continue
+
+        # 有序列表 → 保留序号
+        ol_match = re.match(r"^\d+\.\s+(.+)$", stripped)
+        if ol_match:
+            paragraphs.append([_el_text(stripped)])
+            continue
+
+        # 引用块
+        if stripped.startswith(">"):
+            text = stripped.lstrip("> ").lstrip(">")
+            paragraphs.append([_el_text(text)])
+            continue
+
+        # 分隔线
+        if stripped in ("---", "***", "___"):
+            paragraphs.append([_el_text("—" * 20)])
+            continue
+
+        # 普通段落 → 解析内联样式
+        elements = _parse_inline(stripped)
+        paragraphs.append(elements)
+
+    return paragraphs
+
+
+def _parse_inline(text: str) -> _PostParagraph:
+    """解析一行中的内联 Markdown 为 post 元素列表。"""
+    elements: _PostParagraph = []
+    pos = 0
+    remaining = text
+
+    while remaining:
+        # 找最早的标记
+        bold_m = _MD_BOLD_RE.search(remaining)
+        italic_m = _MD_ITALIC_RE.search(remaining)
+        code_m = _MD_CODE_RE.search(remaining)
+        link_m = _MD_LINK_RE.search(remaining)
+
+        candidates = []
+        if bold_m: candidates.append((bold_m.start(), bold_m, "bold"))
+        if italic_m: candidates.append((italic_m.start(), italic_m, "italic"))
+        if code_m: candidates.append((code_m.start(), code_m, "code"))
+        if link_m: candidates.append((link_m.start(), link_m, "link"))
+
+        if not candidates:
+            # 剩余纯文本
+            txt = _unescape_md(remaining)
+            if txt:
+                elements.append(_el_text(txt))
+            break
+
+        candidates.sort(key=lambda x: x[0])
+        first_start, first_match, first_type = candidates[0]
+
+        # 标记前的纯文本
+        if first_start > 0:
+            prefix = _unescape_md(remaining[:first_start])
+            if prefix:
+                elements.append(_el_text(prefix))
+
+        if first_type == "bold":
+            elements.append(_el_text(first_match.group(1), ["bold"]))
+            remaining = remaining[first_match.end():]
+        elif first_type == "italic":
+            elements.append(_el_text(first_match.group(1), ["italic"]))
+            remaining = remaining[first_match.end():]
+        elif first_type == "code":
+            elements.append(_el_text(first_match.group(1)))
+            remaining = remaining[first_match.end():]
+        elif first_type == "link":
+            elements.append(_el_link(first_match.group(1), first_match.group(2)))
+            remaining = remaining[first_match.end():]
+
+    # 合并相邻同风格 text 元素
+    merged: _PostParagraph = []
+    for el in elements:
+        if (merged and el.get("tag") == "text" and merged[-1].get("tag") == "text"
+                and el.get("style") == merged[-1].get("style")
+                and "href" not in el):
+            merged[-1]["text"] += el["text"]
+        else:
+            merged.append(el)
+    return merged
+
+
+def _el_text(text: str, style: list | None = None) -> _PostElement:
+    el: _PostElement = {"tag": "text", "text": text}
+    if style:
+        el["style"] = style
+    return el
+
+
+def _el_link(text: str, href: str) -> _PostElement:
+    return {"tag": "a", "text": text, "href": href}
+
+
+def _unescape_md(text: str) -> str:
+    """去掉反斜杠转义。"""
+    return text.replace("\\*", "*").replace("\\`", "`").replace("\\[", "[")
+
+
+def _build_card_content(md_text: str) -> str:
+    """构建交互式卡片的 markdown 内容（用于含表格的消息）。"""
+    # 卡片 markdown 元素原生支持 Markdown 语法
+    return md_text[:30000]  # 飞书卡片 markdown 有长度限制
+
+
+# ── 回复消息 ──────────────────────────────────────────────────────────────────
 
 
 def _reply_text(message_id: str, text: str) -> None:
-    """回复一条文本消息（线程内回复，飞书 UI 显示成 reply）。"""
+    """回复消息，自动检测表格并选择合适的格式（post 或 interactive）。"""
     if not text:
         text = "(已完成)"
+
+    # 空回复不处理
+    if not text.strip():
+        return
+
+    # 含表格 → 用 interactive 卡片（markdown 元素原生支持表格）
+    if _has_table(text):
+        _reply_card(message_id, text)
+        return
+
+    # 普通内容 → post 格式
+    post_content = _build_post_content(text)
+    if not post_content:
+        _reply_raw_text(message_id, text)
+        return
+
+    # 分块发送（post 有大段限制）
+    # 按段落数分块，每块最多 30 个段落
+    para_chunks = [post_content[i:i + 30] for i in range(0, len(post_content), 30)]
+    for para_chunk in para_chunks:
+        content = {"zh_cn": {"title": "", "content": para_chunk}}
+        req = (
+            ReplyMessageRequest.builder()
+            .message_id(message_id)
+            .request_body(
+                ReplyMessageRequestBody.builder()
+                .content(json.dumps(content, ensure_ascii=False))
+                .msg_type("post")
+                .build()
+            )
+            .build()
+        )
+        resp = _api_client.im.v1.message.reply(req)
+        if not resp.success():
+            print(f"[feishu] post 回复失败 code={resp.code} msg={resp.msg}，降级为 text")
+            _reply_raw_text(message_id, text)
+            break
+
+
+def _reply_card(message_id: str, text: str) -> None:
+    """用 interactive 卡片回复（含 markdown 元素，支持表格）。"""
+    card = {
+        "config": {"wide_screen_mode": True},
+        "elements": [{"tag": "markdown", "content": _build_card_content(text)}],
+    }
+    req = (
+        ReplyMessageRequest.builder()
+        .message_id(message_id)
+        .request_body(
+            ReplyMessageRequestBody.builder()
+            .content(json.dumps(card, ensure_ascii=False))
+            .msg_type("interactive")
+            .build()
+        )
+        .build()
+    )
+    resp = _api_client.im.v1.message.reply(req)
+    if not resp.success():
+        print(f"[feishu] card 回复失败 code={resp.code} msg={resp.msg}，降级为 text")
+        _reply_raw_text(message_id, text)
+
+
+def _reply_raw_text(message_id: str, text: str) -> None:
+    """纯文本降级回复。"""
     chunks = [text[i:i + _FS_MSG_MAX] for i in range(0, len(text), _FS_MSG_MAX)] or [text]
     for chunk in chunks:
         req = (
@@ -190,21 +435,66 @@ def _send_to_chat(chat_id: str, text: str) -> None:
     """主动发消息到会话（供 reminder 推送等场景使用）。"""
     if not text:
         return
-    req = (
-        CreateMessageRequest.builder()
-        .receive_id_type("chat_id")
-        .request_body(
-            CreateMessageRequestBody.builder()
-            .receive_id(chat_id)
-            .msg_type("text")
-            .content(json.dumps({"text": text}, ensure_ascii=False))
+
+    # 含表格 → interactive 卡片
+    if _has_table(text):
+        card = {
+            "config": {"wide_screen_mode": True},
+            "elements": [{"tag": "markdown", "content": _build_card_content(text)}],
+        }
+        req = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("interactive")
+                .content(json.dumps(card, ensure_ascii=False))
+                .build()
+            )
             .build()
         )
-        .build()
-    )
-    resp = _api_client.im.v1.message.create(req)
-    if not resp.success():
-        print(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
+        resp = _api_client.im.v1.message.create(req)
+        if not resp.success():
+            print(f"[feishu] 主动发送 card 失败 code={resp.code} msg={resp.msg}")
+        return
+
+    # 普通内容 → post
+    post_content = _build_post_content(text)
+    if post_content:
+        content = {"zh_cn": {"title": "", "content": post_content}}
+        req = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("post")
+                .content(json.dumps(content, ensure_ascii=False))
+                .build()
+            )
+            .build()
+        )
+        resp = _api_client.im.v1.message.create(req)
+        if not resp.success():
+            print(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
+    else:
+        # fallback text
+        req = (
+            CreateMessageRequest.builder()
+            .receive_id_type("chat_id")
+            .request_body(
+                CreateMessageRequestBody.builder()
+                .receive_id(chat_id)
+                .msg_type("text")
+                .content(json.dumps({"text": text}, ensure_ascii=False))
+                .build()
+            )
+            .build()
+        )
+        resp = _api_client.im.v1.message.create(req)
+        if not resp.success():
+            print(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
 
 
 # ── 事件处理 ──────────────────────────────────────────────────────────────────
@@ -236,6 +526,11 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         chat_id = msg.chat_id
         chat_type = msg.chat_type  # "p2p" 或 "group"
 
+        # ── 去重：飞书可能因 ack 超时重发同一事件 ──────────────────────
+        if _is_duplicate(message_id):
+            print(f"[feishu] 跳过重复消息 message_id={message_id}")
+            return
+
         # 只处理文本（其他类型先忽略）
         if msg_type != "text":
             _reply_text(message_id, f"(暂不支持的消息类型: {msg_type}，目前只接收文本)")
@@ -266,7 +561,6 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
             return
 
         if not ALLOWED_OPEN_IDS:
-            # 白名单为空时也提示（一次性引导）
             print(
                 f"[feishu] ℹ 白名单为空，已允许所有人；建议把此 open_id 加入白名单：{sender_open_id}"
             )

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -18,6 +18,7 @@ feishu_bot.py — 将 agent.py 接入飞书（Lark）自建应用，长连接接
 """
 
 import argparse
+import concurrent.futures
 import io
 import json
 import re
@@ -60,6 +61,9 @@ if not APP_ID or not APP_SECRET:
 
 # ── 全局 API client（用来回复消息） ────────────────────────────────────────────
 _api_client = lark.Client.builder().app_id(APP_ID).app_secret(APP_SECRET).build()
+
+# ── 后台线程池（LLM 推理在后台线程执行，避免阻塞 WS event loop） ─────────
+_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_prefix="feishu")
 
 # ── 会话状态（每个 open_id 独立） ─────────────────────────────────────────────
 _sessions: dict[str, dict] = {}
@@ -187,10 +191,11 @@ def _is_duplicate(message_id: str) -> bool:
 _FS_MSG_MAX = 4000  # 飞书单条消息长度上限约 5000，留点余量
 
 _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_MD_BOLD_ITALIC_RE = re.compile(r"\*\*\*(.+?)\*\*\*")
 _MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _MD_ITALIC_RE = re.compile(r"(?<!\*)\*([^*\n]+?)\*(?!\*)")
 _MD_CODE_RE = re.compile(r"`([^`\n]+?)`")
-_MD_TABLE_SEP_RE = re.compile(r"^\|?\s*[-:]{3,}\s*(\|\s*[-:]{3,}\s*)*\|?\s*$")
+_MD_TABLE_SEP_RE = re.compile(r"^\|?\s*[-:]{3,}\s*\|\s*[-:]{3,}\s*(\|\s*[-:]{3,}\s*)*\|?\s*$")
 
 # 飞书 post 格式中的元素类型
 _PostElement = dict  # {"tag": "text"|"a", "text": str, ...}
@@ -218,27 +223,30 @@ def _build_post_content(md_text: str) -> _PostContent:
             paragraphs.append([])  # 空行
             continue
 
-        # 标题 → 去掉 # 前缀，加粗整行
+        # 标题 → 去掉 # 前缀，内联解析后整体加粗
         header_match = re.match(r"^(#{1,3})\s+(.+)$", stripped)
         if header_match:
-            level = len(header_match.group(1))
             text = header_match.group(2)
-            if level <= 2:
-                paragraphs.append([_el_text(text, ["bold"])])
-            else:
-                paragraphs.append([_el_text(text, ["bold"])])
+            h_elements = _parse_inline(text)
+            for el in h_elements:
+                if el.get("tag") == "text":
+                    el["style"] = (el.get("style") or []) + ["bold"]
+            paragraphs.append(h_elements)
             continue
 
-        # 无序列表 → 去掉 - 前缀
+        # 无序列表 → 去掉前缀，内联解析
         list_match = re.match(r"^[-*]\s+(.+)$", stripped)
         if list_match:
-            paragraphs.append([_el_text("• " + list_match.group(1))])
+            li_elements = _parse_inline(list_match.group(1))
+            paragraphs.append([_el_text("• ")] + li_elements)
             continue
 
-        # 有序列表 → 保留序号
-        ol_match = re.match(r"^\d+\.\s+(.+)$", stripped)
+        # 有序列表 → 提取序号和内容，内联解析
+        ol_match = re.match(r"^(\d+\.)\s+(.+)$", stripped)
         if ol_match:
-            paragraphs.append([_el_text(stripped)])
+            prefix = ol_match.group(1) + " "
+            ol_elements = _parse_inline(ol_match.group(2))
+            paragraphs.append([_el_text(prefix)] + ol_elements)
             continue
 
         # 引用块
@@ -266,20 +274,21 @@ def _parse_inline(text: str) -> _PostParagraph:
     remaining = text
 
     while remaining:
-        # 找最早的标记
+        # 找最早的标记（bold+italic 优先于 bold 和 italic）
+        bold_italic_m = _MD_BOLD_ITALIC_RE.search(remaining)
         bold_m = _MD_BOLD_RE.search(remaining)
         italic_m = _MD_ITALIC_RE.search(remaining)
         code_m = _MD_CODE_RE.search(remaining)
         link_m = _MD_LINK_RE.search(remaining)
 
         candidates = []
+        if bold_italic_m: candidates.append((bold_italic_m.start(), bold_italic_m, "bold_italic"))
         if bold_m: candidates.append((bold_m.start(), bold_m, "bold"))
         if italic_m: candidates.append((italic_m.start(), italic_m, "italic"))
         if code_m: candidates.append((code_m.start(), code_m, "code"))
         if link_m: candidates.append((link_m.start(), link_m, "link"))
 
         if not candidates:
-            # 剩余纯文本
             txt = _unescape_md(remaining)
             if txt:
                 elements.append(_el_text(txt))
@@ -294,7 +303,10 @@ def _parse_inline(text: str) -> _PostParagraph:
             if prefix:
                 elements.append(_el_text(prefix))
 
-        if first_type == "bold":
+        if first_type == "bold_italic":
+            elements.append(_el_text(first_match.group(1), ["bold", "italic"]))
+            remaining = remaining[first_match.end():]
+        elif first_type == "bold":
             elements.append(_el_text(first_match.group(1), ["bold"]))
             remaining = remaining[first_match.end():]
         elif first_type == "italic":
@@ -514,7 +526,26 @@ def _extract_text(content_json: str) -> str:
     return text.strip()
 
 
+def _process_in_thread(sender_open_id: str, message_id: str, text: str) -> None:
+    """Phase 2: 在后台线程中执行 LLM 推理 + 回复。"""
+    sess, lock = _get_session(sender_open_id)
+    if not lock.acquire(blocking=False):
+        _reply_text(message_id, "⏳ 上一条消息还在处理中，请稍候…")
+        return
+    try:
+        reply = _capture_turn(sess, text)
+    except Exception as e:
+        print(f"[feishu] 处理出错：{e}")
+        _reply_text(message_id, f"❌ 出错了：{e}")
+        return
+    finally:
+        lock.release()
+
+    _reply_text(message_id, reply)
+
+
 def _handle_message(data: P2ImMessageReceiveV1) -> None:
+    """Phase 1: 轻量同步工作（event loop 线程），立即返回让 ack 快速发出。"""
     try:
         ev = data.event
         msg = ev.message
@@ -524,14 +555,13 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         message_id = msg.message_id
         msg_type = msg.message_type
         chat_id = msg.chat_id
-        chat_type = msg.chat_type  # "p2p" 或 "group"
+        chat_type = msg.chat_type
 
         # ── 去重：飞书可能因 ack 超时重发同一事件 ──────────────────────
         if _is_duplicate(message_id):
             print(f"[feishu] 跳过重复消息 message_id={message_id}")
             return
 
-        # 只处理文本（其他类型先忽略）
         if msg_type != "text":
             _reply_text(message_id, f"(暂不支持的消息类型: {msg_type}，目前只接收文本)")
             return
@@ -540,45 +570,31 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         if not text:
             return
 
-        print(f"[feishu] 收到消息 from open_id={sender_open_id[:12]}… chat_type={chat_type} text={text[:60]!r}")
+        print(f"[feishu] 收到消息 from open_id={sender_open_id[:12]}… "
+              f"chat_type={chat_type} text={text[:60]!r}")
 
-        # whoami 调试模式：直接回 open_id
         if WHOAMI_MODE:
             _reply_text(
                 message_id,
-                f"你的 open_id 是:\n{sender_open_id}\n\n请把它加入 config.json 的 feishu_allowed_open_ids 后重启 bot。",
+                f"你的 open_id 是:\n{sender_open_id}\n\n"
+                f"请把它加入 config.json 的 feishu_allowed_open_ids 后重启 bot。",
             )
             return
 
-        # 白名单
         if ALLOWED_OPEN_IDS and sender_open_id not in ALLOWED_OPEN_IDS:
-            print(f"[feishu] ⚠ 未授权 open_id：{sender_open_id}（请加入 feishu_allowed_open_ids）")
-            _reply_text(
-                message_id,
-                "⚠️ 你不在该机器人的允许列表中。\n"
-                f"如果是你本人请把这个 open_id 加入 config.json 的 feishu_allowed_open_ids:\n{sender_open_id}",
-            )
+            print(f"[feishu] ⚠ 未授权 open_id：{sender_open_id}")
+            _reply_text(message_id, "⚠️ 你不在该机器人的允许列表中。\n"
+                        f"请把这个 open_id 加入 config.json 的 feishu_allowed_open_ids:\n"
+                        f"{sender_open_id}")
             return
 
         if not ALLOWED_OPEN_IDS:
-            print(
-                f"[feishu] ℹ 白名单为空，已允许所有人；建议把此 open_id 加入白名单：{sender_open_id}"
-            )
+            print(f"[feishu] ℹ 白名单为空，已允许所有人；建议把此 open_id 加入白名单："
+                  f"{sender_open_id}")
 
-        sess, lock = _get_session(sender_open_id)
-        if not lock.acquire(blocking=False):
-            _reply_text(message_id, "⏳ 上一条消息还在处理中，请稍候…")
-            return
-        try:
-            reply = _capture_turn(sess, text)
-        except Exception as e:
-            print(f"[feishu] 处理出错：{e}")
-            _reply_text(message_id, f"❌ 出错了：{e}")
-            return
-        finally:
-            lock.release()
+        # ── 提交到后台线程，立即返回 ──
+        _EXECUTOR.submit(_process_in_thread, sender_open_id, message_id, text)
 
-        _reply_text(message_id, reply)
     except Exception as e:
         print(f"[feishu] handler 异常：{e}")
 

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -55,7 +55,7 @@ APP_SECRET = cfg.get("feishu_app_secret", "").strip()
 ALLOWED_OPEN_IDS: set[str] = set(cfg.get("feishu_allowed_open_ids", []) or [])
 
 if not APP_ID or not APP_SECRET:
-    print("❌ config.json 中未设置 feishu_app_id / feishu_app_secret，请先在 WebUI 或 setup 中配置")
+    print("[X] config.json 中未设置 feishu_app_id / feishu_app_secret，请先在 WebUI 或 setup 中配置")
     sys.exit(1)
 
 
@@ -587,14 +587,14 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
             return
 
         if ALLOWED_OPEN_IDS and sender_open_id not in ALLOWED_OPEN_IDS:
-            print(f"[feishu] ⚠ 未授权 open_id：{sender_open_id}")
-            _reply_text(message_id, "⚠️ 你不在该机器人的允许列表中。\n"
+            print(f"[feishu] [!] 未授权 open_id：{sender_open_id}")
+            _reply_text(message_id, "你不在该机器人的允许列表中。\n"
                         f"请把这个 open_id 加入 config.json 的 feishu_allowed_open_ids:\n"
                         f"{sender_open_id}")
             return
 
         if not ALLOWED_OPEN_IDS:
-            print(f"[feishu] ℹ 白名单为空，已允许所有人；建议把此 open_id 加入白名单："
+            print(f"[feishu] [i] 白名单为空，已允许所有人；建议把此 open_id 加入白名单："
                   f"{sender_open_id}")
 
         # ── 提交到后台线程，立即返回 ──
@@ -634,22 +634,22 @@ def main() -> None:
         try:
             tenant_token = _api_client._config.token_manager.get_tenant_access_token()  # type: ignore
             if tenant_token:
-                print(f"✅ 凭据 OK，tenant_access_token 已获取（前 8 位）：{tenant_token[:8]}…")
+                print(f"[OK] 凭据 OK，tenant_access_token 已获取（前 8 位）：{tenant_token[:8]}…")
                 sys.exit(0)
-            print("❌ 未能获取 tenant_access_token，请检查 App ID / App Secret")
+            print("[X] 未能获取 tenant_access_token，请检查 App ID / App Secret")
             sys.exit(1)
         except Exception as e:
-            print(f"❌ 凭据校验失败：{e}")
+            print(f"[X] 凭据校验失败：{e}")
             sys.exit(1)
 
     WHOAMI_MODE = args.whoami
     if WHOAMI_MODE:
-        print("⚙️  WHOAMI 模式：bot 会把每个发送者的 open_id 原样回显，不调 agent")
+        print("[whoami] WHOAMI 模式：bot 会把每个发送者的 open_id 原样回显，不调 agent")
 
     client = _build_ws_client()
-    print(f"✅ 飞书 bot 已启动（App ID: {APP_ID[:10]}…），等待消息…")
+    print(f"[OK] 飞书 bot 已启动（App ID: {APP_ID[:10]}…），等待消息…")
     if not ALLOWED_OPEN_IDS:
-        print("ℹ️  feishu_allowed_open_ids 为空，所有人均可对话。建议加白名单后重启。")
+        print("[i] feishu_allowed_open_ids 为空，所有人均可对话。建议加白名单后重启。")
     client.start()  # 阻塞，内部 WS 自动重连
 
 

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -570,6 +570,11 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         if not text:
             return
 
+        # 过滤"清空聊天记录"/撤回消息产生的系统通知
+        if text in {"此消息已删除", "该消息已被撤回"}:
+            print(f"[feishu] 跳过已删除/撤回的系统消息 message_id={message_id}")
+            return
+
         print(f"[feishu] 收到消息 from open_id={sender_open_id[:12]}… "
               f"chat_type={chat_type} text={text[:60]!r}")
 

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -309,6 +309,7 @@ def _cmd_install_daemons(args: argparse.Namespace) -> int:
             daily_report_time=args.daily_report_time,
             remind_interval=args.remind_interval,
             load=not args.write_only,
+            backend=getattr(args, "backend", "taskschd"),
             **platform_kwargs,
         )
     except (RuntimeError, ValueError) as exc:
@@ -418,6 +419,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=10,
         help="(macOS) launchd throttle interval for telegram bot restarts, default 10",
+    )
+    install_daemons_parser.add_argument(
+        "--backend",
+        choices=["taskschd", "psmux"],
+        default="taskschd",
+        help="(Windows) 后端选择：taskschd（任务计划程序，默认）或 psmux（分离会话）",
     )
     install_daemons_parser.set_defaults(func=_cmd_install_daemons)
 

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -25,18 +25,20 @@ def install_daemons(
     remind_interval: int = 60,
     telegram_throttle: int = 10,
     load: bool = True,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
     安装后台守护进程。
 
     参数：
-        service_names       要安装的服务子集，默认全部（daily-report / remind-check / telegram-bot）
+        service_names       要安装的服务子集，默认全部
         python_executable   使用的 Python 解释器路径，默认当前解释器
         daily_report_time   日报发送时间 (hour, minute)，默认 (22, 0)
         remind_interval     提醒检查间隔秒数（macOS/Linux 适用），默认 60
         telegram_throttle   Telegram bot 重启节流秒数（macOS 适用），默认 10
         load                是否立即加载/启动服务，默认 True
+        backend             Windows 后端选择：taskschd（默认）或 psmux
         **platform_kwargs   各平台专属参数（如 macOS 的 output_dir）
 
     返回包含安装结果的字典。
@@ -44,7 +46,10 @@ def install_daemons(
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import install as _install
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import install as _install
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import install as _install
+        else:
+            from sjtu_agent.scheduler.taskschd import install as _install
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import install as _install
     else:
@@ -66,6 +71,7 @@ def install_daemons(
 
 def uninstall_daemons(
     service_names: tuple[str, ...] | None = None,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
@@ -73,11 +79,15 @@ def uninstall_daemons(
 
     参数：
         service_names  要卸载的服务子集，默认全部
+        backend        Windows 后端选择：taskschd（默认）或 psmux
     """
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import uninstall as _uninstall
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import uninstall as _uninstall
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import uninstall as _uninstall
+        else:
+            from sjtu_agent.scheduler.taskschd import uninstall as _uninstall
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import uninstall as _uninstall
     else:
@@ -88,17 +98,24 @@ def uninstall_daemons(
 
 def daemon_status(
     service_names: tuple[str, ...] | None = None,
+    backend: str = "taskschd",
     **platform_kwargs,
 ) -> dict:
     """
     查询后台守护进程状态。
 
+    参数：
+        service_names  要查询的服务子集，默认全部
+        backend        Windows 后端选择：taskschd（默认）或 psmux
     返回包含各服务状态的字典。
     """
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import status as _status
     elif sys.platform == "win32":
-        from sjtu_agent.scheduler.taskschd import status as _status
+        if backend == "psmux":
+            from sjtu_agent.scheduler.psmuxd import status as _status
+        else:
+            from sjtu_agent.scheduler.taskschd import status as _status
     elif sys.platform.startswith("linux"):
         from sjtu_agent.scheduler.systemd import status as _status
     else:

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -134,7 +134,7 @@ def current_platform_name() -> str:
     if sys.platform == "darwin":
         return "macOS (launchd)"
     elif sys.platform == "win32":
-        return "Windows (Task Scheduler)"
+        return "Windows (psmux / Task Scheduler)"
     elif sys.platform.startswith("linux"):
         return "Linux (systemd)"
     else:

--- a/sjtu_agent/scheduler/psmuxd.py
+++ b/sjtu_agent/scheduler/psmuxd.py
@@ -1,0 +1,180 @@
+"""
+sjtu_agent/scheduler/psmuxd.py — Windows psmux 后端实现
+
+使用 psmux (tmux on Windows) 的分离会话管理后台服务。
+psmux 会话在 psmux 服务端进程存活期间保持运行，适合常驻进程管理。
+命名空间统一为 sjtu-agent（-L sjtu-agent），避免与用户的日常 psmux 会话混淆。
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from sjtu_agent.paths import DATA_DIR, LOG_DIR
+
+_NAMESPACE = "sjtu-agent"
+
+_SERVICE_SPECS = {
+    "daily-report": {
+        "session_name": "daily-report",
+        "subcommand": "daily-report",
+    },
+    "remind-check": {
+        "session_name": "remind-check",
+        "subcommand": "remind-check",
+    },
+    "telegram-bot": {
+        "session_name": "telegram-bot",
+        "subcommand": "telegram-bot",
+    },
+    "wechat-bot": {
+        "session_name": "wechat-bot",
+        "subcommand": "wechat-bot",
+    },
+    "feishu-bot": {
+        "session_name": "feishu-bot",
+        "subcommand": "feishu-bot",
+    },
+    "web": {
+        "session_name": "web",
+        "subcommand": "web --no-browser",
+    },
+}
+
+
+def _find_psmux() -> str | None:
+    return shutil.which("psmux")
+
+
+def _run_psmux(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [_find_psmux(), "-L", _NAMESPACE, *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def install(
+    service_names: tuple[str, ...] | None = None,
+    python_executable: Path | None = None,
+    daily_report_time: tuple[int, int] = (22, 0),
+    remind_interval: int = 60,
+    load: bool = True,
+    **_,
+) -> dict:
+    """启动 psmux 分离会话来运行后台服务。"""
+    if not _find_psmux():
+        raise RuntimeError("未找到 psmux，请先安装：winget install psmux")
+
+    py = str(python_executable or Path(sys.executable))
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        subcommand = spec["subcommand"]
+        log_path = LOG_DIR / f"{name}.psmux.log"
+
+        # 如果会话已存在，先 kill 再重建
+        if not load:
+            continue
+
+        # 尝试 kill 已有会话（忽略失败）
+        subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "kill-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+
+        # 启动新会话：psmux -L sjtu-agent new -s <name> -d -- python -m sjtu_agent <sub>
+        result = subprocess.run(
+            [
+                _find_psmux(), "-L", _NAMESPACE,
+                "new-session", "-s", session, "-d",
+                "--", py, "-m", "sjtu_agent", subcommand,
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        success = result.returncode == 0
+        results.append({
+            "name": name,
+            "session_name": session,
+            "log_path": str(log_path),
+            "success": success,
+            "error": result.stderr.strip() if not success else "",
+        })
+
+    return {
+        "platform": "Windows (psmux)",
+        "namespace": _NAMESPACE,
+        "python_executable": py,
+        "services": results,
+    }
+
+
+def uninstall(
+    service_names: tuple[str, ...] | None = None,
+    **_,
+) -> dict:
+    """终止 psmux 会话（停止后台服务）。"""
+    if not _find_psmux():
+        return {"platform": "Windows (psmux)", "removed": []}
+
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    removed: list[dict] = []
+
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        result = subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "kill-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+        removed.append({
+            "name": name,
+            "session_name": session,
+            "success": result.returncode == 0,
+        })
+
+    return {"platform": "Windows (psmux)", "removed": removed}
+
+
+def status(
+    service_names: tuple[str, ...] | None = None,
+    **_,
+) -> dict:
+    """检查 psmux 会话是否存在（即服务是否运行中）。"""
+    if not _find_psmux():
+        return {"platform": "Windows (psmux)", "services": [], "all_installed": False}
+
+    selected = set(service_names or _SERVICE_SPECS.keys())
+    services: list[dict] = []
+
+    for name, spec in _SERVICE_SPECS.items():
+        if name not in selected:
+            continue
+
+        session = spec["session_name"]
+        result = subprocess.run(
+            [_find_psmux(), "-L", _NAMESPACE, "has-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+        running = result.returncode == 0
+        services.append({
+            "name": name,
+            "session_name": session,
+            "running": running,
+        })
+
+    return {
+        "platform": "Windows (psmux)",
+        "services": services,
+        "all_running": bool(services) and all(s["running"] for s in services),
+    }


### PR DESCRIPTION
Add a troubleshooting guide for common Feishu bot issues encountered during development and deployment.

## Content
- Credential validation (App ID/Secret)
- Bot process health checks (psmux / Task Scheduler)
- Windows GBK terminal emoji crash (`UnicodeEncodeError`)
- Double-JSON-encoded whitelist (`feishu_allowed_open_ids`)
- Event subscription and permission checks
- Quick diagnostic commands

## Files
- `docs/feishu-bot-troubleshooting.md` (new)