### PR TITLE
feat: SJTU_PAPERS_DIR env var for template target directory

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -1100,13 +1100,8 @@ def _handle_commands(open_id: str, text: str) -> str | None:
             match = next((t for t in templates if t["name"] == sub), None)
             if not match:
                 return f"模板不存在: {sub}。用 /template 查看可用模板。"
-            # 将模板复制到当前工作目录
-            from pathlib import Path
-            target = Path.cwd()
-            msg = apply_template(sub, target)
-            return (f"{msg}\n\n"
-                    f"模板已就绪。现在发送「帮我格式化成{next((t['description'] for t in templates if t['name']==sub), sub)} PDF」"
-                    f"即可让 Claude Code 自动填入内容并编译。")
+            msg = apply_template(sub)  # 使用 PAPERS_DIR
+            return f"{msg}\n\n把你的文档文件放进去，然后说「帮我格式化」即可。"
         return f"未知命令：{cmd}。输入 /help 查看可用命令。"
 
 

--- a/sjtu_agent/overleaf_client.py
+++ b/sjtu_agent/overleaf_client.py
@@ -119,8 +119,12 @@ def compile_latex(tex_file: Path, work_dir: Path | None = None) -> tuple[bool, s
         return False, f"[xelatex] 异常: {e}"
 
 
-def apply_template(template_name: str, target_dir: Path) -> str:
-    """将模板复制到目标目录，返回操作说明文本。"""
+def apply_template(template_name: str, target_dir: Path | None = None) -> str:
+    """将模板复制到目标目录，返回操作说明文本。默认使用 PAPERS_DIR。"""
+    from sjtu_agent.paths import PAPERS_DIR
+    target_dir = Path(target_dir) if target_dir else PAPERS_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+
     template_dir = _TEMPLATES_DIR / template_name
     if not template_dir.exists():
         template_dir = _USER_TEMPLATES_DIR / template_name
@@ -144,13 +148,8 @@ def apply_template(template_name: str, target_dir: Path) -> str:
             shutil.copy2(item, dest)
         copied += 1
 
-    guide = template_dir / "TEMPLATE_GUIDE.md"
-    guide_text = ""
-    if guide.exists():
-        guide_text = guide.read_text(encoding="utf-8")
-
     return (
-        f"📄 模板 '{template_name}' 已复制到当前目录（{copied} 个文件/目录）。\n\n"
-        f"接下来由 Claude Code 读取你的文档和模板，自动填入内容并编译 PDF。\n"
-        f"{'模板指引：' + guide_text if guide_text else ''}"
+        f"📄 模板 '{template_name}' 已复制到 `{target_dir}`（{copied} 个文件/目录）。\n\n"
+        f"把你的论文/文档文件放到这个目录，然后说「帮我格式化」即可。\n"
+        f"可通过环境变量 `SJTU_PAPERS_DIR` 自定义目录。"
     )

--- a/sjtu_agent/paths.py
+++ b/sjtu_agent/paths.py
@@ -36,6 +36,7 @@ except ImportError:
     pass
 
 ASSIGNMENTS_DIR = Path(os.environ.get("SJTU_HOMEWORK_DIR", str(DATA_DIR / "assignments")))
+PAPERS_DIR = Path(os.environ.get("SJTU_PAPERS_DIR", str(DATA_DIR / "papers")))
 CONFIG_PATH = DATA_DIR / "config.json"
 AGENT_CONFIG_PATH = DATA_DIR / "agent_config.json"
 REMINDERS_PATH = DATA_DIR / "reminders.json"


### PR DESCRIPTION
## Summary

`/template` 之前用的 `Path.cwd()` 做目标目录，在 Bot 上下文中无意义。现在支持 `SJTU_PAPERS_DIR` 环境变量。

### 用法
```bash
# .env
SJTU_PAPERS_DIR=E:/sjtu/sjtu-agent-papers-area
```

未设置时默认 `%APPDATA%/sjtu-agent/papers`。

### 流程
1. 在 `.env` 设置 `SJTU_PAPERS_DIR`
2. `/template bachelor-thesis` → 模板复制到论文目录
3. 把你写的文档放到论文目录
4. 说「帮我格式化」→ Claude Code 填入模板 + 编译 PDF