### PR TITLE
feat: LaTeX Phase 2 — /template compile, clone, push

### DIFF
--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -213,7 +213,9 @@ _FS_CTX = (
     "- 重命名/改名 → /name <序号> <新名称>\n"
     "- 聊天记录/之前说了什么 → /history\n"
     "- 删除对话/清空聊天 → /delete <序号>\n"
-    "- 套用 SJTU 模板/毕业论文格式/课程报告模板 → /template\n"
+    "- 套用 SJTU 模板/毕业论文格式/课程报告模板 → /template <名称>\n"
+    "- 编译论文 PDF/帮我编译/生成 PDF → /template compile\n"
+    "- 从 Overleaf 克隆模板 → /template clone <project-id>\n"
     "- AI 资讯/今天 AI 圈/大模型新闻 → /aihot\n"
     "- 查看帮助/有什么功能/怎么用/命令列表 → /help\n"
     "\n"
@@ -1011,7 +1013,10 @@ def _handle_commands(open_id: str, text: str) -> str | None:
                 "`/aihot`  获取今日 AI 圈精选新闻\n\n"
                 "📄 LaTeX 模板\n"
                 "`/template`  列出可用模板\n"
-                "`/template <名称>`  套用模板，如 /template bachelor-thesis\n\n"
+                "`/template <名称>`  套用模板到 PAPERS_DIR\n"
+                "`/template compile`  编译论文 PDF（需 MiKTeX）\n"
+                "`/template clone <id>`  从 Overleaf 克隆模板\n"
+                "`/template push`  推送改动回 Overleaf\n\n"
                 "ℹ️  `/help`  显示此帮助"
             )
         if cmd == "/hw":
@@ -1059,22 +1064,63 @@ def _handle_commands(open_id: str, text: str) -> str | None:
             return "[aihot] 正在获取 AI 资讯…\n\n" + _fetch_aihot_news()
         if cmd == "/template":
             sub = parts[1].strip() if len(parts) > 1 else ""
-            from sjtu_agent.overleaf_client import list_local_templates, apply_template
+            action = sub.split()[0] if sub else ""
+            rest = " ".join(sub.split()[1:]) if sub and " " in sub else ""
+
+            from sjtu_agent.overleaf_client import (
+                list_local_templates, apply_template, clone_template_from_overleaf,
+                compile_latex, find_tex_file, push_to_overleaf,
+            )
+
+            # ── /template compile ──
+            if action == "compile":
+                from sjtu_agent.paths import PAPERS_DIR
+                tex = find_tex_file()
+                if not tex:
+                    return f"[xelatex] 在 {PAPERS_DIR} 下未找到 .tex 文件。请先用 /template <name> 套用模板，放入文档后编译。"
+                ok, output = compile_latex(tex)
+                if ok:
+                    pdf = tex.with_suffix(".pdf")
+                    return f"[xelatex] 编译成功 ✅\nPDF: {pdf.name} ({pdf.stat().st_size // 1024} KB)"
+                return f"[xelatex] 编译失败 ❌\n```\n{output}\n```"
+
+            # ── /template clone <project-id> [name] ──
+            if action == "clone":
+                args = rest.split() if rest else []
+                if not args:
+                    return "用法: /template clone <project-id> [name]"
+                pid = args[0]
+                name = args[1] if len(args) > 1 else ""
+                path = clone_template_from_overleaf(pid, name)
+                if not path:
+                    return f"克隆失败: 请检查 project-id 是否正确，以及 Git 是否已配置。Overleaf Git Bridge URL: https://latex.sjtu.edu.cn/git/{pid}"
+                return f"模板已克隆到 `{path}`\n\n/template {Path(path).name} 即可套用。"
+
+            # ── /template push [name] ──
+            if action == "push":
+                from sjtu_agent.paths import PAPERS_DIR
+                target = PAPERS_DIR
+                msg = push_to_overleaf(target)
+                return f"[git] {msg[1]}"
+
+            # ── /template list (default) ──
             templates = list_local_templates()
             if not templates:
-                return "暂无可用模板。"
+                return "暂无可用模板。用 /template clone <project-id> 从 Overleaf 克隆。"
             if not sub:
                 lines = ["📄 **可用模板**："]
                 for t in templates:
                     src = "📦 内置" if t["source"] == "builtin" else "📥 下载"
                     lines.append(f"  [{t['name']}] {t['description']} {src}")
-                lines.append("\n/template <名称> 套用模板")
+                lines.append("\n子命令: /template <名称> | compile | clone <id> | push")
                 return "\n".join(lines)
