### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.3.0"
+version = "0.3.1"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## Summary

Patch release — bump version from v0.3.0 to v0.3.1.

### Changes since v0.3.0

- #80 LaTeX Phase 2 — `/template compile`, `/template clone`, `/template push`
- #79 Canvas course monitoring — `canvas_watcher`, `canvas_client`, `notifications`