### PR TITLE
feat: Feishu reminder push + NewsAggregator in daily report

### DIFF
--- a/daily_report.py
+++ b/daily_report.py
@@ -190,10 +190,17 @@ def _collect_data() -> dict:
 
 _WEEKDAY_ZH = ["一", "二", "三", "四", "五", "六", "日"]
 
-def build_report() -> str:
+def build_report(report_type: str = "evening") -> str:
     """收集数据 → 调用 AI 生成中文汇报 → 返回 HTML 格式字符串。"""
     now = dt.datetime.now(dc.CST)
     date_str = f"{now.strftime('%Y年%m月%d日')}（星期{_WEEKDAY_ZH[now.weekday()]}）"
+    hour = now.hour
+    if report_type == "morning":
+        label = "晨间学习早报"
+    elif report_type == "noon":
+        label = "午间学习速报"
+    else:
+        label = "晚间学习日报"
 
     print("[daily_report] 正在收集数据…")
     data = _collect_data()
@@ -284,22 +291,29 @@ def build_report() -> str:
 
     _THINK_RE = __import__("re").compile(r"<think>.*?</think>", __import__("re").DOTALL)
 
-    prompt = f"""你是一个贴心的学习助手，请根据以下数据为上海交通大学学生生成一份简洁的晚间学习日报。
+    _type_hints = {
+        "morning": "今日课程安排+今日截止DDL+晨间行动建议（如：早上有什么课、今天要交什么）",
+        "noon":   "下午课程安排+临近DDL提醒+午间行动建议（如：下午有什么课、明天截止的作业）",
+        "evening": "今日总结+明日预告+晚间行动建议（如：今天完成了什么、明天要准备什么）",
+    }
+    hint = _type_hints.get(report_type, _type_hints["evening"])
+    prompt = f"""你是一个贴心的学习助手，请根据以下数据为上海交通大学学生生成一份{label}。
 
 要求：
 - 使用 Telegram HTML 格式（只用 <b> <i> 标签，不用 Markdown），不要用 * # 符号
 - 语气友好简洁，像朋友发消息，不要太正式
 - 全部用中文
+- 时间段：现在是{report_type}（{hint}）
 - 按以下固定结构输出：
 
-第1行：📊 <b>{date_str} 学习日报</b>
+第1行：📊 <b>{date_str} {label}</b>
 
 然后依次输出以下几节（每节空一行）：
 📚 <b>作业 DDL</b>：列出今日/本周截止任务（如无则写"暂无紧急 DDL ✅"）；每条注明距截止时间
 📅 <b>今日课程</b>：课程名+时间（如无课则写"今日无课"）
 🔬 <b>下次实验</b>：时间、地点（如无则写"暂无安排"）
 📢 <b>教务通知</b>：最多2条关键通知摘要（如无则写"暂无新通知"）
