### PR TITLE
ci: add pytest workflow for PRs and pushes to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
+      - name: Install test deps
+        run: pip install pytest
+
       - name: Run tests
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary

添加 GitHub Actions CI 工作流，每次 PR 和 push to main 自动运行 pytest。

- Python 3.10 + 3.13 双版本测试矩阵
- 安装 editable 模式 + 运行 pytest
- 后续可扩展：lint、coverage 等

## Test plan

- [x] Workflow 文件语法正确
- 合并后 CI 自动触发