+
+            # ── /template <name> (apply) ──
             match = next((t for t in templates if t["name"] == sub), None)
             if not match:
                 return f"模板不存在: {sub}。用 /template 查看可用模板。"
-            msg = apply_template(sub)  # 使用 PAPERS_DIR
-            return f"{msg}\n\n把你的文档文件放进去，然后说「帮我格式化」即可。"
+            msg = apply_template(sub)
+            return f"{msg}\n\n把你的文档文件放进去，然后 /template compile 编译。"
         return f"未知命令：{cmd}。输入 /help 查看可用命令。"
 
 

--- a/sjtu_agent/overleaf_client.py
+++ b/sjtu_agent/overleaf_client.py
@@ -119,6 +119,62 @@ def compile_latex(tex_file: Path, work_dir: Path | None = None) -> tuple[bool, s
         return False, f"[xelatex] 异常: {e}"
 
 
+def find_tex_file(target_dir: Path | None = None) -> Path | None:
+    """在目标目录中查找主 .tex 文件。优先级：main.tex > 单个 .tex > None。"""
+    from sjtu_agent.paths import PAPERS_DIR
+    d = Path(target_dir) if target_dir else PAPERS_DIR
+    if not d.exists():
+        return None
+    tex_files = sorted(d.glob("*.tex"))
+    if not tex_files:
+        return None
+    # 优先 main.tex
+    for f in tex_files:
+        if f.name.lower() == "main.tex":
+            return f
+    return tex_files[0]
+
+
+def push_to_overleaf(project_dir: Path) -> tuple[bool, str]:
+    """通过 Git Bridge 将本地改动推送回 Overleaf。返回 (success, message)。"""
+    git = shutil.which("git")
+    if not git:
+        return False, "未找到 git，请安装 Git"
+
+    if not project_dir.exists():
+        return False, f"目录不存在: {project_dir}"
+
+    git_dir = project_dir / ".git"
+    if not git_dir.exists():
+        return False, "该目录不是 git 仓库（没有 .git），请先用 /template clone 从 Overleaf 克隆"
+
+    try:
+        # git add -A
+        subprocess.run(
+            [git, "add", "-A"], cwd=str(project_dir),
+            capture_output=True, text=True, timeout=30, check=True,
+        )
+        # git commit (allow empty in case nothing changed)
+        result = subprocess.run(
+            [git, "commit", "-m", "Update from sjtu-agent"],
+            cwd=str(project_dir),
+            capture_output=True, text=True, timeout=30,
+        )
+        # git push
+        push = subprocess.run(
+            [git, "push"], cwd=str(project_dir),
+            capture_output=True, text=True, timeout=60,
+        )
+        if push.returncode == 0:
+            changed = "nothing to commit" not in result.stdout
+            return True, "已推送到 Overleaf" if changed else "没有新的改动，无需推送"
+        return False, f"推送失败: {push.stderr[:300] or push.stdout[:300]}"
+    except subprocess.TimeoutExpired:
+        return False, "推送超时"
+    except Exception as e:
+        return False, f"推送异常: {e}"
+
+
 def apply_template(template_name: str, target_dir: Path | None = None) -> str:
     """将模板复制到目标目录，返回操作说明文本。默认使用 PAPERS_DIR。"""
     from sjtu_agent.paths import PAPERS_DIR


### PR DESCRIPTION
## Summary

LaTeX Phase 2: wired up the existing `compile_latex()` function, added Overleaf Git Bridge push, and new `/template` subcommands.

### New `/template` subcommands

| Command | Action |
|---------|--------|
| `/template` | List available templates |
| `/template <name>` | Apply template to PAPERS_DIR |
| `/template compile` | xelatex compile, find main.tex, show errors |
| `/template clone <id> [name]` | Clone from Overleaf Git Bridge |
| `/template push` | git push back to Overleaf |

### What changed

**`overleaf_client.py`**:
- New `find_tex_file()` — finds main.tex in PAPERS_DIR
- New `push_to_overleaf()` — git add/commit/push via Git Bridge

**`feishu_bot.py`**:
- `/template` handler expanded with compile/clone/push subcommands
- Updated `/help` output and `_FS_CTX` prompt
- LLM now suggests `/template compile` for "帮我编译" / "生成 PDF" requests

### Usage in Feishu chat

```
/template bachelor-thesis       # apply thesis template
/template compile               # build PDF
/template clone abc123 my-proj  # fetch from Overleaf
/template push                  # push edits back
```