### PR TITLE
feat: SJTU LaTeX template system with /template command

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -919,6 +919,24 @@ def _handle_commands(open_id: str, text: str) -> str | None:
                 return _do_hw_answer(open_id)
             else:
                 return run_homework_check(list_only=True)
+        if cmd == "/template":
+            sub = parts[1].strip() if len(parts) > 1 else ""
+            from sjtu_agent.overleaf_client import list_local_templates
+            templates = list_local_templates()
+            if not templates:
+                return "暂无可用模板。请从 SJTU Overleaf Gallery 克隆模板到本地。"
+            if not sub:
+                lines = ["📄 **可用模板**："]
+                for t in templates:
+                    src = "📦 内置" if t["source"] == "builtin" else "📥 下载"
+                    lines.append(f"  [{t['name']}] {t['description']} {src}")
+                lines.append("\n/template <名称> 套用模板")
+                return "\n".join(lines)
+            # 查找模板
+            match = next((t for t in templates if t["name"] == sub), None)
+            if not match:
+                return f"模板不存在: {sub}。用 /template 查看可用模板。"
+            return f"[template] 📄 模板 {sub} 已就绪。\n\n由于模板文件需从 SJTU Overleaf Gallery 获取具体 .cls/.sty 文件，请先执行：\n```\ngit clone https://latex.sjtu.edu.cn/git/<project-id> sjtu_agent/sjtu_templates/{sub}\n```\n完成后即可用 /template {sub} 套用。"
         return f"未知命令：{cmd}。输入 /help 查看可用命令。"
 
 

--- a/sjtu_agent/overleaf_client.py
+++ b/sjtu_agent/overleaf_client.py
@@ -1,0 +1,111 @@
+"""SJTU Overleaf (latex.sjtu.edu.cn) 客户端 — Git Bridge + 模板管理。
+
+通过 Overleaf Git Bridge 克隆模板项目，本地套用后编译。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from sjtu_agent.paths import DATA_DIR
+
+_OVERLEAF_BASE = "https://latex.sjtu.edu.cn"
+_TEMPLATES_DIR = Path(__file__).resolve().parent / "sjtu_templates"
+_USER_TEMPLATES_DIR = DATA_DIR / "sjtu_templates"
+
+
+def list_local_templates() -> list[dict]:
+    """列出本地可用的模板。内置模板 + 用户下载的模板。"""
+    templates = []
+    for base in (_TEMPLATES_DIR, _USER_TEMPLATES_DIR):
+        if not base.exists():
+            continue
+        for d in sorted(base.iterdir()):
+            if d.is_dir() and not d.name.startswith("."):
+                readme = d / "README.md"
+                desc = ""
+                if readme.exists():
+                    desc = readme.read_text(encoding="utf-8").strip().split("\n")[0]
+                templates.append({
+                    "name": d.name,
+                    "path": str(d),
+                    "description": desc or "(无描述)",
+                    "source": "builtin" if str(base) == str(_TEMPLATES_DIR) else "user",
+                })
+    return templates
+
+
+def _ensure_templates_dir() -> Path:
+    _USER_TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
+    return _USER_TEMPLATES_DIR
+
+
+def clone_template_from_overleaf(project_id: str, template_name: str = "") -> str | None:
+    """通过 Git Bridge 克隆 Overleaf 项目到本地模板目录。返回模板路径。"""
+    git = shutil.which("git")
+    if not git:
+        return None
+
+    name = template_name or f"overleaf-{project_id}"
+    target = _USER_TEMPLATES_DIR / name
+    if target.exists():
+        return str(target)
+
+    url = f"{_OVERLEAF_BASE}/git/{project_id}"
+    try:
+        subprocess.run(
+            [git, "clone", "--depth", "1", url, str(target)],
+            capture_output=True, text=True, timeout=60,
+            check=True,
+        )
+        return str(target)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _find_xelatex() -> str | None:
+    """查找本机 xelatex。"""
+    candidates = [shutil.which("xelatex"), shutil.which("xelatex.exe")]
+    if os.name == "nt":
+        for d in [r"C:\Program Files\MiKTeX\miktex\bin\x64\xelatex.exe",
+                  r"C:\Program Files (x86)\MiKTeX\miktex\bin\x64\xelatex.exe"]:
+            if Path(d).exists():
+                candidates.insert(0, d)
+    for c in candidates:
+        if c and Path(c).exists():
+            return c
+    return None
+
+
+def compile_latex(tex_file: Path, work_dir: Path | None = None) -> tuple[bool, str]:
+    """运行 xelatex 编译 .tex 文件。返回 (success, output)。"""
+    xelatex = _find_xelatex()
+    if not xelatex:
+        return False, "[xelatex] 未找到 xelatex，请安装 MiKTeX"
+
+    cwd = work_dir or tex_file.parent
+    try:
+        result = subprocess.run(
+            [xelatex, "-interaction=nonstopmode", tex_file.name],
+            cwd=str(cwd), capture_output=True, text=True,
+            timeout=120, encoding="utf-8", errors="replace",
+        )
+        # xelatex 需要跑两次以生成目录和交叉引用
+        subprocess.run(
+            [xelatex, "-interaction=nonstopmode", tex_file.name],
+            cwd=str(cwd), capture_output=True, text=True,
+            timeout=120, encoding="utf-8", errors="replace",
+        )
+        if result.returncode == 0:
+            return True, result.stdout.strip()
+        # 提取错误行
+        errors = [l for l in result.stdout.split("\n") if l.startswith("!")]
+        return False, "\n".join(errors[:5]) or result.stdout[-500:]
+    except subprocess.TimeoutExpired:
+        return False, "[xelatex] 编译超时"
+    except Exception as e:
+        return False, f"[xelatex] 异常: {e}"

--- a/sjtu_agent/sjtu_templates/README.md
+++ b/sjtu_agent/sjtu_templates/README.md
@@ -1,0 +1,22 @@
+# SJTU LaTeX Templates
+
+内置模板来自 SJTU Overleaf (latex.sjtu.edu.cn) Gallery。学生可用 `/template <名称>` 套用。
+
+## 如何新增模板
+
+1. 在 Overleaf Gallery 找到模板项目
+2. 通过 Git Bridge 克隆：
+   ```bash
+   git clone https://latex.sjtu.edu.cn/git/<project-id> sjtu_agent/sjtu_templates/<模板名>
+   ```
+3. 添加 README.md 说明用途
+4. 提交 PR
+
+## 当前模板
+
+| 名称 | 用途 |
+|------|------|
+| `bachelor-thesis` | 本科毕业论文（请在 Overleaf 克隆实际模板后替换） |
+| `course-report` | 课程报告（请在 Overleaf 克隆实际模板后替换） |
+
+这些目录目前仅包含框架，实际 LaTeX 模板文件(.cls/.sty/main.tex)需从 SJTU Overleaf Gallery 获取。


### PR DESCRIPTION
## Summary

LaTeX 模板系统的第一步：基础设施 + `/template` 命令。

### 新增
- `sjtu_agent/overleaf_client.py`: Overleaf Git Bridge 客户端、本地模板列表、xelatex 编译
- `sjtu_agent/sjtu_templates/`: 模板目录（`bachelor-thesis`、`course-report` 占位）
- `/template` 命令: 列出可用模板，引导用户从 Overleaf Gallery 克隆实际 .cls/.sty 文件

### 下一步
1. 从 latex.sjtu.edu.cn 克隆实际模板文件到相应目录
2. 实现内容套用 + 编译流程（Claude Code 自动映射内容到模板）