### PR TITLE
feat: homework "解题助手" two-phase mode with AI disclaimers

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -79,6 +79,10 @@ _sessions: dict[str, dict] = {}
 _locks: dict[str, threading.Lock] = {}
 _sess_meta_lock = threading.Lock()
 
+# ── 作业解答上下文（记住最近一次 /hw do，供"给我答案"使用）────────────────
+_hw_context: dict[str, dict] = {}
+_hw_ctx_lock = threading.Lock()
+
 # ── 会话持久化 ──────────────────────────────────────────────────────────────
 from sjtu_agent.paths import DATA_DIR
 _SESSIONS_FILE = DATA_DIR / "feishu_sessions.json"
@@ -190,6 +194,7 @@ _FS_CTX = (
     "## 斜杠命令（用户输入 / 开头即可触发，主动引导使用）\n"
     "遇到以下需求时，主动建议用户使用斜杠命令而非让 LLM 代劳：\n"
     "- 做作业/写作业/作业答案/帮我做XX/解题/帮我看题 → /hw do <序号> 或先 /hw\n"
+    "- 给我答案/核对答案/我要答案 → 获取完整解答（需先运行 /hw do）\n"
     "- 查看作业/有什么作业/列出作业/功课 → /hw 或 /hw list\n"
     "- N天内到期/即将截止/最近作业 → /hw due <N>\n"
     "- 历史作业/已交作业/以前作业 → /hw past\n"
@@ -718,8 +723,28 @@ def _extract_text(content_json: str) -> str:
 
 # ── 多对话命令处理 ──────────────────────────────────────────────────────────
 
+def _do_hw_answer(open_id: str) -> str:
+    """执行 /hw answer 或自然语言触发"给我答案"。"""
+    with _hw_ctx_lock:
+        ctx = _hw_context.get(open_id, {})
+    if not ctx:
+        return "[homework] 请先用 /hw do <序号> 分析作业。"
+    from sjtu_agent.homework_agent import run_homework_check
+    return "[homework] 📝 正在生成完整解答…\n\n" + run_homework_check(
+        specific_idx=ctx["idx"], answer_mode=True)
+
+
 def _handle_commands(open_id: str, text: str) -> str | None:
     """解析并执行对话管理命令。返回命令结果文本（None 表示不是命令）。"""
+    # 自然语言触发"给我答案"
+    answer_phrases = {"给我答案", "给答案", "核对答案", "我要答案", "获取完整解答",
+                      "看答案", "要答案", "上答案", "出答案"}
+    if text.strip() in answer_phrases:
+        with _hw_ctx_lock:
+            ctx = _hw_context.get(open_id, {})
+        if ctx:
+            return _do_hw_answer(open_id)
+        return "[homework] 请先用 /hw do <序号> 分析作业，再要答案哦~"
     if not text.startswith("/"):
         return None
     parts = text.strip().split(maxsplit=2)
@@ -808,6 +833,7 @@ def _handle_commands(open_id: str, text: str) -> str | None:
                 "`/hw brief <序号>`  仅查看摘要\n"
                 "`/hw due <N>`  N 天内到期\n"
                 "`/hw past`  查看历史作业\n"
+                "`/hw answer`  获取完整解答（分析后使用）\n"
                 "`/hw all`  分析全部作业\n"
                 "`/hw list`  列出作业（同 /hw）\n\n"
                 "ℹ️  `/help`  显示此帮助"
@@ -822,7 +848,10 @@ def _handle_commands(open_id: str, text: str) -> str | None:
                     idx = int(parts[2])
                 except ValueError:
                     return f"无效序号：{parts[2]}"
-                return "[homework] 正在解题…\n\n" + run_homework_check(specific_idx=idx)
+                # 记住上下文供"给我答案"使用
+                with _hw_ctx_lock:
+                    _hw_context[open_id] = {"idx": idx}
+                return "[homework] 🧠 解题助手模式…\n\n" + run_homework_check(specific_idx=idx)
             elif sub == "brief":
                 if len(parts) < 3:
                     return "用法：/hw brief <序号>"
@@ -849,6 +878,8 @@ def _handle_commands(open_id: str, text: str) -> str | None:
                 return run_homework_check(due_within_days=days, list_only=True)
             elif sub == "all":
                 return run_homework_check(due_within_days=3650, include_past=True, list_only=True)
+            elif sub == "answer":
+                return _do_hw_answer(open_id)
             else:
                 return run_homework_check(list_only=True)
         return f"未知命令：{cmd}。输入 /help 查看可用命令。"

--- a/sjtu_agent/homework_agent.py
+++ b/sjtu_agent/homework_agent.py
@@ -103,15 +103,31 @@ def _extract_code_blocks(md_text: str) -> list[tuple[str, str]]:
     return blocks
 
 
-def generate_solution_files(title: str, solution: str, output_dir: Path) -> list[str]:
+def generate_solution_files(title: str, solution: str, output_dir: Path,
+                            answer_mode: bool = False) -> list[str]:
     """生成 .md + 提取代码文件。PDF/HTML 由 Claude Code 自行生成。"""
     output_dir.mkdir(parents=True, exist_ok=True)
     saved = [str(output_dir / "_解答.md")]
-    (output_dir / "_解答.md").write_text(solution, encoding="utf-8")
+
+    ai_notice = "> ⚠️ 本文由 AI 辅助生成，仅供学习参考\n\n"
+    md_content = (ai_notice + solution) if answer_mode else solution
+    (output_dir / "_解答.md").write_text(md_content, encoding="utf-8")
+
+    code_notice = {
+        "py": "# AI 辅助生成代码，供学习参考\n\n",
+        "java": "// AI 辅助生成代码，供学习参考\n\n",
+        "cpp": "// AI 辅助生成代码，供学习参考\n\n",
+        "c": "// AI 辅助生成代码，供学习参考\n\n",
+        "js": "// AI 辅助生成代码，供学习参考\n\n",
+        "ts": "// AI 辅助生成代码，供学习参考\n\n",
+        "go": "// AI 辅助生成代码，供学习参考\n\n",
+    }
+
     for i, (lang, code) in enumerate(_extract_code_blocks(solution)):
         ext = lang if lang in ("py", "java", "cpp", "c", "js", "ts", "go") else "txt"
         p = output_dir / f"_code_{i+1}.{ext}"
-        p.write_text(code, encoding="utf-8")
+        notice = code_notice.get(ext, "") if answer_mode else ""
+        p.write_text(notice + code, encoding="utf-8")
         saved.append(str(p))
     return saved
 
@@ -239,8 +255,8 @@ _CLAUDE_BIN = next((p for p in _CLAUDE_CANDIDATES if p and Path(p).exists()), ""
 
 
 def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
-                        brief: bool = False) -> str:
-    """使用本地 Claude Code CLI 解题。不可用时回退到 _call_llm。"""
+                        brief: bool = False, answer_mode: bool = False) -> str:
+    """使用本地 Claude Code CLI 解题。answer_mode=True 输出完整答案。"""
     if not _CLAUDE_BIN or not Path(_CLAUDE_BIN).exists():
         print("[homework] Claude Code 不可用，回退到 API 调用")
         return solve_homework(course, aname, content, brief=brief)
