### PR TITLE
release: v0.2.0-rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.2.0-rc2"
+version = "0.2.0-rc3"
 description = "Deployable SJTU campus agent with CLI, Telegram bot, and MCP server entrypoints."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0-rc2"
+__version__ = "0.2.0-rc3"


### PR DESCRIPTION
## v0.2.0-rc3

自 rc2 以来的关键修复：

### 修复
- 日报/TG Bot/提醒等 CLI 命令因根目录重组后路径错误导致静默失败
- /hw do 后"给我答案"时序问题（上下文保存已移到主线程）
- 消息重复执行（新增基于内容的消息去重）
- 斜杠命令因变量命名错误导致全部失效
- 飞书 lark-oapi 1.6.5 兼容性
- LaTeX PDF 页号不统一、数学公式断行问题