### PR TITLE
chore: bump version to 0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.3.1"
+version = "0.3.3"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"


### PR DESCRIPTION
## Summary

Patch release — v0.3.2 → v0.3.3.

### Changes since v0.3.2

- Polished /help, recent updates, and _FS_CTX
- Memory-driven care nudge in daily report
- ChromaDB memory security audit (M1-M4 fixed)
- README: added memory feature section