### PR TITLE
chore: bump version to 0.2.0-rc9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.2.0-rc8"
+version = "0.2.0-rc9"
 description = "Deployable SJTU campus agent with CLI, Telegram bot, and MCP server entrypoints."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0-rc8"
+__version__ = "0.2.0-rc9"


### PR DESCRIPTION
## Summary

Bump version from v0.2.0-rc8 to v0.2.0-rc9.

### Changes since rc8

| PR | Description |
|----|-------------|
| #74 | refactor: extract shared Feishu client — deduplicate auth + send |
| #75 | feat: AI HOT daily news push to Feishu via aihot.virxact.com |
| #76 | feat: /aihot slash command + LLM prompt + README docs |