### PR TITLE
fix: show course time slots in daily reports

### DIFF
--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -272,6 +272,11 @@ def build_report(report_type: str = "evening") -> str:
             lines = []
             for c in courses:
                 t = c.get("time_str") or c.get("time") or ""
+                if not t:
+                    ts = c.get("time_start", "")
+                    te = c.get("time_end", "")
+                    if ts and te:
+                        t = f"{ts}-{te}"
                 room = c.get("room") or c.get("location") or ""
                 lines.append(f"{t} {c.get('name','未知课程')} @ {room}".strip())
             return "\n".join(lines) if lines else f"（{schedule_day_label}无课）"


### PR DESCRIPTION
## Summary

早/午/晚报列出课程时不显示具体时间段。根因：`_fmt_schedule()` 查找 `time_str`/`time` 字段，但 `fetch_schedule()` 输出的课程 dict 只有 `time_start` + `time_end`。

### Before
```
高等数学 @ 东上院501
```

### After
```
8:00-9:40 高等数学 @ 东上院501
```