### PR TITLE
fix: /hw do context saved in main thread, not background

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -1025,7 +1025,6 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
             return
 
         cmd_result = _handle_commands(sender_open_id, text)
-        print(f"[feishu] _handle_commands({text[:40]!r}) → {cmd_result!r}")
         if cmd_result is not None:
             print(f"[feishu] 命令: {text[:40]!r}")
             _reply_text(message_id, cmd_result)


### PR DESCRIPTION
Save _hw_context immediately in the main event loop thread instead of in the background thread, preventing race condition where '给我答案' arrives before context is set.