### PR TITLE
fix: Feishu slash command deadlock — Lock → RLock for _sess_meta_lock

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -79,7 +79,7 @@ _EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=4, thread_name_pre
 # ── 多对话会话（每个 open_id 可拥有多个独立对话） ────────────────────────
 _sessions: dict[str, dict] = {}
 _locks: dict[str, threading.Lock] = {}
-_sess_meta_lock = threading.Lock()
+_sess_meta_lock = threading.RLock()  # reentrant: _handle_commands calls _save_sessions inside lock
 
 # ── 作业解答上下文（记住最近一次 /hw do，供"给我答案"使用）────────────────
 _hw_context: dict[str, dict] = {}


### PR DESCRIPTION
## Summary

Slash commands (`/new`, `/list`, `/hw`, etc.) caused the Feishu bot to hang — no reply, command not executed.

**Root cause**: `_sess_meta_lock` was `threading.Lock` (non-reentrant). `_handle_commands()` holds this lock, then calls `_save_sessions()` for commands like `/new`, `/switch`, `/name`, `/delete`. `_save_sessions()` internally tries to acquire `_sess_meta_lock` again → deadlock (same thread blocks waiting for itself).

## Fix

One-line change: `threading.Lock` → `threading.RLock` for `_sess_meta_lock`. An RLock allows the same thread to acquire it multiple times, eliminating the deadlock.