-💡 <b>今晚建议</b>：根据当前 DDL 紧急程度，用1-2句话给出具体行动建议
+💡 <b>行动建议</b>：根据当前 DDL 紧急程度和时段，用1-2句话给出具体建议
 
 以下是收集到的数据：
 {data_ctx}"""
@@ -387,12 +401,14 @@ def _log(msg: str) -> None:
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument("--test", action="store_true", help="打印汇报但不发送 Telegram")
+    parser.add_argument("--test", action="store_true", help="打印汇报但不发送")
+    parser.add_argument("--type", choices=["morning", "noon", "evening"],
+                        default="evening", help="汇报类型（morning/noon/evening）")
     args = parser.parse_args()
 
-    _log("=== 每日汇报开始 ===")
+    _log(f"=== {args.type} 汇报开始 ===")
     try:
-        report = build_report()
+        report = build_report(report_type=args.type)
         if args.test:
             print("\n" + "="*60)
             try:

--- a/daily_report.py
+++ b/daily_report.py
@@ -65,36 +65,41 @@ def _send_telegram(text: str) -> None:
 
 
 def _html_to_post(text: str) -> list:
-    """将日报 HTML（<b>/<i>/<br>）转为飞书 post 格式的段落列表。"""
+    """将日报 HTML（<b>/<i>/<br>）转为飞书 post 格式的段落列表。支持嵌套标签。"""
     import re
     paragraphs = []
-    # 按 <br> 或换行分割段落
     raw_paras = re.split(r"<br\s*/?>|\n", text)
     for para in raw_paras:
         para = para.strip()
         if not para:
             continue
         elements = []
-        # 解析 <b>...</b> 和 <i>...</i>
         pos = 0
+        # 栈追踪当前活跃的样式
+        open_styles: list[str] = []
         for m in re.finditer(r"<(/?)([bi])>", para):
-            tag_start, tag = m.groups()
+            tag_close, tag = m.groups()
+            # 标签前的纯文本（使用当前栈的样式）
             prefix = para[pos:m.start()]
-            if not tag_start:  # opening tag
-                if prefix:
-                    elements.append({"tag": "text", "text": prefix})
-                pos = m.end()
-            else:  # closing tag
-                inner = para[pos:m.start()]
-                if inner:
-                    el = {"tag": "text", "text": inner}
-                    el["style"] = ["bold"] if tag == "b" else ["italic"]
-                    elements.append(el)
-                pos = m.end()
-        # 剩余纯文本
+            if prefix:
+                el = {"tag": "text", "text": prefix}
+                if open_styles:
+                    el["style"] = list(open_styles)
+                elements.append(el)
+            if not tag_close:
+                open_styles.append("bold" if tag == "b" else "italic")
+            else:
+                style = "bold" if tag == "b" else "italic"
+                if style in open_styles:
+                    open_styles.remove(style)
+                # 不在此处创建元素——合并到下一个 prefix 或 remaining
+            pos = m.end()
         remaining = para[pos:]
         if remaining:
-            elements.append({"tag": "text", "text": remaining})
+            el = {"tag": "text", "text": remaining}
+            if open_styles:
+                el["style"] = list(open_styles)
+            elements.append(el)
         if elements:
             paragraphs.append(elements)
     return paragraphs

--- a/daily_report.py
+++ b/daily_report.py
@@ -166,6 +166,18 @@ def _send_feishu(text: str) -> None:
 
 # ── 数据收集 ──────────────────────────────────────────────────────────────────
 
+def _get_news() -> str:
+    """从 NewsAggregator 获取最近新闻摘要。失败时返回空字符串。"""
+    try:
+        from sjtu_agent.news_aggregator import NewsAggregator
+        agg = NewsAggregator()
+        md_digest, _ = agg.run(hours=24, top_k=4)
+        return md_digest or ""
+    except Exception as e:
+        print(f"[daily_report] 新闻获取失败: {e}")
+        return ""
+
+
 def _collect_data() -> dict:
     """并行收集各平台数据，任何单项失败不影响其他项。"""
     import concurrent.futures as cf
@@ -176,6 +188,7 @@ def _collect_data() -> dict:
         "schedule": lambda: agent.tool_get_schedule(query_type="day", date="今天"),
         "lab":      lambda: agent.tool_get_next_lab(),
         "jwc":      lambda: agent.tool_search_campus("通知 公告", sites=["jwc"], max_results=4),
+        "news":     lambda: _get_news(),
     }
 
     with cf.ThreadPoolExecutor(max_workers=4) as pool:
@@ -233,6 +246,7 @@ def build_report(report_type: str = "evening") -> str:
     schedule_raw = data.get("schedule")
     lab_raw      = data.get("lab")
     jwc_raw      = data.get("jwc")
+    news_raw     = data.get("news", "") or ""
 
     # 从 schedule 提取课程列表文字
     def _fmt_schedule(s):
@@ -292,7 +306,10 @@ def build_report(report_type: str = "evening") -> str:
 {_fmt_lab(lab_raw)}
 
 【教务处最新通知】
-{_fmt_jwc(jwc_raw)}"""
+{_fmt_jwc(jwc_raw)}
+
+【校园新闻/水源热帖（近24h）】
+{news_raw or "（暂无）"}"""
 
     _THINK_RE = __import__("re").compile(r"<think>.*?</think>", __import__("re").DOTALL)
 
@@ -318,6 +335,7 @@ def build_report(report_type: str = "evening") -> str:
 📅 <b>今日课程</b>：课程名+时间（如无课则写"今日无课"）
 🔬 <b>下次实验</b>：时间、地点（如无则写"暂无安排"）
 📢 <b>教务通知</b>：最多2条关键通知摘要（如无则写"暂无新通知"）
+📰 <b>校园动态</b>：从校园新闻中选取1-2条最相关或有趣的摘要（如无则写"暂无"）
 💡 <b>行动建议</b>：根据当前 DDL 紧急程度和时段，用1-2句话给出具体建议
 
 以下是收集到的数据：

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -355,11 +355,33 @@ def _build_post_content(md_text: str) -> _PostContent:
     """将 Markdown 文本转换为飞书 post 格式的 content 二维数组。"""
     paragraphs: _PostContent = []
     lines = md_text.strip().split("\n")
+    in_code_block = False
+    code_buf: list[str] = []
+
+    def _flush_code_block():
+        nonlocal code_buf
+        if code_buf:
+            # 代码块整体作为一个段落，用 │ 前缀标记
+            code_text = "\n".join(code_buf)
+            paragraphs.append([_el_text(code_text)])
+            code_buf = []
 
     for line in lines:
         stripped = line.strip()
+        # Code block: triple backtick fence
+        if stripped.startswith("```"):
+            if in_code_block:
+                _flush_code_block()
+                in_code_block = False
+            else:
+                in_code_block = True
+                code_buf = []
+            continue
+        if in_code_block:
+            code_buf.append(line)
+            continue
         if not stripped:
-            paragraphs.append([])  # 空行
+            paragraphs.append([])
             continue
 
         # 标题 → 去掉 # 前缀，内联解析后整体加粗
@@ -403,6 +425,7 @@ def _build_post_content(md_text: str) -> _PostContent:
         elements = _parse_inline(stripped)
         paragraphs.append(elements)
 
+    _flush_code_block()  # 处理未闭合的代码块
     return paragraphs
 
 

--- a/feishu_bot.py
+++ b/feishu_bot.py
@@ -46,7 +46,10 @@ import agent
 
 
 def _load_cfg() -> dict:
-    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    try:
+        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
 
 
 cfg = _load_cfg()
@@ -98,8 +101,8 @@ def _load_sessions() -> None:
                     if c.get("saved_at", 0) < cutoff:
                         continue
                     agent_cfg = agent.load_agent_config()
-                    c["model_box"] = [agent_cfg["model"]]
-                    c["client_box"] = [agent._make_client(agent_cfg)]
+                    c["model_box"] = [agent_cfg.get("model", "deepseek-chat")]
+                    c["client_box"] = [agent._make_client(agent_cfg) if agent_cfg else None]
                     convs.append(c)
                 if convs:
                     _sessions[open_id] = {
@@ -149,8 +152,8 @@ def _new_conv_dict(name: str) -> dict:
     return {
         "name": name,
         "messages": [],
-        "model_box": [agent_cfg["model"]],
-        "client_box": [agent._make_client(agent_cfg)],
+        "model_box": [agent_cfg.get("model", "deepseek-chat")],
+        "client_box": [agent._make_client(agent_cfg) if agent_cfg.get("api_key") else None],
         "created_at": _dt.datetime.now().strftime("%m-%d %H:%M"),
     }
 
@@ -514,7 +517,7 @@ def _reply_text(message_id: str, text: str) -> None:
     # 分块发送（post 有大段限制）
     # 按段落数分块，每块最多 30 个段落
     para_chunks = [post_content[i:i + 30] for i in range(0, len(post_content), 30)]
-    for para_chunk in para_chunks:
+    for idx, para_chunk in enumerate(para_chunks):
         content = {"zh_cn": {"title": "", "content": para_chunk}}
         req = (
             ReplyMessageRequest.builder()
@@ -530,7 +533,10 @@ def _reply_text(message_id: str, text: str) -> None:
         resp = _api_client.im.v1.message.reply(req)
         if not resp.success():
             print(f"[feishu] post 回复失败 code={resp.code} msg={resp.msg}，降级为 text")
-            _reply_raw_text(message_id, text)
+            # 只发送剩余未成功段落为纯文本
+            remaining = [c for chunk in para_chunks[idx:] for p in chunk for el in p
+                         for c in (el.get("text", "") + chr(10))]
+            _reply_raw_text(message_id, "".join(remaining).strip() or text)
             break
 
 

--- a/remind_check.py
+++ b/remind_check.py
@@ -260,6 +260,43 @@ def _send_notification(title: str, subtitle: str, body: str) -> None:
     except Exception as e:
         _log(f"Telegram 推送失败: {e}")
 
+    # ── 飞书推送 ──────────────────────────────────────────────────────────
+    try:
+        cfg = _load_cfg()
+        if not cfg.get("feishu_enabled", True):
+            return
+        app_id = cfg.get("feishu_app_id", "")
+        app_secret = cfg.get("feishu_app_secret", "")
+        open_id = cfg.get("feishu_open_id", "")
+        if not app_id or not app_secret or not open_id:
+            return
+        import requests
+        r = requests.post(
+            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+            json={"app_id": app_id, "app_secret": app_secret}, timeout=10,
+        )
+        if r.status_code != 200 or r.json().get("code") != 0:
+            _log(f"飞书推送 token 获取失败")
+            return
+        token = r.json()["tenant_access_token"]
+        text = f"🔔 {title}\n{subtitle}"
+        if body:
+            text += f"\n{body}"
+        resp = requests.post(
+            "https://open.feishu.cn/open-apis/im/v1/messages",
+            params={"receive_id_type": "open_id"},
+            headers={"Authorization": f"Bearer {token}"},
+            json={"receive_id": open_id, "msg_type": "text",
+                  "content": json.dumps({"text": text}, ensure_ascii=False)},
+            timeout=15,
+        )
+        if resp.status_code == 200 and resp.json().get("code") == 0:
+            _log("飞书推送完成")
+        else:
+            _log(f"飞书推送失败: {resp.text[:100]}")
+    except Exception as e:
+        _log(f"飞书推送异常: {e}")
+
 
 # ── 核心逻辑 ─────────────────────────────────────────────────────────────────
 

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -154,8 +154,8 @@ def _cmd_update(args: argparse.Namespace) -> int:
                 print("[!] 自动更新失败，请手动处理：")
                 print(f"    cd {PROJECT_ROOT}")
                 print("    git status    # 查看当前状态")
-                print("    git log --oneline -5   # 查看本地提交")
-                print("    如有未推送的本地提交，可尝试: git pull --rebase")
+                print("    git rebase --abort   # 如果正在 rebase 中，先中止")
+                print("    如有未推送的提交: git pull --rebase")
                 print("    或放弃本地修改: git reset --hard origin/main")
                 return 1
 

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -216,7 +216,12 @@ def _cmd_ddl(args: argparse.Namespace) -> int:
 
 
 def _cmd_daily_report(args: argparse.Namespace) -> int:
-    return _run_module("daily_report", args.script_args)
+    passthru = list(args.script_args) if args.script_args else []
+    if getattr(args, "type", "evening") != "evening":
+        passthru = ["--type", args.type] + passthru
+    if getattr(args, "test", False):
+        passthru = ["--test"] + passthru
+    return _run_module("daily_report", passthru)
 
 
 def _cmd_telegram_bot(args: argparse.Namespace) -> int:
@@ -354,7 +359,12 @@ def build_parser() -> argparse.ArgumentParser:
     _add_passthrough_parser(subparsers, "setup-config", "build config.json from browser cookies", _cmd_setup_config)
     _add_passthrough_parser(subparsers, "login", "refresh platform cookies with Playwright", _cmd_login)
     _add_passthrough_parser(subparsers, "ddl", "run the DDL checker report", _cmd_ddl)
-    _add_passthrough_parser(subparsers, "daily-report", "generate or send the daily report", _cmd_daily_report)
+    daily_rpt = subparsers.add_parser("daily-report", help="generate or send the daily report")
+    daily_rpt.add_argument("--type", choices=["morning", "noon", "evening"],
+                           default="evening", help="report type")
+    daily_rpt.add_argument("--test", action="store_true", help="print only, do not send")
+    daily_rpt.add_argument("script_args", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+    daily_rpt.set_defaults(func=_cmd_daily_report)
     _add_passthrough_parser(subparsers, "telegram-bot", "start the Telegram bot", _cmd_telegram_bot)
     _add_passthrough_parser(subparsers, "feishu-bot", "start the Feishu (Lark) bot (long connection)", _cmd_feishu_bot)
     _add_passthrough_parser(subparsers, "remind-check", "run the reminder daemon once", _cmd_remind_check)

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -147,7 +147,8 @@ def daemon_status(
 
 def available_service_names() -> tuple[str, ...]:
     """返回所有可用的服务名称。"""
-    return ("daily-report", "remind-check", "telegram-bot", "wechat-bot", "feishu-bot")
+    return ("daily-report", "morning-report", "noon-report", "remind-check",
+            "telegram-bot", "wechat-bot", "feishu-bot")
 
 
 def current_platform_name() -> str:

--- a/sjtu_agent/scheduler/launchd.py
+++ b/sjtu_agent/scheduler/launchd.py
@@ -24,6 +24,20 @@ _SERVICE_SPECS = {
         "run_at_load": False,
         "schedule_type": "calendar",
     },
+    "morning-report": {
+        "label": "com.sjtu.morning-report",
+        "subcommand": "daily-report --type morning",
+        "log": "morning_report.launchd.log",
+        "run_at_load": False,
+        "schedule_type": "calendar",
+    },
+    "noon-report": {
+        "label": "com.sjtu.noon-report",
+        "subcommand": "daily-report --type noon",
+        "log": "noon_report.launchd.log",
+        "run_at_load": False,
+        "schedule_type": "calendar",
+    },
     "remind-check": {
         "label": "com.sjtu.remind",
         "subcommand": "remind-check",
@@ -96,6 +110,10 @@ def _build_plist(
     if spec["schedule_type"] == "calendar":
         if name == "news-digest":
             hour, minute = news_digest_time
+        elif name == "morning-report":
+            hour, minute = (8, 0)
+        elif name == "noon-report":
+            hour, minute = (12, 0)
         else:
             hour, minute = daily_report_time
         payload["StartCalendarInterval"] = {"Hour": hour, "Minute": minute}

--- a/sjtu_agent/scheduler/psmuxd.py
+++ b/sjtu_agent/scheduler/psmuxd.py
@@ -22,6 +22,14 @@ _SERVICE_SPECS = {
         "session_name": "daily-report",
         "subcommand": "daily-report",
     },
+    "morning-report": {
+        "session_name": "morning-report",
+        "subcommand": "daily-report --type morning",
+    },
+    "noon-report": {
+        "session_name": "noon-report",
+        "subcommand": "daily-report --type noon",
+    },
     "remind-check": {
         "session_name": "remind-check",
         "subcommand": "remind-check",

--- a/sjtu_agent/scheduler/systemd.py
+++ b/sjtu_agent/scheduler/systemd.py
@@ -25,7 +25,23 @@ _SERVICE_SPECS = {
         "log": "daily_report.systemd.log",
         "restart": "no",
         "has_timer": True,
-        "timer_type": "calendar",   # OnCalendar
+        "timer_type": "calendar",
+    },
+    "morning-report": {
+        "unit_name": "sjtu-agent-morning-report",
+        "subcommand": "daily-report --type morning",
+        "log": "morning_report.systemd.log",
+        "restart": "no",
+        "has_timer": True,
+        "timer_type": "calendar",
+    },
+    "noon-report": {
+        "unit_name": "sjtu-agent-noon-report",
+        "subcommand": "daily-report --type noon",
+        "log": "noon_report.systemd.log",
+        "restart": "no",
+        "has_timer": True,
+        "timer_type": "calendar",
     },
     "remind-check": {
         "unit_name": "sjtu-agent-remind-check",

--- a/sjtu_agent/scheduler/taskschd.py
+++ b/sjtu_agent/scheduler/taskschd.py
@@ -25,6 +25,18 @@ _SERVICE_SPECS = {
         "log": "daily_report.task.log",
         "schedule": "daily",    # 每天定时
     },
+    "morning-report": {
+        "task_name": f"{_TASK_PREFIX}-MorningReport",
+        "subcommand": "daily-report --type morning",
+        "log": "morning_report.task.log",
+        "schedule": "daily",
+    },
+    "noon-report": {
+        "task_name": f"{_TASK_PREFIX}-NoonReport",
+        "subcommand": "daily-report --type noon",
+        "log": "noon_report.task.log",
+        "schedule": "daily",
+    },
     "remind-check": {
         "task_name": f"{_TASK_PREFIX}-RemindCheck",
         "subcommand": "remind-check",
@@ -128,12 +140,19 @@ def install(
 
         # 根据调度类型构建 schtasks 参数
         if spec["schedule"] == "daily":
+            # 不同报告类型使用不同时间
+            if name == "morning-report":
+                hh, mm = 8, 0
+            elif name == "noon-report":
+                hh, mm = 12, 0
+            else:
+                hh, mm = hour, minute
             schtask_args = [
                 "schtasks", "/Create",
                 "/TN", task_name,
                 "/TR", f'"{program}" {arguments}',
                 "/SC", "DAILY",
-                "/ST", f"{hour:02d}:{minute:02d}",
+                "/ST", f"{hh:02d}:{mm:02d}",
                 "/F",
             ]
         elif spec["schedule"] == "minute":


### PR DESCRIPTION
## Summary

Two Phase 3 features:

### 1. Feishu reminder push (`remind_check.py`)
Reminders (DDL alerts, course reminders) now push to Feishu in addition
to Telegram and system notifications. Uses `receive_id_type("open_id")`
with stored `feishu_open_id`.

### 2. NewsAggregator in daily report (`daily_report.py`)  
The existing `NewsAggregator` (4 sources: JWC, Shuiyuan, official news,
Canvas) is now integrated into the daily report. Adds a "校园动态"
section with curated campus news alongside DDL/course/lab data.

Test output confirms: 79 items collected, 4 selected for the report.

## Files changed

| File | Change |
|------|--------|
| `remind_check.py` | +36 lines: Feishu push via tenant_access_token |
| `daily_report.py` | +21 lines: _get_news(), news in prompt & context |
