### PR TITLE
chore: bump version to 0.2.0-rc7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.2.0-rc6"
+version = "0.2.0-rc7"
 description = "Deployable SJTU campus agent with CLI, Telegram bot, and MCP server entrypoints."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0-rc6"
+__version__ = "0.2.0-rc7"


### PR DESCRIPTION
## Summary

Bump version from v0.2.0-rc6 to v0.2.0-rc7.

### Changes since rc6

- #64 fix: Feishu bot stdout capture thread-safety + lock timeout
- #65 fix: email_watcher persistent sent_uids to stop duplicate push
- #66 fix: Feishu slash command deadlock — Lock → RLock