@@ -293,6 +309,21 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
 
     if brief:
         prompt += "\n注意：只要摘要，不要完整解答。"
+    elif answer_mode:
+        prompt += (
+            "\n**完整解答模式**：逐题给出详细推导/代码/结果。"
+            "\n在 _解答.md 第一行写入：> ⚠️ 本文由 AI 辅助生成，仅供学习参考"
+            "\n在 _解答.tex 中加入：\\fancyfoot[C]{AI 辅助生成 · 学习参考}"
+            "\n代码文件中头部注释：# AI 辅助生成代码，供学习参考"
+        )
+    else:
+        prompt += (
+            "\n**解题助手模式（重要）**："
+            "\n- 只输出：题目考点分析 + 解题思路框架 + 关键公式/方法提示"
+            "\n- **不要给完整答案、不写最终结果、不写完整代码**"
+            "\n- 每题末尾留白，暗示用户自己尝试"
+            "\n- 最后一行写：「📝 思考后再核对？回复『给我答案』获取完整解答」"
+        )
 
     try:
         # Windows subprocess 会截断多行参数，改用 stdin 传 prompt
@@ -323,7 +354,8 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
         return solve_homework(course, aname, content, brief=brief)
 
 
-def _download_and_analyze_one(d: dict, idx: int, brief: bool = False) -> str:
+def _download_and_analyze_one(d: dict, idx: int, brief: bool = False,
+                              answer_mode: bool = False) -> str:
     """下载并解答单个作业。brief=True 仅返回摘要。"""
     course = d.get("course", "未知课程")
     aname = d.get("name", "未知作业")
