### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
## Summary

Patch release — bump version from v0.3.1 to v0.3.2.

### Changes since v0.3.1

- Security audit: fixed all 16 findings (P1-P4) — path traversal, CORS, command injection, XSS, SSRF, file permissions, env stripping, dep lock, temp cleanup
- Web auth: token moved from URL to Set-Cookie (HttpOnly, SameSite)
- ChromaDB memory: semantic memory for Feishu Bot (cross-session context)
- README restructured: 454 → 261 lines, 6 clear sections