### PR TITLE
chore: bump version to 0.2.0-rc8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.2.0-rc7"
+version = "0.2.0-rc8"
 description = "Deployable SJTU campus agent with CLI, Telegram bot, and MCP server entrypoints."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0-rc7"
+__version__ = "0.2.0-rc8"


### PR DESCRIPTION
## Summary

Bump version from v0.2.0-rc7 to v0.2.0-rc8.

### Changes since rc7

| PR | Description |
|----|-------------|
| #68 | fix: show course time slots in daily reports |
| #69 | refactor: tools.py split Phase 1 — reminders, user_profile, python_exec |
| #70 | refactor: tools.py split Phase 2 — email tools |
| #71 | refactor: tools.py split Phase 3 — MCP/skills tools |
| #72 | refactor: tools.py split Phase 4 — platform setup tools |
| — | chore: repo cleanup (move docs, update CLAUDE.md, .gitignore) |