### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.2.0-rc9"
-description = "Deployable SJTU campus agent with CLI, Telegram bot, and MCP server entrypoints."
+version = "0.3.0"
+description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"
 dynamic = ["dependencies"]

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0-rc9"
+__version__ = "0.3.0"


### PR DESCRIPTION
## Summary

Release v0.3.0 — first non-RC release since the 0.2.0 series.

### From v0.2.0-rc1 to v0.3.0

After 9 release candidates, the project has reached a stable enough state to drop the `-rc` suffix.

**Stability fixes (rc1→rc7):**
- Feishu Bot deadlock fix (Lock → RLock)
- Stdout capture thread-safety + lock timeout
- Email watcher dedup (persistent sent_uids)
- Course time slots in daily reports
- Various slash command and subprocess fixes

**Architecture (rc8):**
- tools.py split: 5269 lines → 7 domain submodules (-32%)
- Shared Feishu client: eliminated triple-duplicated auth code

**New features (rc9):**
- AI HOT daily news push (`sjtu-agent aihot`)
- `/aihot` Feishu slash command
- LLM suggests `/aihot` for AI-related questions

45 tests passing, CI green.