@@ -374,14 +406,14 @@ def _download_and_analyze_one(d: dict, idx: int, brief: bool = False) -> str:
             except Exception: pass
 
     print(f"[homework] 解题: {course} - {aname}")
-    feishu_reply = _claude_code_solve(hw_dir, course, aname, content, brief=brief)
+    feishu_reply = _claude_code_solve(hw_dir, course, aname, content, brief=brief, answer_mode=answer_mode)
 
     # 生成解答文件（从 Claude Code 写入的 _解答.md 读取完整内容）
     solution_path = hw_dir / "_解答.md"
     full_solution = solution_path.read_text(encoding="utf-8") if solution_path.exists() else feishu_reply
     title = f"{course} — {aname}"
     try:
-        files = generate_solution_files(title, full_solution, hw_dir)
+        files = generate_solution_files(title, full_solution, hw_dir, answer_mode=answer_mode)
         print(f"[homework] 已生成 {len(files)} 个文件: {files}")
     except Exception as e:
         print(f"[homework] 文件生成失败: {e}")
@@ -398,10 +430,11 @@ def _download_and_analyze_one(d: dict, idx: int, brief: bool = False) -> str:
         pass
 
     # 飞书回复
+    notice = "\n\n📝 AI 辅助生成，供学习参考" if answer_mode else ""
     return (
         f"[{idx}] {course} — {aname}\n"
         f"截止：{due_str}（{remaining}）\n\n"
-        f"{feishu_reply}{file_info}"
+        f"{feishu_reply}{file_info}{notice}"
     )
 
 
@@ -429,8 +462,8 @@ def _format_list(pending: list[dict], past: bool = False) -> str:
 
 def run_homework_check(due_within_days: int = 0, specific_idx: int | None = None,
                        list_only: bool = False, brief: bool = False,
-                       include_past: bool = False) -> str:
-    """主入口：列出或分析 Canvas 作业。include_past=True 时包含历史作业。"""
+                       include_past: bool = False, answer_mode: bool = False) -> str:
+    """主入口：列出或分析 Canvas 作业。answer_mode=True 输出完整答案。"""
     pending = _fetch_pending(include_past=include_past)
     if due_within_days > 0:
         pending = _filter_by_due(pending, due_within_days)
@@ -448,7 +481,7 @@ def run_homework_check(due_within_days: int = 0, specific_idx: int | None = None
     if specific_idx is not None:
         idx = specific_idx - 1
         if 0 <= idx < len(pending):
-            return _download_and_analyze_one(pending[idx], idx, brief=brief)
+            return _download_and_analyze_one(pending[idx], idx, brief=brief, answer_mode=answer_mode)
         return f"[homework] 无效序号：{specific_idx}，共 {len(pending)} 个（1~{len(pending)}）"
 
     # 默认：列出


### PR DESCRIPTION
## Summary

将 `/hw do` 改为"解题助手"模式，保留学习过程，避免直接抄答案。

### 两阶段流程

1. **`/hw do <idx>`** → 只输出题目分析 + 解题思路框架，不给完整答案。末尾提示用户尝试后回复"给我答案"获取完整解答。
2. **"给我答案"** 或 `/hw answer` → 生成完整详细解答（逐题推导/代码/结果），所有文件包含 AI 辅助声明。

### AI 辅助声明
- `_解答.md` 头部：`> ⚠️ 本文由 AI 辅助生成，仅供学习参考`
- `_解答.tex` 页脚：`\fancyfoot[C]{AI 辅助生成 · 学习参考}`
- 代码文件头部：`# AI 辅助生成代码，供学习参考`
- 飞书回复末尾：`📝 AI 辅助生成，供学习参考`

### 其他改动
- `_hw_context` 记住最近一次 `/hw do` 的作业上下文
- `/help` 和 `_FS_CTX` 新增 `/hw answer` 和自然语言触发词
- `run_homework_check` → `answer_mode` 参数贯穿全链路

## Test plan
- [x] `pytest` — 20/20 pass