### PR TITLE
fix: daily report and other CLI commands broken after scripts/ reorganization

### DIFF
--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -26,6 +26,22 @@ def _run_module(module_name: str, script_args: list[str] | None = None) -> int:
         sys.argv = old_argv
 
 
+def _run_script(script_name: str, script_args: list[str] | None = None) -> int:
+    """Run a script from the scripts/ directory via runpy.run_path."""
+    root = Path(__file__).resolve().parent.parent
+    script = root / "scripts" / f"{script_name}.py"
+    old_argv = sys.argv[:]
+    sys.argv = [str(script), *(script_args or [])]
+    try:
+        runpy.run_path(str(script), run_name="__main__")
+        return 0
+    except SystemExit as exc:
+        code = exc.code
+        return code if isinstance(code, int) else 0
+    finally:
+        sys.argv = old_argv
+
+
 def _cmd_doctor(_: argparse.Namespace) -> int:
     import agent
 
@@ -204,7 +220,7 @@ def _cmd_chat(args: argparse.Namespace) -> int:
 
 
 def _cmd_setup_config(args: argparse.Namespace) -> int:
-    return _run_module("setup_config", args.script_args)
+    return _run_script("setup_config", args.script_args)
 
 
 def _cmd_login(args: argparse.Namespace) -> int:
@@ -216,11 +232,11 @@ def _cmd_ddl(args: argparse.Namespace) -> int:
 
 
 def _cmd_daily_report(args: argparse.Namespace) -> int:
-    return _run_module("daily_report", args.script_args)
+    return _run_script("daily_report", args.script_args)
 
 
 def _cmd_telegram_bot(args: argparse.Namespace) -> int:
-    return _run_module("telegram_bot", args.script_args)
+    return _run_script("telegram_bot", args.script_args)
 
 
 def _cmd_feishu_bot(args: argparse.Namespace) -> int:
@@ -243,7 +259,7 @@ def _cmd_qq_bot(args: argparse.Namespace) -> int:
 
 
 def _cmd_remind_check(args: argparse.Namespace) -> int:
-    return _run_module("remind_check", args.script_args)
+    return _run_script("remind_check", args.script_args)
 
 
 def _cmd_news_digest(args: argparse.Namespace) -> int:
@@ -261,7 +277,7 @@ def _cmd_news_digest(args: argparse.Namespace) -> int:
 
 
 def _cmd_mcp(args: argparse.Namespace) -> int:
-    return _run_module("mcp_server", args.script_args)
+    return _run_script("mcp_server", args.script_args)
 
 
 def _parse_kv_items(items: list[str] | None) -> dict[str, str]:


### PR DESCRIPTION
## Root Cause

根目录重组（`scripts/` 迁移）后，`pyproject.toml` 的 `py-modules` 只保留了 `agent`, `ddl_checker`, `login`，但 CLI 中多个命令仍在用 `_run_module()` 调用已移走的脚本，导致 `ImportError: No module named 'daily_report'`。

## Fix

- 新增 `_run_script()` 辅助函数（通过 `runpy.run_path` 执行 `scripts/` 下的脚本）
- 修复 5 个命令：`daily-report`, `telegram-bot`, `remind-check`, `setup-config`, `mcp-server`

所有 3 个日报任务（Morning/Noon/Evening）之前全部因 `ImportError` 静默失败，现在恢复正常。

## Test plan
- [x] `python -m sjtu_agent daily-report --test` — exit code 0