### PR TITLE
refactor: extract shared Feishu client — deduplicate auth + send

### DIFF
--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -114,54 +114,19 @@ def _send_feishu(text: str) -> None:
     if not cfg.get("feishu_enabled", True):
         print("[daily_report] 飞书推送已关闭，跳过")
         return
-    app_id = cfg.get("feishu_app_id", "")
-    app_secret = cfg.get("feishu_app_secret", "")
     open_id = cfg.get("feishu_open_id", "")
-    if not app_id or not app_secret or not open_id:
-        print("[daily_report] 飞书未配置（feishu_app_id/secret/open_id），跳过推送")
+    if not open_id:
+        print("[daily_report] 飞书未配置（feishu_open_id 缺失），跳过推送")
         return
 
     # 把 HTML 转为飞书 post 段落格式
     post_paras = _html_to_post(text)
 
-    # 获取 tenant_access_token
-    import requests
-    try:
-        r = requests.post(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-            json={"app_id": app_id, "app_secret": app_secret}, timeout=10,
-        )
-        if r.status_code != 200 or r.json().get("code") != 0:
-            print(f"[daily_report] 飞书 token 获取失败: {r.text[:100]}")
-            return
-        token = r.json()["tenant_access_token"]
-    except Exception as e:
-        print(f"[daily_report] 飞书 token 请求异常: {e}")
-        return
-
-    # 按段落数分块发送（post 格式有大段限制）
-    para_chunks = [post_paras[i:i + 25] for i in range(0, len(post_paras), 25)]
-    for para_chunk in para_chunks:
-        content = {"zh_cn": {"title": "", "content": para_chunk}}
-        body = {
-            "receive_id": open_id,
-            "msg_type": "post",
-            "content": json.dumps(content, ensure_ascii=False),
-        }
-        try:
-            r = requests.post(
-                "https://open.feishu.cn/open-apis/im/v1/messages",
-                params={"receive_id_type": "open_id"},
-                headers={"Authorization": f"Bearer {token}"},
-                json=body, timeout=15,
-            )
-            if r.status_code != 200 or r.json().get("code") != 0:
-                print(f"[daily_report] 飞书推送失败: {r.text[:100]}")
-                return
-        except Exception as e:
-            print(f"[daily_report] 飞书推送异常: {e}")
-            return
-    print("[daily_report] 飞书推送完成")
+    from sjtu_agent.feishu_client import send_post_message
+    if send_post_message(open_id, post_paras):
+        print("[daily_report] 飞书推送完成")
+    else:
+        print("[daily_report] 飞书推送失败")
 
 
 # ── 数据收集 ──────────────────────────────────────────────────────────────────

--- a/scripts/email_watcher.py
+++ b/scripts/email_watcher.py
@@ -131,39 +131,12 @@ def _push_feishu(text: str) -> bool:
         cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
     except Exception:
         return False
-    app_id = cfg.get("feishu_app_id", "")
-    app_secret = cfg.get("feishu_app_secret", "")
     open_id = cfg.get("feishu_open_id", "")
-    if not app_id or not app_secret or not open_id:
+    if not open_id:
         return False
 
-    import requests
-    try:
-        r = requests.post(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-            json={"app_id": app_id, "app_secret": app_secret}, timeout=10,
-        )
-        if r.status_code != 200 or r.json().get("code") != 0:
-            return False
-        token = r.json()["tenant_access_token"]
-    except Exception:
-        return False
-
-    body = {
-        "receive_id": open_id,
-        "msg_type": "text",
-        "content": json.dumps({"text": text}, ensure_ascii=False),
-    }
-    try:
-        r = requests.post(
-            "https://open.feishu.cn/open-apis/im/v1/messages",
-            params={"receive_id_type": "open_id"},
-            headers={"Authorization": f"Bearer {token}"},
-            json=body, timeout=15,
-        )
-        return r.status_code == 200 and r.json().get("code") == 0
-    except Exception:
-        return False
+    from sjtu_agent.feishu_client import send_text_message
+    return send_text_message(open_id, text)
 
 
 def _check_new_emails(last_uid: int, sent_uids: set) -> list[dict]:

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -316,9 +316,6 @@ _SEEN_CONTENT: dict[str, tuple[str, float]] = {}
 _SEEN_CONTENT_LOCK = threading.Lock()
 _CONTENT_DEDUP_SEC = 5
 _TMP_DIR = Path(tempfile.mkdtemp(prefix="sjtu_feishu_"))
-_TOKEN_LOCK = threading.Lock()
-_TENANT_TOKEN = ""
-_TENANT_TOKEN_EXPIRES_AT = 0.0
 
 
 def _is_duplicate(message_id: str) -> bool:
@@ -372,25 +369,8 @@ def _capture_turn_multimodal(sess: dict, content: list) -> str:
 
 
 def _get_tenant_access_token() -> str:
-    global _TENANT_TOKEN, _TENANT_TOKEN_EXPIRES_AT
-    now = time.time()
-    with _TOKEN_LOCK:
-        if _TENANT_TOKEN and now < _TENANT_TOKEN_EXPIRES_AT - 30:
-            return _TENANT_TOKEN
-
-        resp = requests.post(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-            json={"app_id": APP_ID, "app_secret": APP_SECRET},
-            timeout=15,
-        )
-        data = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
-        if data.get("code") != 0 or not data.get("tenant_access_token"):
-            raise RuntimeError(f"获取 tenant_access_token 失败: {data or resp.text[:200]}")
-
-        _TENANT_TOKEN = data["tenant_access_token"]
-        expires_in = int(data.get("expire", 7200) or 7200)
-        _TENANT_TOKEN_EXPIRES_AT = now + max(60, expires_in)
-        return _TENANT_TOKEN
+    from sjtu_agent.feishu_client import get_tenant_access_token
+    return get_tenant_access_token(APP_ID, APP_SECRET)
 
 
 def _guess_suffix(filename: str, content_type: str, default: str = ".bin") -> str:

--- a/sjtu_agent/feishu_client.py
+++ b/sjtu_agent/feishu_client.py
@@ -1,0 +1,104 @@
+"""Shared Feishu API client — used by feishu_bot, daily_report, and email_watcher.
+
+Provides cached tenant_access_token retrieval and message sending, so the
+three callers no longer duplicate the auth + POST logic.
+"""
+
+import json
+import threading
+import time
+
+import requests
+
+from sjtu_agent.paths import CONFIG_PATH
+
+_TENANT_TOKEN: str = ""
+_TENANT_TOKEN_EXPIRES_AT: float = 0.0
+_TOKEN_LOCK = threading.Lock()
+
+
+def get_tenant_access_token(app_id: str, app_secret: str) -> str:
+    """Return a cached tenant_access_token, refreshing if expired.
+
+    Raises RuntimeError when the Feishu API returns an error code.
+    """
+    global _TENANT_TOKEN, _TENANT_TOKEN_EXPIRES_AT
+    now = time.time()
+    with _TOKEN_LOCK:
+        if _TENANT_TOKEN and now < _TENANT_TOKEN_EXPIRES_AT - 30:
+            return _TENANT_TOKEN
+
+        resp = requests.post(
+            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+            json={"app_id": app_id, "app_secret": app_secret},
+            timeout=15,
+        )
+        data = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+        if data.get("code") != 0 or not data.get("tenant_access_token"):
+            raise RuntimeError(f"获取 tenant_access_token 失败: {data or resp.text[:200]}")
+
+        _TENANT_TOKEN = data["tenant_access_token"]
+        expires_in = int(data.get("expire", 7200) or 7200)
+        _TENANT_TOKEN_EXPIRES_AT = now + max(60, expires_in)
+        return _TENANT_TOKEN
+
+
+def _load_feishu_config() -> dict | None:
+    try:
+        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not cfg.get("feishu_app_id") or not cfg.get("feishu_app_secret"):
+        return None
+    return cfg
+
+
+def send_text_message(open_id: str, text: str) -> bool:
+    """Send a text message to a Feishu user via the REST API.  Returns True on success."""
+    cfg = _load_feishu_config()
+    if not cfg:
+        return False
+    try:
+        token = get_tenant_access_token(cfg["feishu_app_id"], cfg["feishu_app_secret"])
+        resp = requests.post(
+            "https://open.feishu.cn/open-apis/im/v1/messages",
+            params={"receive_id_type": "open_id"},
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "receive_id": open_id,
+                "msg_type": "text",
+                "content": json.dumps({"text": text}, ensure_ascii=False),
+            },
+            timeout=15,
+        )
+        return resp.status_code == 200 and resp.json().get("code") == 0
+    except Exception:
+        return False
+
+
+def send_post_message(open_id: str, post_paras: list) -> bool:
+    """Send a post-format message, chunking if needed.  Returns True on success."""
+    cfg = _load_feishu_config()
+    if not cfg:
+        return False
+    try:
+        token = get_tenant_access_token(cfg["feishu_app_id"], cfg["feishu_app_secret"])
+        para_chunks = [post_paras[i:i + 25] for i in range(0, len(post_paras), 25)]
+        for chunk in para_chunks:
+            content = {"zh_cn": {"title": "", "content": chunk}}
+            resp = requests.post(
+                "https://open.feishu.cn/open-apis/im/v1/messages",
+                params={"receive_id_type": "open_id"},
+                headers={"Authorization": f"Bearer {token}"},
+                json={
+                    "receive_id": open_id,
+                    "msg_type": "post",
+                    "content": json.dumps(content, ensure_ascii=False),
+                },
+                timeout=15,
+            )
+            if resp.status_code != 200 or resp.json().get("code") != 0:
+                return False
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary

Extracted duplicated Feishu auth + message-send logic into a shared module.

### Before

Three copies of the same token-request + message-send pattern:

| File | Function | Lines |
|------|----------|-------|
| `feishu_bot.py` | `_get_tenant_access_token()` | 20 |
| `daily_report.py` | `_send_feishu()` | 57 |
| `email_watcher.py` | `_push_feishu()` | 40 |

Total: ~117 duplicated lines.

### After

New shared module `sjtu_agent/feishu_client.py`:
- `get_tenant_access_token(app_id, app_secret)` — TTL-cached token
- `send_text_message(open_id, text)` — text message
- `send_post_message(open_id, paragraphs)` — post message with chunking

All three callers now use these functions. Removed 94 lines across the three files.