### PR TITLE
fix: improve canvas handling and progress feedback

### DIFF
--- a/docs/superpowers/plans/2026-06-15-web-agent-streaming-tool-progress.md
+++ b/docs/superpowers/plans/2026-06-15-web-agent-streaming-tool-progress.md
@@ -1,0 +1,1411 @@
+# Web Agent Streaming Tool Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `subagent-driven-development` (recommended) or `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the local web agent stream transparent progress for thinking, tool calls, retries, limits, and errors while preventing runaway tool loops.
+
+**Architecture:** Keep `/api/chat` as an SSE endpoint and add a small web-turn state object in `sjtu_agent/web/server.py` to track tool IDs, budgets, repeated signatures, timings, and retries. The frontend keeps streaming answer text but renders a compact progress timeline keyed by tool IDs, with expandable JSON details for each tool call.
+
+**Tech Stack:** Python 3.10+, `http.server` / `ThreadingHTTPServer`, OpenAI-compatible chat completions, Anthropic Messages streaming, vanilla HTML/CSS/JavaScript, pytest.
+
+---
+
+## File Structure
+
+- Modify `sjtu_agent/web/server.py`
+  - Add backend SSE helpers, transient error handling, tool-call budget tracking, repeated-call detection, tool timings, and chat lock.
+  - Update OpenAI and Anthropic streaming loops to emit structured progress events.
+- Modify `sjtu_agent/web/static/index.html`
+  - Add compact progress timeline styles.
+  - Replace single-card tracking with a `Map` keyed by tool IDs.
+  - Expand Canvas tool labels and render retry/limit/error status rows.
+- Create `tests/test_web_streaming.py`
+  - Unit tests for backend SSE events, budget stops, repeated stops, transient retries, and chat lock behavior.
+- Create `tests/test_web_static.py`
+  - Static frontend checks for Canvas labels, keyed tool map, timeline helpers, and removal of single `currentToolCard` tracking.
+
+The current worktree already has unrelated WeChat/Canvas changes. Each task must stage only the files named in that task.
+
+---
+
+### Task 1: Backend Streaming Tests
+
+**Files:**
+- Create: `tests/test_web_streaming.py`
+- Modify: none
+- Test: `tests/test_web_streaming.py`
+
+- [ ] **Step 1: Write failing backend tests**
+
+Create `tests/test_web_streaming.py` with this content:
+
+```python
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+
+def _chunk(*, content: str = "", tool_calls=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _tool_call(name: str, arguments: str = "{}", index: int = 0, call_id: str = "call_1"):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _events_from(chunks):
+    events = []
+    for chunk in chunks:
+        for block in chunk.split("\n\n"):
+            block = block.strip()
+            if not block.startswith("data: "):
+                continue
+            payload = block.removeprefix("data: ").strip()
+            if payload == "[DONE]":
+                events.append({"done": True})
+                continue
+            events.append(json.loads(payload))
+    return events
+
+
+class FakeOpenAIToolClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return [
+                _chunk(tool_calls=[
+                    _tool_call("get_canvas_todo", '{"limit": 1}'),
+                    _tool_call(
+                        "get_canvas_course_quizzes",
+                        '{"course": "ECE2300"}',
+                        index=1,
+                        call_id="call_2",
+                    ),
+                ])
+            ]
+        return [_chunk(content="查好了。")]
+
+
+class FakeOpenAILoopingClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return [
+            _chunk(tool_calls=[
+                _tool_call("get_canvas_course_quizzes", '{"course": "电磁学"}')
+            ])
+        ]
+
+
+class FakeOpenAIRotatingClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return [
+            _chunk(tool_calls=[
+                _tool_call(
+                    "get_canvas_course_updates",
+                    json.dumps({"course": f"COURSE{self.calls}"}, ensure_ascii=False),
+                )
+            ])
+        ]
+
+
+class FailingStream:
+    def __iter__(self):
+        if False:
+            yield None
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
+
+
+class FakeTransientLimitClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls < 3:
+            return FailingStream()
+        return [_chunk(content="现在可以继续了。")]
+
+
+class FakePersistentLimitClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return FailingStream()
+
+
+def _reset_web_server(monkeypatch, client):
+    import agent
+    import sjtu_agent.web.server as server
+
+    server._chat_history = []
+    if hasattr(server, "_chat_lock") and server._chat_lock.locked():
+        server._chat_lock.release()
+    monkeypatch.setattr(server, "_get_chat_client", lambda: (client, "deepseek-chat", "openai"))
+    monkeypatch.setattr(agent, "run_tool", lambda name, args: '{"ok": true, "tool": "%s"}' % name)
+    return server
+
+
+def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+
+    events = _events_from(server._stream_chat("看看 Canvas 待办和 ECE2300 quiz"))
+
+    starts = [event["tool_start"] for event in events if "tool_start" in event]
+    ends = [event["tool_end"] for event in events if "tool_end" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert events[0]["status"]["phase"] == "thinking"
+    assert [start["id"] for start in starts] == ["tool-1", "tool-2"]
+    assert [start["index"] for start in starts] == [1, 2]
+    assert starts[0]["label"] == "正在读取 Canvas 待办"
+    assert starts[0]["summary"] == "limit=1"
+    assert starts[1]["label"] == "正在读取 Canvas Quiz"
+    assert starts[1]["summary"] == "course=ECE2300"
+    assert [end["id"] for end in ends] == ["tool-1", "tool-2"]
+    assert all(isinstance(end["elapsed_ms"], int) for end in ends)
+    assert tokens == ["查好了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_stops_repeated_tool_loop(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAILoopingClient())
+
+    events = _events_from(server._stream_chat("帮我看电磁学 quiz"))
+
+    starts = [event for event in events if "tool_start" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert len(starts) == 3
+    assert "连续调用" in tokens
+    assert "Canvas Quiz" in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_stops_after_total_tool_budget(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIRotatingClient())
+
+    events = _events_from(server._stream_chat("把所有 Canvas 动态都查一下"))
+
+    starts = [event for event in events if "tool_start" in event]
+    limits = [event["tool_limit"] for event in events if "tool_limit" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert len(starts) == 12
+    assert limits == [{
+        "max_tool_calls": 12,
+        "message": "工具调用已到上限，正在整理已有结果…",
+    }]
+    assert "工具调用次数已经达到上限" in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_retries_transient_concurrency_limit(monkeypatch):
+    client = FakeTransientLimitClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 3
+    assert [retry["attempt"] for retry in retries] == [1, 2]
+    assert tokens == ["现在可以继续了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_returns_friendly_message_when_limit_persists(monkeypatch):
+    client = FakePersistentLimitClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert client.calls == 3
+    assert "模型服务现在有点忙" in tokens
+    assert "Concurrency limit" not in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_rejects_concurrent_turn(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+    server._chat_lock.acquire()
+    try:
+        events = _events_from(server._stream_chat("第二个请求"))
+    finally:
+        server._chat_lock.release()
+
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert "上一轮对话还在运行" in tokens
+    assert events[-1] == {"done": True}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/test_web_streaming.py -q
+```
+
+Expected: FAIL. The current backend does not emit `status`, `id`, `label`, `summary`, `retry`, `tool_limit`, or `done` events, and `_chat_lock` does not exist yet.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/test_web_streaming.py
+git commit -m "test: cover web agent streaming progress"
+```
+
+---
+
+### Task 2: Backend Helpers and Chat Lock
+
+**Files:**
+- Modify: `sjtu_agent/web/server.py`
+- Test: `tests/test_web_streaming.py`
+
+- [ ] **Step 1: Add constants, lock, and helper functions**
+
+In `sjtu_agent/web/server.py`, replace the chat session block:
+
+```python
+# ── 聊天会话（内存，单用户） ────────────────────────────────────────────────────
+
+_chat_history: list[dict] = []   # [{role, content}, additional entries]
+```
+
+with:
+
+```python
+# ── 聊天会话（内存，单用户） ────────────────────────────────────────────────────
+
+MAX_TOOL_ROUNDS = 20
+MAX_TOOL_CALLS = 12
+REPEATED_TOOL_LIMIT = 3
+_LLM_TRANSIENT_RETRY_DELAYS = (2.0, 5.0)
+
+_chat_history: list[dict] = []   # [{role, content}, additional entries]
+_chat_lock = threading.Lock()
+
+
+def _sse(obj: dict) -> str:
+    return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
+
+
+def _token_event(text: str) -> str:
+    return _sse({"token": text})
+
+
+def _done_event() -> str:
+    return _sse({"done": True})
+
+
+def _canonical_tool_signature(name: str, args: dict) -> str:
+    try:
+        args_text = json.dumps(args or {}, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        args_text = "{}"
+    return f"{name}:{args_text}"
+
+
+def _tool_label(_agent, tool_name: str) -> str:
+    labels = getattr(_agent, "_TOOL_LABELS", {})
+    return labels.get(tool_name, tool_name)
+
+
+def _summarize_tool_args(name: str, args: dict) -> str:
+    if not isinstance(args, dict):
+        return ""
+    parts: list[str] = []
+    course = args.get("course")
+    if course:
+        parts.append(f"course={course}")
+    include = args.get("include")
+    if include:
+        if isinstance(include, list):
+            include_text = ",".join(str(item) for item in include[:4])
+        else:
+            include_text = str(include)
+        parts.append(f"include={include_text}")
+    limit = args.get("limit")
+    if limit is not None:
+        parts.append(f"limit={limit}")
+    course_limit = args.get("course_limit")
+    if course_limit is not None:
+        parts.append(f"course_limit={course_limit}")
+    include_past = args.get("include_past")
+    if include_past:
+        parts.append("含过去项目")
+    return "；".join(parts[:4])
+
+
+def _result_preview(result: str, max_chars: int = 500) -> str:
+    text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    return text[:max_chars] if len(text) > max_chars else text
+
+
+def _is_transient_llm_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "concurrency limit exceeded",
+            "rate limit",
+            "too many requests",
+            "please retry later",
+        )
+    )
+
+
+def _llm_busy_reply() -> str:
+    return (
+        "模型服务现在有点忙，同一个账号的并发请求被上游限制了。\n"
+        "我已经自动重试过，还是没抢到空位。请稍等半分钟后再发一次。"
+    )
+
+
+def _tool_budget_reply(max_tool_calls: int = MAX_TOOL_CALLS) -> str:
+    return (
+        f"工具调用次数已经达到上限（{max_tool_calls} 次），我先停止继续查找，避免网页端一直卡住。\n"
+        "如果你要看 Canvas 的全局 quiz、通知和最近任务，请直接说“Canvas 总览”；"
+        "我会优先使用 get_canvas_overview 一次性汇总。"
+    )
+
+
+def _repeated_tool_reply(_agent, tool_name: str) -> str:
+    label = _tool_label(_agent, tool_name)
+    return (
+        f"连续调用「{label}」仍未得到可继续推进的结果。\n"
+        "这通常是课程名没有匹配到 Canvas 课程，或当前查询条件过于模糊。\n"
+        "请尽量改用课程代码/Canvas 课程名再试，例如 `ECE2300`。"
+    )
+
+
+def _max_rounds_reply() -> str:
+    return (
+        "这轮对话的工具调用次数过多，我先暂停以避免一直卡住。\n"
+        "请把问题缩小一点，或直接提供课程代码/作业名称后再试。"
+    )
+
+
+class _TurnState:
+    def __init__(self, _agent, max_tool_calls: int = MAX_TOOL_CALLS):
+        self._agent = _agent
+        self.max_tool_calls = max_tool_calls
+        self.total_tool_calls = 0
+        self.tool_counts: dict[str, int] = {}
+
+    def next_tool_start(self, name: str, args: dict) -> dict | None:
+        if self.total_tool_calls >= self.max_tool_calls:
+            return None
+        self.total_tool_calls += 1
+        return {
+            "id": f"tool-{self.total_tool_calls}",
+            "index": self.total_tool_calls,
+            "name": name,
+            "label": _tool_label(self._agent, name),
+            "summary": _summarize_tool_args(name, args),
+            "input": args,
+        }
+
+    def record_signature(self, name: str, args: dict) -> bool:
+        signature = _canonical_tool_signature(name, args)
+        self.tool_counts[signature] = self.tool_counts.get(signature, 0) + 1
+        return self.tool_counts[signature] >= REPEATED_TOOL_LIMIT
+```
+
+- [ ] **Step 2: Update `_stream_chat` to use the lock and new done event**
+
+Replace the whole `_stream_chat` function with:
+
+```python
+def _stream_chat(user_message: str):
+    """生成器：将 user_message 发给 LLM，支持 tool_use 循环，以 SSE 格式 yield 数据行。"""
+    import datetime as _dt
+    global _chat_history
+
+    if not _chat_lock.acquire(blocking=False):
+        yield _token_event("上一轮对话还在运行，请等它结束后再发送新消息。")
+        yield _done_event()
+        return
+
+    try:
+        yield _sse({"status": {"phase": "thinking", "message": "正在思考…"}})
+
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+        import agent as _agent
+
+        if not _chat_history:
+            _now = _dt.datetime.now()
+            _date_ctx = (
+                f"\n\n## 当前时间\n"
+                f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
+            )
+            _chat_history.append({"role": "system", "content": _agent.SYSTEM_PROMPT + _date_ctx})
+
+        _chat_history.append({"role": "user", "content": user_message})
+
+        try:
+            client, model, proto = _get_chat_client()
+        except Exception as exc:
+            if _chat_history and _chat_history[-1]["role"] == "user":
+                _chat_history.pop()
+            yield _sse({"error": f"创建客户端失败：{exc}"})
+            yield _done_event()
+            return
+
+        state = _TurnState(_agent)
+        try:
+            if proto == "anthropic":
+                yield from _stream_chat_anthropic(client, model, _agent, MAX_TOOL_ROUNDS, state)
+            else:
+                yield from _stream_chat_openai(client, model, _agent, MAX_TOOL_ROUNDS, state)
+        except Exception as exc:
+            yield _sse({"error": str(exc)})
+
+        yield _done_event()
+    finally:
+        _chat_lock.release()
+```
+
+- [ ] **Step 3: Run the chat lock test**
+
+Run:
+
+```bash
+pytest tests/test_web_streaming.py::test_web_stream_chat_rejects_concurrent_turn -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit helper and lock changes**
+
+```bash
+git add sjtu_agent/web/server.py
+git commit -m "feat: add web chat streaming state helpers"
+```
+
+---
+
+### Task 3: OpenAI Streaming Loop Controls
+
+**Files:**
+- Modify: `sjtu_agent/web/server.py`
+- Test: `tests/test_web_streaming.py`
+
+- [ ] **Step 1: Replace `_stream_chat_openai`**
+
+Replace the whole `_stream_chat_openai` function with:
+
+```python
+def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
+    """OpenAI Chat Completions 流式 + tool_calls 循环。"""
+    global _chat_history
+
+    messages = list(_chat_history)
+    full_text_all = ""
+
+    for _round in range(max_rounds):
+        attempts = len(_LLM_TRANSIENT_RETRY_DELAYS) + 1
+        text_so_far = ""
+        tool_calls_map: dict[int, dict] = {}
+
+        for attempt in range(attempts):
+            text_so_far = ""
+            tool_calls_map = {}
+            try:
+                stream = client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    tools=_agent.TOOLS,
+                    tool_choice="auto",
+                    stream=True,
+                    timeout=180,
+                )
+                for chunk in stream:
+                    if not chunk.choices:
+                        continue
+                    delta = chunk.choices[0].delta
+                    if delta.content:
+                        text_so_far += delta.content
+                        full_text_all += delta.content
+                        yield _token_event(delta.content)
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            idx = tc.index
+                            if idx not in tool_calls_map:
+                                tool_calls_map[idx] = {"id": tc.id or "", "name": "", "arguments": ""}
+                            if tc.id:
+                                tool_calls_map[idx]["id"] = tc.id
+                            if tc.function:
+                                if tc.function.name:
+                                    tool_calls_map[idx]["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    tool_calls_map[idx]["arguments"] += tc.function.arguments
+                break
+            except Exception as exc:
+                if not _is_transient_llm_error(exc):
+                    if _chat_history and _chat_history[-1]["role"] == "user":
+                        _chat_history.pop()
+                    yield _sse({"error": str(exc)})
+                    return
+                if attempt >= attempts - 1:
+                    reply = _llm_busy_reply()
+                    _chat_history.append({"role": "assistant", "content": reply})
+                    yield _token_event(reply)
+                    return
+                delay = _LLM_TRANSIENT_RETRY_DELAYS[attempt]
+                yield _sse({
+                    "retry": {
+                        "attempt": attempt + 1,
+                        "delay_s": delay,
+                        "message": f"模型服务忙，{delay:g}s 后自动重试…",
+                    }
+                })
+                time.sleep(delay)
+
+        if not tool_calls_map:
+            _chat_history.append({"role": "assistant", "content": text_so_far})
+            messages.append({"role": "assistant", "content": text_so_far})
+            return
+
+        tool_calls_payload = []
+        for idx in sorted(tool_calls_map):
+            entry = tool_calls_map[idx]
+            tool_calls_payload.append({
+                "id": entry["id"] or f"call_{idx + 1}",
+                "type": "function",
+                "function": {"name": entry["name"], "arguments": entry["arguments"]},
+            })
+
+        assistant_msg = {
+            "role": "assistant",
+            "content": text_so_far or None,
+            "tool_calls": tool_calls_payload,
+        }
+        messages.append(assistant_msg)
+
+        repeated_tool_name = ""
+        for tc in tool_calls_payload:
+            fn_name = tc["function"]["name"]
+            try:
+                fn_args = json.loads(tc["function"]["arguments"] or "{}")
+            except Exception:
+                fn_args = {}
+
+            start_payload = state.next_tool_start(fn_name, fn_args)
+            if start_payload is None:
+                reply = _tool_budget_reply(state.max_tool_calls)
+                yield _sse({
+                    "tool_limit": {
+                        "max_tool_calls": state.max_tool_calls,
+                        "message": "工具调用已到上限，正在整理已有结果…",
+                    }
+                })
+                _chat_history.append({"role": "assistant", "content": reply})
+                yield _token_event(reply)
+                return
+
+            yield _sse({"tool_start": start_payload})
+            t0 = time.monotonic()
+            try:
+                result = _agent.run_tool(fn_name, fn_args)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "result_preview": _result_preview(result),
+                    }
+                })
+            except Exception as exc:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                result = json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "error": str(exc),
+                        "result_preview": result,
+                    }
+                })
+
+            messages.append({"role": "tool", "tool_call_id": tc["id"], "content": result})
+
+            if state.record_signature(fn_name, fn_args) and not repeated_tool_name:
+                repeated_tool_name = fn_name
+
+        if repeated_tool_name:
+            reply = _repeated_tool_reply(_agent, repeated_tool_name)
+            _chat_history.append({"role": "assistant", "content": reply})
+            yield _token_event(reply)
+            return
+
+    reply = full_text_all or _max_rounds_reply()
+    if full_text_all:
+        reply = _max_rounds_reply()
+        yield _token_event(reply)
+    _chat_history.append({"role": "assistant", "content": reply})
+```
+
+- [ ] **Step 2: Run OpenAI streaming tests**
+
+Run:
+
+```bash
+pytest tests/test_web_streaming.py -q
+```
+
+Expected: the OpenAI progress, repeated loop, budget, retry, persistent busy, and lock tests PASS.
+
+- [ ] **Step 3: Run existing WeChat progress tests**
+
+Run:
+
+```bash
+pytest tests/test_wechat_progress.py -q
+```
+
+Expected: PASS. This confirms the web changes did not break the patterns copied from the WeChat side.
+
+- [ ] **Step 4: Commit OpenAI loop controls**
+
+```bash
+git add sjtu_agent/web/server.py
+git commit -m "feat: stream web agent tool progress events"
+```
+
+---
+
+### Task 4: Anthropic Streaming Parity
+
+**Files:**
+- Modify: `sjtu_agent/web/server.py`
+- Test: `tests/test_web_streaming.py`
+
+- [ ] **Step 1: Update `_stream_chat_anthropic` signature and body**
+
+Replace the whole `_stream_chat_anthropic` function with:
+
+```python
+def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState):
+    """Anthropic Messages API 流式 + tool_use 循环。"""
+    global _chat_history
+
+    system_msg = ""
+    for m in _chat_history:
+        if m["role"] == "system":
+            system_msg = m["content"]
+            break
+    api_msgs = [m for m in _chat_history if m["role"] != "system"]
+    tools = _agent._anthropic_tools()
+    full_text_all = ""
+
+    for _round in range(max_rounds):
+        full_text = ""
+        content_blocks: list[dict] = []
+        tool_inputs: dict[int, str] = {}
+
+        try:
+            with client.messages.stream(
+                model=model,
+                max_tokens=4096,
+                system=system_msg,
+                messages=api_msgs,
+                tools=tools,
+            ) as stream:
+                for event in stream:
+                    etype = getattr(event, "type", "")
+                    if etype == "content_block_start":
+                        block = event.content_block
+                        btype = getattr(block, "type", "")
+                        if btype == "text":
+                            content_blocks.append({"type": "text", "text": ""})
+                        elif btype == "tool_use":
+                            content_blocks.append({
+                                "type": "tool_use",
+                                "id": block.id,
+                                "name": block.name,
+                                "input": {},
+                            })
+                            tool_inputs[len(content_blocks) - 1] = ""
+                    elif etype == "content_block_delta":
+                        delta = event.delta
+                        dtype = getattr(delta, "type", "")
+                        if dtype == "text_delta":
+                            chunk = delta.text
+                            full_text += chunk
+                            full_text_all += chunk
+                            if content_blocks and content_blocks[-1].get("type") == "text":
+                                content_blocks[-1]["text"] += chunk
+                            yield _token_event(chunk)
+                        elif dtype == "input_json_delta":
+                            idx = event.index
+                            tool_inputs[idx] = tool_inputs.get(idx, "") + delta.partial_json
+        except Exception as exc:
+            if _chat_history and _chat_history[-1]["role"] == "user":
+                _chat_history.pop()
+            yield _sse({"error": str(exc)})
+            return
+
+        for idx, raw_json in tool_inputs.items():
+            if idx < len(content_blocks) and content_blocks[idx].get("type") == "tool_use":
+                try:
+                    content_blocks[idx]["input"] = json.loads(raw_json or "{}")
+                except Exception:
+                    content_blocks[idx]["input"] = {}
+
+        api_msgs.append({"role": "assistant", "content": content_blocks})
+        tool_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
+        if not tool_blocks:
+            _chat_history.append({"role": "assistant", "content": full_text})
+            return
+
+        tool_results = []
+        repeated_tool_name = ""
+        for block in tool_blocks:
+            fn_name = block["name"]
+            fn_args = block["input"] if isinstance(block.get("input"), dict) else {}
+            start_payload = state.next_tool_start(fn_name, fn_args)
+            if start_payload is None:
+                reply = _tool_budget_reply(state.max_tool_calls)
+                yield _sse({
+                    "tool_limit": {
+                        "max_tool_calls": state.max_tool_calls,
+                        "message": "工具调用已到上限，正在整理已有结果…",
+                    }
+                })
+                _chat_history.append({"role": "assistant", "content": reply})
+                yield _token_event(reply)
+                return
+
+            yield _sse({"tool_start": start_payload})
+            t0 = time.monotonic()
+            try:
+                result = _agent.run_tool(fn_name, fn_args)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "result_preview": _result_preview(result),
+                    }
+                })
+            except Exception as exc:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                result = json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "error": str(exc),
+                        "result_preview": result,
+                    }
+                })
+
+            tool_results.append({"type": "tool_result", "tool_use_id": block["id"], "content": result})
+            if state.record_signature(fn_name, fn_args) and not repeated_tool_name:
+                repeated_tool_name = fn_name
+
+        api_msgs.append({"role": "user", "content": tool_results})
+        if repeated_tool_name:
+            reply = _repeated_tool_reply(_agent, repeated_tool_name)
+            _chat_history.append({"role": "assistant", "content": reply})
+            yield _token_event(reply)
+            return
+
+    reply = full_text_all or _max_rounds_reply()
+    if full_text_all:
+        reply = _max_rounds_reply()
+        yield _token_event(reply)
+    _chat_history.append({"role": "assistant", "content": reply})
+```
+
+- [ ] **Step 2: Run backend tests**
+
+Run:
+
+```bash
+pytest tests/test_web_streaming.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the focused Canvas and WeChat tests**
+
+Run:
+
+```bash
+pytest tests/test_canvas_tools.py tests/test_wechat_progress.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Anthropic parity**
+
+```bash
+git add sjtu_agent/web/server.py
+git commit -m "feat: align anthropic web tool progress"
+```
+
+---
+
+### Task 5: Frontend Timeline Tests
+
+**Files:**
+- Create: `tests/test_web_static.py`
+- Test: `tests/test_web_static.py`
+
+- [ ] **Step 1: Write failing static frontend tests**
+
+Create `tests/test_web_static.py` with this content:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+
+HTML = Path("sjtu_agent/web/static/index.html").read_text(encoding="utf-8")
+
+
+def test_web_chat_has_canvas_tool_labels():
+    for name in [
+        "list_canvas_courses",
+        "get_canvas_course_announcements",
+        "get_canvas_course_quizzes",
+        "get_canvas_course_updates",
+        "get_canvas_overview",
+        "get_canvas_todo",
+        "configure_canvas_monitor",
+        "list_canvas_assignments",
+        "submit_canvas_assignment",
+        "setup_canvas",
+    ]:
+        assert name in HTML
+
+
+def test_web_chat_uses_keyed_tool_cards():
+    assert "const toolCards = new Map();" in HTML
+    assert "toolCards.set(toolId, card);" in HTML
+    assert "toolCards.get(toolId)" in HTML
+    assert "currentToolCard" not in HTML
+
+
+def test_web_chat_renders_progress_events():
+    for helper in [
+        "appendStatusRow",
+        "appendToolCard",
+        "markToolDone",
+        "appendRetryRow",
+        "appendLimitRow",
+    ]:
+        assert f"function {helper}" in HTML
+
+
+def test_web_chat_handles_structured_done_event():
+    assert "evt.done" in HTML
+    assert "payload === '[DONE]'" in HTML
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/test_web_static.py -q
+```
+
+Expected: FAIL because the current frontend still uses `currentToolCard` and lacks the new helpers.
+
+- [ ] **Step 3: Commit failing frontend tests**
+
+```bash
+git add tests/test_web_static.py
+git commit -m "test: cover web chat progress timeline"
+```
+
+---
+
+### Task 6: Frontend Progress Timeline Implementation
+
+**Files:**
+- Modify: `sjtu_agent/web/static/index.html`
+- Test: `tests/test_web_static.py`
+
+- [ ] **Step 1: Add timeline CSS**
+
+In `sjtu_agent/web/static/index.html`, replace the `.tool-card` CSS block from `/* 工具调用卡片 */` through `.tool-card .tool-label` with:
+
+```css
+    /* 工具调用时间线 */
+    .progress-row,
+    .tool-card {
+      align-self: flex-start;
+      max-width: calc(100% - 50px);
+      margin-left: 42px;
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 9px 12px;
+      font-size: 13px;
+      color: var(--text2);
+    }
+    .progress-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .progress-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--text3);
+      flex-shrink: 0;
+    }
+    .progress-row.running .progress-dot {
+      width: 14px;
+      height: 14px;
+      border: 2px solid var(--text3);
+      border-right-color: transparent;
+      background: transparent;
+      animation: spin .6s linear infinite;
+    }
+    .progress-row.done .progress-dot { background: var(--green); }
+    .progress-row.warn .progress-dot { background: var(--yellow); }
+    .progress-row.error .progress-dot { background: var(--red); }
+    .progress-text {
+      color: var(--text2);
+      line-height: 1.45;
+    }
+    .tool-card .tool-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .tool-card .tool-icon {
+      width: 14px; height: 14px;
+      border: 2px solid var(--text3);
+      border-right-color: transparent;
+      border-radius: 50%;
+      animation: spin .6s linear infinite;
+      flex-shrink: 0;
+    }
+    .tool-card.done .tool-icon {
+      border: none;
+      animation: none;
+      background: var(--green);
+      width: 14px; height: 14px;
+      position: relative;
+    }
+    .tool-card.done .tool-icon::after {
+      content: "✓";
+      color: #0a0b10;
+      font-size: 10px;
+      font-weight: 700;
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .tool-card.error .tool-icon {
+      border: none;
+      animation: none;
+      background: var(--red);
+    }
+    .tool-card.limited .tool-icon {
+      border: none;
+      animation: none;
+      background: var(--yellow);
+    }
+    .tool-card .tool-name {
+      font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
+      color: var(--text);
+      font-size: 12.5px;
+    }
+    .tool-card .tool-summary {
+      color: var(--text3);
+      font-size: 12px;
+      overflow-wrap: anywhere;
+    }
+    .tool-card .tool-caret {
+      margin-left: auto;
+      color: var(--text3);
+      font-size: 11px;
+      transition: transform .15s;
+    }
+    .tool-card.expanded .tool-caret { transform: rotate(90deg); }
+    .tool-card .tool-body {
+      display: none;
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px dashed var(--border);
+    }
+    .tool-card.expanded .tool-body { display: block; }
+    .tool-card pre {
+      background: #0a0b10;
+      border-radius: 6px;
+      padding: 8px 10px;
+      margin: 4px 0;
+      overflow-x: auto;
+      font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
+      font-size: 11.5px;
+      line-height: 1.5;
+      color: var(--text2);
+      max-height: 240px;
+      overflow-y: auto;
+    }
+    .tool-card .tool-label {
+      color: var(--text3);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: .5px;
+      margin: 6px 0 2px;
+    }
+```
+
+- [ ] **Step 2: Replace tool label and progress helper JavaScript**
+
+Replace the `TOOL_LABELS` object and `appendToolCard` function with:
+
+```javascript
+const TOOL_LABELS = {
+  get_ddls: '获取作业 DDL',
+  get_all: '获取全部信息',
+  get_next_lab: '查询物理实验安排',
+  get_schedule: '查询课表',
+  query_grades: '查询成绩',
+  check_setup: '检查配置',
+  download_assignments: '下载作业材料',
+  search_campus: '搜索校园内容',
+  browse_mysjtu: '浏览交大门户',
+  list_reminders: '查看提醒',
+  read_emails: '读取邮件',
+  send_email: '发送邮件',
+  setup_canvas: '引导配置 Canvas',
+  list_canvas_courses: '读取 Canvas 课程',
+  get_canvas_course_announcements: '读取 Canvas 公告',
+  get_canvas_course_quizzes: '读取 Canvas Quiz',
+  get_canvas_course_updates: '汇总 Canvas 课程动态',
+  get_canvas_overview: '汇总 Canvas 总览',
+  get_canvas_todo: '读取 Canvas 待办',
+  configure_canvas_monitor: '配置 Canvas 监控',
+  list_canvas_assignments: '列出 Canvas 作业',
+  submit_canvas_assignment: '上传并提交作业',
+};
+
+function escapeHtml(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function formatJson(value) {
+  if (value === undefined || value === null || value === '') return '(无)';
+  if (typeof value === 'string') {
+    try { return JSON.stringify(JSON.parse(value), null, 2); }
+    catch { return value; }
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function appendStatusRow(text, kind = 'running') {
+  const msgs = document.getElementById('chat-messages');
+  const row = document.createElement('div');
+  row.className = 'progress-row ' + kind;
+  row.innerHTML = `
+    <span class="progress-dot"></span>
+    <span class="progress-text">${escapeHtml(text)}</span>
+  `;
+  msgs.appendChild(row);
+  msgs.scrollTop = msgs.scrollHeight;
+  return row;
+}
+
+function appendRetryRow(retry) {
+  const msg = retry.message || `模型服务忙，${retry.delay_s || 0}s 后自动重试（第 ${retry.attempt || 1} 次）…`;
+  return appendStatusRow(msg, 'warn');
+}
+
+function appendLimitRow(limit) {
+  const msg = limit.message || `工具调用已到上限（${limit.max_tool_calls || '?'} 次），正在整理已有结果…`;
+  return appendStatusRow(msg, 'warn');
+}
+
+function appendToolCard(tool) {
+  const msgs = document.getElementById('chat-messages');
+  const card = document.createElement('div');
+  const label = tool.label || TOOL_LABELS[tool.name] || tool.name;
+  const summary = tool.summary ? `：${tool.summary}` : '';
+  card.className = 'tool-card running';
+  card.dataset.toolId = tool.id;
+  card.innerHTML = `
+    <div class="tool-head" onclick="this.parentElement.classList.toggle('expanded')">
+      <div class="tool-icon"></div>
+      <span class="tool-name">#${tool.index || '?'} ${escapeHtml(label)}</span>
+      <span class="tool-summary">${escapeHtml(summary)}</span>
+      <span class="tool-caret">▶</span>
+    </div>
+    <div class="tool-body">
+      <div class="tool-label">工具</div>
+      <pre>${escapeHtml(tool.name || '')}</pre>
+      <div class="tool-label">参数</div>
+      <pre>${escapeHtml(formatJson(tool.input))}</pre>
+      <div class="tool-label">结果</div>
+      <pre class="tool-result">等待中…</pre>
+    </div>
+  `;
+  msgs.appendChild(card);
+  msgs.scrollTop = msgs.scrollHeight;
+  return card;
+}
+
+function markToolDone(card, toolEnd) {
+  card.classList.remove('running');
+  card.classList.add(toolEnd.error ? 'error' : 'done');
+  const result = card.querySelector('.tool-result');
+  if (result) {
+    const preview = toolEnd.result_preview ?? toolEnd.result ?? toolEnd.error ?? '';
+    result.textContent = formatJson(preview);
+  }
+  const name = card.querySelector('.tool-name');
+  if (name && toolEnd.elapsed_ms !== undefined) {
+    const seconds = (Number(toolEnd.elapsed_ms || 0) / 1000).toFixed(1);
+    name.textContent = `${name.textContent}（${seconds}s）`;
+  }
+}
+```
+
+- [ ] **Step 3: Replace tool event handling in `sendChat`**
+
+Inside `sendChat`, replace:
+
+```javascript
+  let currentToolCard = null;
+```
+
+with:
+
+```javascript
+  const toolCards = new Map();
+  let generatedToolId = 0;
+  let streamDone = false;
+```
+
+Then replace the event handling block from `if (evt.error) {` through the closing `if (evt.tool_end)` block with:
+
+```javascript
+        if (evt.done) {
+          streamDone = true;
+          break;
+        }
+
+        if (evt.error) {
+          appendStatusRow(evt.error, 'error');
+          bubble.innerHTML = '<p style="color:var(--red)">❌ ' + escapeHtml(evt.error) + '</p>';
+          streamDone = true;
+          break;
+        }
+
+        if (evt.status) {
+          appendStatusRow(evt.status.message || evt.status.phase || '正在处理…', evt.status.phase === 'done' ? 'done' : 'running');
+        }
+
+        if (evt.retry) {
+          appendRetryRow(evt.retry);
+        }
+
+        if (evt.tool_limit) {
+          appendLimitRow(evt.tool_limit);
+        }
+
+        if (evt.token) {
+          if (firstToken) { fullText = ''; firstToken = false; }
+          fullText += evt.token;
+          bubble.innerHTML = renderMd(fullText) + '<span class="cursor"></span>';
+          document.getElementById('chat-messages').scrollTop =
+            document.getElementById('chat-messages').scrollHeight;
+        }
+
+        if (evt.tool_start) {
+          const tool = evt.tool_start;
+          const toolId = tool.id || `tool-local-${++generatedToolId}`;
+          tool.id = toolId;
+          const card = appendToolCard(tool);
+          toolCards.set(toolId, card);
+        }
+
+        if (evt.tool_end) {
+          const toolEnd = evt.tool_end;
+          const toolId = toolEnd.id || `tool-local-${++generatedToolId}`;
+          const card = toolCards.get(toolId);
+          if (card) {
+            markToolDone(card, toolEnd);
+          }
+        }
+```
+
+After the inner `for (const line of lines)` loop, add:
+
+```javascript
+      if (streamDone) break;
+```
+
+- [ ] **Step 4: Run frontend static tests**
+
+Run:
+
+```bash
+pytest tests/test_web_static.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run a JavaScript syntax check**
+
+Extract and check the inline script:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+html = Path("sjtu_agent/web/static/index.html").read_text(encoding="utf-8")
+start = html.index("<script>") + len("<script>")
+end = html.rindex("</script>")
+Path("/tmp/sjtu-agent-web-inline.js").write_text(html[start:end], encoding="utf-8")
+PY
+node --check /tmp/sjtu-agent-web-inline.js
+```
+
+Expected: `node --check` exits 0.
+
+- [ ] **Step 6: Commit frontend timeline**
+
+```bash
+git add sjtu_agent/web/static/index.html tests/test_web_static.py
+git commit -m "feat: show web chat tool progress timeline"
+```
+
+---
+
+### Task 7: Final Verification and Runtime Check
+
+**Files:**
+- Modify: none unless verification exposes a bug
+- Test: all focused tests and local web UI
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run:
+
+```bash
+pytest tests/test_web_streaming.py tests/test_web_static.py tests/test_wechat_progress.py tests/test_canvas_tools.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run:
+
+```bash
+pytest -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Start the web server locally**
+
+Run:
+
+```bash
+python -m sjtu_agent.cli web --port 8765 --no-browser
+```
+
+Expected: terminal prints a local URL for `127.0.0.1:8765` and stays running.
+
+- [ ] **Step 4: Manually verify web streaming behavior**
+
+Open `http://127.0.0.1:8765`, go to the chat page, and send:
+
+```text
+看看 Canvas 总览，尤其是 quiz 和最近通知
+```
+
+Expected:
+
+- The assistant bubble appears immediately.
+- A compact progress row says `正在思考…`.
+- Canvas tool rows appear with Chinese labels.
+- Tool rows can be expanded to show tool name, parameters, and result preview.
+- The final answer streams token by token.
+- The page does not remain stuck at `正在思考…` or `等待中`.
+
+- [ ] **Step 5: Stop the web server**
+
+Press `Ctrl-C` in the server terminal.
+
+Expected: the server exits cleanly.
+
+- [ ] **Step 6: Commit any verification fixes**
+
+If Step 1 through Step 5 required code changes, commit only those files:
+
+```bash
+git add sjtu_agent/web/server.py sjtu_agent/web/static/index.html tests/test_web_streaming.py tests/test_web_static.py
+git commit -m "fix: polish web agent progress streaming"
+```
+
+If no code changes were required, do not create an empty commit.
+
+---
+
+## Implementation Notes
+
+- Keep the current SSE `data: <json payload>\n\n` format so existing parsing continues to work.
+- Emit `{"done": true}` instead of only `data: [DONE]`. The frontend should still tolerate `data: [DONE]` for compatibility.
+- Do not show hidden model chain-of-thought. Only show public text, status messages, tool names, arguments, result previews, timings, limits, retries, and errors.
+- Use Chinese user-facing messages for progress and recovery states.
+- The backend lock is process-local by design because this web UI is a local personal server.
+- Stage carefully. Existing unrelated files are dirty in this worktree.

--- a/docs/superpowers/specs/2026-06-15-web-agent-streaming-tool-progress-design.md
+++ b/docs/superpowers/specs/2026-06-15-web-agent-streaming-tool-progress-design.md
@@ -1,0 +1,204 @@
+# Web Agent Streaming Tool Progress Design
+
+Date: 2026-06-15
+
+## Context
+
+The web agent already streams assistant text through `POST /api/chat` with
+`text/event-stream`. The current stuck-looking behavior comes from weaker tool
+loop control and UI state handling, not from a lack of streaming.
+
+Current findings:
+
+- `sjtu_agent/web/server.py` streams `{token}`, `{tool_start}`, `{tool_end}`,
+  and `{error}` events.
+- The web backend has `MAX_TOOL_ROUNDS = 20`, but no total tool-call budget,
+  repeated-call guard, or transient model retry handling.
+- The frontend tracks tool calls with a single `currentToolCard`, which can
+  mismatch when a model emits multiple tool calls in one turn.
+- The frontend tool label map is missing many Canvas tools, so users see raw
+  function names for important operations.
+- The web server is threaded while chat history is global, so concurrent chat
+  requests can overlap and make upstream concurrency errors more likely.
+
+The desired UX is option C: show a concise ChatGPT-style progress summary by
+default, with a way to expand and inspect full tool parameters and results.
+
+## Goals
+
+- Keep assistant text streaming token by token.
+- Make every long-running step visible to the user.
+- Show concise progress by default and complete tool details on demand.
+- Stop runaway tool loops before the user sees an endless "thinking" state.
+- Translate transient upstream errors into useful Chinese status and recovery
+  messages.
+- Keep this change scoped to the web agent path.
+
+## Non-Goals
+
+- Do not refactor CLI, WeChat, and web into one shared runner in this change.
+- Do not change Canvas tool behavior beyond labels, summaries, and progress
+  visibility.
+- Do not expose hidden model chain-of-thought. Tool calls, tool arguments,
+  timings, retries, and public status should be visible; private reasoning
+  should not be surfaced.
+
+## Backend Design
+
+`POST /api/chat` remains an SSE endpoint. It will emit a more structured event
+stream while preserving compatibility with existing `{token: "..."}` events.
+
+Event examples:
+
+```json
+{"status":{"phase":"thinking","message":"正在思考…"}}
+{"tool_start":{"id":"tool-1","index":1,"name":"get_canvas_course_quizzes","label":"正在读取 Canvas Quiz","summary":"course=ECE2300"}}
+{"tool_end":{"id":"tool-1","index":1,"name":"get_canvas_course_quizzes","elapsed_ms":1234,"result_preview":"..."}}
+{"retry":{"attempt":1,"delay_s":2,"message":"模型服务忙，2s 后自动重试…"}}
+{"tool_limit":{"max_tool_calls":12,"message":"工具调用已到上限，正在整理已有结果…"}}
+{"token":"最终回答的一部分"}
+{"done":true}
+```
+
+The backend should add these controls to both OpenAI-style and Anthropic-style
+streaming paths:
+
+- Total tool-call budget: default 12 tool calls per user turn.
+- Repeated-call guard: if the same tool name and normalized arguments are called
+  3 times in one turn, stop the loop and ask the user to narrow the request or
+  provide a course code / Canvas course name.
+- Max-round guard: if model rounds are exhausted, return a friendly stop message
+  instead of attempting an opaque final no-tools call that can also hang.
+- Transient model retry: retry `Concurrency limit exceeded`, `rate limit`,
+  `too many requests`, and `please retry later` errors with short delays, and
+  stream `retry` events while waiting.
+- Tool timings: measure each `agent.run_tool` call and include `elapsed_ms` in
+  the matching `tool_end` event.
+- Tool IDs: include stable per-turn IDs such as `tool-1`, `tool-2` so the
+  frontend can update the correct UI row.
+
+The backend should reuse the existing WeChat progress concepts where practical:
+tool labels, argument summaries, transient error detection, friendly busy
+messages, and tool budget wording.
+
+## Frontend Design
+
+The chat surface will have three layers during a response:
+
+- Assistant answer bubble: keeps streaming public text token by token.
+- Progress timeline: shows concise status rows by default.
+- Expandable tool details: shows full tool name, parameters, result preview,
+  elapsed time, and error detail when the user opens a row.
+
+Default timeline examples:
+
+```text
+正在思考…
+#1 正在读取 Canvas Quiz：course=ECE2300
+#1 已完成（1.2s）
+#2 正在汇总 Canvas 总览
+模型服务忙，2s 后自动重试（第 1 次）
+开始生成回复…
+```
+
+Frontend state changes:
+
+- Replace the single `currentToolCard` with a `Map` keyed by `tool_start.id`.
+- If a legacy event lacks `id`, fall back to a generated sequential ID.
+- Update tool rows by ID when `tool_end` arrives.
+- Keep default rows compact; allow users to expand a tool row for full JSON.
+- Mark rows as `running`, `done`, `error`, or `limited`.
+- On `tool_limit`, `retry`, and friendly backend errors, update the timeline so
+  the user is never left at "正在思考" or "等待中".
+
+Canvas tool labels should be expanded to cover:
+
+- `list_canvas_courses`
+- `get_canvas_course_announcements`
+- `get_canvas_course_quizzes`
+- `get_canvas_course_updates`
+- `get_canvas_overview`
+- `get_canvas_todo`
+- `configure_canvas_monitor`
+- `list_canvas_assignments`
+- `submit_canvas_assignment`
+- `setup_canvas`
+
+The UI should not expose hidden model reasoning. It should expose observable
+execution: statuses, tool names, arguments, result previews, timings, retries,
+limits, and errors.
+
+## Concurrency Design
+
+The frontend already prevents duplicate sends with `isSending`, but the backend
+also needs a guard because refreshes, multiple tabs, or manual requests can
+bypass frontend state.
+
+Short-term design:
+
+- Add a process-local chat lock around one `/api/chat` turn.
+- If a second request arrives while a turn is active, return an SSE error/status
+  saying the previous request is still running and the user should wait or retry
+  after it finishes.
+- Release the lock in a `finally` path when streaming completes or the client
+  disconnects.
+
+This does not solve multi-user hosting, but the web UI is a local personal
+server, so a process-local lock fits the current deployment model.
+
+## Error Handling
+
+User-facing errors should be actionable and Chinese-first.
+
+- Transient upstream concurrency/rate errors: stream retry status, retry a small
+  fixed number of times, then return a friendly busy message.
+- Tool budget reached: stream `tool_limit`, stop further tool execution, and ask
+  the model or backend to summarize what is already known.
+- Repeated tool loop: stop after 3 identical tool signatures and tell the user
+  the course/query may be too vague.
+- Tool execution exception: emit a tool row error and continue to a final answer
+  when possible.
+- Client disconnect: stop writing, release the backend chat lock, and avoid
+  leaving the server stuck in a busy state.
+
+## Testing Plan
+
+Backend unit tests:
+
+- Streams `tool_start` and `tool_end` with stable IDs, indexes, labels,
+  summaries, and elapsed time.
+- Stops after total tool budget and emits `tool_limit`.
+- Stops repeated identical tool calls after 3 executions.
+- Retries transient model concurrency errors and emits `retry`.
+- Returns a friendly busy message if transient errors persist.
+- Releases the chat lock after normal completion and after errors.
+
+Frontend verification:
+
+- Multiple tool starts before tool ends update the correct rows by ID.
+- Canvas tool labels render as Chinese progress labels.
+- `retry`, `tool_limit`, and `error` events replace the indefinite thinking
+  state with explicit status.
+- The details panel can expand/collapse and shows parameters plus result preview.
+
+Manual verification:
+
+- Start the web UI and ask a Canvas quiz or Canvas overview question.
+- Confirm text streams as it is generated.
+- Confirm progress rows appear immediately for thinking, tools, retries, and
+  answer generation.
+- Confirm no request remains stuck at "正在思考" or "等待中" after a limit or
+  error condition.
+
+## Acceptance Criteria
+
+- A web Canvas query that triggers tools shows visible progress within one SSE
+  event after the model chooses a tool.
+- Multiple tool calls in one model response render as separate rows and finish
+  independently.
+- A repeated or runaway tool loop stops with a clear message before exceeding 12
+  total tool calls.
+- Upstream concurrency-limit errors no longer show raw provider text as the main
+  user-facing answer.
+- The web agent still streams final assistant text token by token.
+- Tests cover backend loop control and event emission behavior.

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -64,6 +64,9 @@ ILINK_BASE = "https://ilinkai.weixin.qq.com"
 
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[mKABCDEFGHJKST]')
 _TMP_DIR = Path(tempfile.mkdtemp(prefix="sjtu_wechat_"))
+_CANVAS_COURSE_INDEX_TTL = 1800
+_canvas_course_index_cache: dict = {"expires_at": 0.0, "courses": []}
+_LLM_TRANSIENT_RETRY_DELAYS = (2.0, 5.0)
 
 
 # ── ilink HTTP 客户端 ──────────────────────────────────────────────────────────
@@ -277,12 +280,61 @@ def _build_date_ctx() -> str:
     )
 
 
+def _get_canvas_course_index() -> list[dict]:
+    now = time.monotonic()
+    cached = _canvas_course_index_cache.get("courses") or []
+    if cached and now < float(_canvas_course_index_cache.get("expires_at", 0)):
+        return cached
+    try:
+        result = agent.tool_list_canvas_courses()
+    except Exception:
+        return cached if isinstance(cached, list) else []
+    courses = result.get("courses", []) if isinstance(result, dict) else []
+    slim_courses = []
+    for course in courses[:30]:
+        if not isinstance(course, dict):
+            continue
+        slim_courses.append({
+            "course_id": course.get("course_id"),
+            "name": course.get("name", ""),
+            "course_code": course.get("course_code", ""),
+        })
+    _canvas_course_index_cache.update({
+        "expires_at": now + _CANVAS_COURSE_INDEX_TTL,
+        "courses": slim_courses,
+    })
+    return slim_courses
+
+
+def _build_canvas_course_ctx() -> str:
+    courses = _get_canvas_course_index()
+    if not courses:
+        return ""
+    lines = []
+    for course in courses:
+        course_id = course.get("course_id", "")
+        name = str(course.get("name", "") or "").strip()
+        code = str(course.get("course_code", "") or "").strip()
+        lines.append(f"- {course_id} | {name} | {code}")
+    return (
+        "\n\n## 当前 Canvas 课程索引（微信侧辅助识别）\n"
+        "当用户用简称、数字或口语化说法指代课程时，优先参考这个索引选择 Canvas 工具的 course 参数；"
+        "用户说“230这门课”时，可从 ECE2300JSU2026-1 这类课程名/代码中识别为 ECE2300。"
+        "若多个课程都可能匹配，先列候选并让用户确认，不要臆断。\n"
+        + "\n".join(lines)
+    )
+
+
+def _build_system_ctx() -> str:
+    return _build_date_ctx() + _build_canvas_course_ctx()
+
+
 def _init_messages(sess: dict) -> None:
     if sess["messages"]:
         return
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_date_ctx(),
+        "content": agent.SYSTEM_PROMPT + _build_system_ctx(),
     })
 
 
@@ -290,7 +342,7 @@ def _capture_turn(sess: dict, user_text: str) -> str:
     """运行一轮对话，返回 Agent 回复文本。"""
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx()
+        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_system_ctx()
     sess["messages"].append({"role": "user", "content": user_text})
 
     buf = io.StringIO()
@@ -333,7 +385,7 @@ def _model_supports_vision(model: str) -> bool:
 def _capture_turn_multimodal(sess: dict, content: list) -> str:
     _init_messages(sess)
     if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx()
+        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_system_ctx()
     sess["messages"].append({"role": "user", "content": content})
 
     buf = io.StringIO()
@@ -362,6 +414,383 @@ def _capture_turn_multimodal(sess: dict, content: list) -> str:
                     return "\n".join(texts).strip() or "(已完成)"
         return "(已完成)"
     return clean[idx + len(marker):].strip()
+
+
+def _emit_progress(on_progress, event_type: str, payload: dict | None = None) -> None:
+    try:
+        on_progress(event_type, payload or {})
+    except Exception:
+        pass
+
+
+def _strip_thinking_text(text: str) -> str:
+    return re.sub(r"<think>.*?</think>", "", text or "", flags=re.DOTALL).strip()
+
+
+def _canonical_tool_signature(name: str, args: dict) -> str:
+    try:
+        args_text = json.dumps(args or {}, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        args_text = "{}"
+    return f"{name}:{args_text}"
+
+
+def _repeated_tool_reply(tool_name: str) -> str:
+    label = _progress_label(tool_name)
+    return (
+        f"连续调用「{label}」仍未得到可继续推进的结果。\n"
+        "这通常是课程名没有匹配到 Canvas 课程，或当前查询条件过于模糊。\n"
+        "请尽量改用课程代码/Canvas 课程名再试，例如 `ECE2300`。"
+    )
+
+
+def _max_rounds_reply() -> str:
+    return (
+        "这轮对话的工具调用次数过多，我先暂停以避免一直卡住。\n"
+        "请把问题缩小一点，或直接提供课程代码/作业名称后再试。"
+    )
+
+
+def _tool_budget_reply(max_tool_calls: int) -> str:
+    return (
+        f"工具调用次数已经达到上限（{max_tool_calls} 次），我先停止继续查找，避免微信里一直刷状态。\n"
+        "如果你要看 Canvas 的全局 quiz、通知和最近任务，请直接说“Canvas 总览”；"
+        "我会优先使用 get_canvas_overview 一次性汇总。"
+    )
+
+
+def _is_transient_llm_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "concurrency limit exceeded",
+            "rate limit",
+            "too many requests",
+            "please retry later",
+        )
+    )
+
+
+def _llm_busy_reply() -> str:
+    return (
+        "模型服务现在有点忙，同一个账号的并发请求被上游限制了。\n"
+        "我已经自动重试过，还是没抢到空位。请稍等半分钟后再发一次。"
+    )
+
+
+def _summarize_tool_args(name: str, args: dict) -> str:
+    if not isinstance(args, dict):
+        return ""
+    parts = []
+    course = args.get("course")
+    if course:
+        parts.append(f"course={course}")
+    include = args.get("include")
+    if include:
+        if isinstance(include, list):
+            include_text = ",".join(str(x) for x in include[:4])
+        else:
+            include_text = str(include)
+        parts.append(f"include={include_text}")
+    limit = args.get("limit")
+    if limit is not None:
+        parts.append(f"limit={limit}")
+    include_past = args.get("include_past")
+    if include_past:
+        parts.append("含过去项目")
+    return "；".join(parts[:4])
+
+
+def _streamed_turn(
+    sess: dict,
+    user_text: str,
+    on_progress,
+    max_rounds: int = 20,
+    max_tool_calls: int = 12,
+) -> str:
+    """Run one text turn while reporting coarse progress events."""
+    import json as _json
+    import time as _time
+
+    _init_messages(sess)
+    if sess["messages"] and sess["messages"][0]["role"] == "system":
+        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_system_ctx()
+    sess["messages"].append({"role": "user", "content": user_text})
+
+    client = sess["client_box"][0]
+    model = sess["model_box"][0]
+    is_anthropic = agent._is_anthropic_model(model)
+    full_text = ""
+    saw_first_token = False
+    tool_call_counts: dict[str, int] = {}
+    total_tool_calls = 0
+
+    def first_token() -> None:
+        nonlocal saw_first_token
+        if saw_first_token:
+            return
+        saw_first_token = True
+        _emit_progress(on_progress, "first_token")
+
+    def next_tool_index() -> int | None:
+        nonlocal total_tool_calls
+        if total_tool_calls >= max_tool_calls:
+            return None
+        total_tool_calls += 1
+        return total_tool_calls
+
+    if is_anthropic:
+        system_msg = sess["messages"][0]["content"] if sess["messages"][0]["role"] == "system" else ""
+        api_msgs = [m for m in sess["messages"] if m["role"] != "system"]
+        tools = agent._anthropic_tools()
+
+        for _ in range(max_rounds):
+            content_blocks: list[dict] = []
+            tool_inputs: dict[int, str] = {}
+
+            with client.messages.stream(
+                model=model,
+                max_tokens=4096,
+                system=system_msg,
+                messages=api_msgs,
+                tools=tools,
+            ) as stream:
+                for event in stream:
+                    etype = getattr(event, "type", "")
+                    if etype == "content_block_start":
+                        block = event.content_block
+                        btype = getattr(block, "type", "")
+                        if btype == "text":
+                            content_blocks.append({"type": "text", "text": ""})
+                        elif btype == "tool_use":
+                            content_blocks.append({
+                                "type": "tool_use",
+                                "id": block.id,
+                                "name": block.name,
+                                "input": {},
+                            })
+                            tool_inputs[len(content_blocks) - 1] = ""
+                    elif etype == "content_block_delta":
+                        delta = event.delta
+                        dtype = getattr(delta, "type", "")
+                        if dtype == "text_delta":
+                            chunk = delta.text
+                            full_text += chunk
+                            if content_blocks and content_blocks[-1].get("type") == "text":
+                                content_blocks[-1]["text"] += chunk
+                            first_token()
+                        elif dtype == "input_json_delta":
+                            idx = event.index
+                            tool_inputs[idx] = tool_inputs.get(idx, "") + delta.partial_json
+
+            for idx, raw_json in tool_inputs.items():
+                if idx < len(content_blocks) and content_blocks[idx].get("type") == "tool_use":
+                    try:
+                        content_blocks[idx]["input"] = _json.loads(raw_json or "{}")
+                    except Exception:
+                        content_blocks[idx]["input"] = {}
+
+            api_msgs.append({"role": "assistant", "content": content_blocks})
+            sess["messages"].append({"role": "assistant", "content": content_blocks})
+            tool_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
+            if not tool_blocks:
+                return full_text
+
+            tool_results = []
+            repeated_tool_name = ""
+            for block in tool_blocks:
+                fn_name = block["name"]
+                fn_args = block["input"] if isinstance(block.get("input"), dict) else {}
+                tool_index = next_tool_index()
+                if tool_index is None:
+                    reply = _tool_budget_reply(max_tool_calls)
+                    _emit_progress(on_progress, "tool_limit", {"max_tool_calls": max_tool_calls})
+                    sess["messages"].append({"role": "assistant", "content": reply})
+                    return reply
+                _emit_progress(on_progress, "tool_start", {
+                    "name": fn_name,
+                    "index": tool_index,
+                    "summary": _summarize_tool_args(fn_name, fn_args),
+                })
+                t0 = _time.monotonic()
+                result = agent.run_tool(fn_name, fn_args)
+                elapsed_ms = int((_time.monotonic() - t0) * 1000)
+                _emit_progress(on_progress, "tool_end", {
+                    "name": fn_name,
+                    "index": tool_index,
+                    "elapsed_ms": elapsed_ms,
+                })
+                tool_results.append({"type": "tool_result", "tool_use_id": block["id"], "content": result})
+                sig = _canonical_tool_signature(fn_name, fn_args)
+                tool_call_counts[sig] = tool_call_counts.get(sig, 0) + 1
+                if tool_call_counts[sig] >= 3 and not repeated_tool_name:
+                    repeated_tool_name = fn_name
+            api_msgs.append({"role": "user", "content": tool_results})
+            sess["messages"].append({"role": "user", "content": tool_results})
+            if repeated_tool_name:
+                reply = _repeated_tool_reply(repeated_tool_name)
+                sess["messages"].append({"role": "assistant", "content": reply})
+                return reply
+        reply = _strip_thinking_text(full_text) or _max_rounds_reply()
+        sess["messages"].append({"role": "assistant", "content": reply})
+        return reply
+
+    messages = list(sess["messages"])
+    for _ in range(max_rounds):
+        attempts = len(_LLM_TRANSIENT_RETRY_DELAYS) + 1
+        for attempt in range(attempts):
+            text_so_far = ""
+            tool_calls_map: dict[int, dict] = {}
+            try:
+                stream = client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    tools=agent.TOOLS,
+                    tool_choice="auto",
+                    stream=True,
+                    timeout=180,
+                )
+                for chunk in stream:
+                    if not chunk.choices:
+                        continue
+                    delta = chunk.choices[0].delta
+                    if delta.content:
+                        text_so_far += delta.content
+                        first_token()
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            idx = tc.index
+                            if idx not in tool_calls_map:
+                                tool_calls_map[idx] = {"id": tc.id or "", "name": "", "arguments": ""}
+                            if tc.id:
+                                tool_calls_map[idx]["id"] = tc.id
+                            if tc.function:
+                                if tc.function.name:
+                                    tool_calls_map[idx]["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    tool_calls_map[idx]["arguments"] += tc.function.arguments
+                break
+            except Exception as exc:
+                if not _is_transient_llm_error(exc):
+                    raise
+                if attempt >= attempts - 1:
+                    reply = _llm_busy_reply()
+                    sess["messages"].append({"role": "assistant", "content": reply})
+                    return reply
+                delay = _LLM_TRANSIENT_RETRY_DELAYS[attempt]
+                _emit_progress(on_progress, "retry", {"attempt": attempt + 1, "delay_s": delay})
+                time.sleep(delay)
+
+        if not tool_calls_map:
+            clean_text = _strip_thinking_text(text_so_far)
+            full_text += clean_text
+            sess["messages"].append({"role": "assistant", "content": clean_text})
+            return full_text
+
+        clean_text_so_far = _strip_thinking_text(text_so_far)
+        full_text += clean_text_so_far
+        tool_calls_payload = []
+        for idx in sorted(tool_calls_map):
+            entry = tool_calls_map[idx]
+            tool_calls_payload.append({
+                "id": entry["id"],
+                "type": "function",
+                "function": {"name": entry["name"], "arguments": entry["arguments"]},
+            })
+        assistant_msg = {
+            "role": "assistant",
+            "content": clean_text_so_far or None,
+            "tool_calls": tool_calls_payload,
+        }
+        messages.append(assistant_msg)
+        sess["messages"].append(assistant_msg)
+
+        repeated_tool_name = ""
+        for tc in tool_calls_payload:
+            fn_name = tc["function"]["name"]
+            try:
+                fn_args = _json.loads(tc["function"]["arguments"] or "{}")
+            except Exception:
+                fn_args = {}
+            tool_index = next_tool_index()
+            if tool_index is None:
+                reply = _tool_budget_reply(max_tool_calls)
+                _emit_progress(on_progress, "tool_limit", {"max_tool_calls": max_tool_calls})
+                sess["messages"].append({"role": "assistant", "content": reply})
+                return reply
+            _emit_progress(on_progress, "tool_start", {
+                "name": fn_name,
+                "index": tool_index,
+                "summary": _summarize_tool_args(fn_name, fn_args),
+            })
+            t0 = _time.monotonic()
+            result = agent.run_tool(fn_name, fn_args)
+            elapsed_ms = int((_time.monotonic() - t0) * 1000)
+            _emit_progress(on_progress, "tool_end", {
+                "name": fn_name,
+                "index": tool_index,
+                "elapsed_ms": elapsed_ms,
+            })
+            tool_msg = {"role": "tool", "tool_call_id": tc["id"], "content": result}
+            messages.append(tool_msg)
+            sess["messages"].append(tool_msg)
+            sig = _canonical_tool_signature(fn_name, fn_args)
+            tool_call_counts[sig] = tool_call_counts.get(sig, 0) + 1
+            if tool_call_counts[sig] >= 3 and not repeated_tool_name:
+                repeated_tool_name = fn_name
+        if repeated_tool_name:
+            reply = _repeated_tool_reply(repeated_tool_name)
+            sess["messages"].append({"role": "assistant", "content": reply})
+            return reply
+
+    reply = _strip_thinking_text(full_text) or _max_rounds_reply()
+    sess["messages"].append({"role": "assistant", "content": reply})
+    return reply
+
+
+def _progress_label(tool_name: str) -> str:
+    return agent._TOOL_LABELS.get(tool_name, tool_name)
+
+
+def _make_progress_sender(client: ILinkClient, to_user: str, ctx_token: str):
+    sent_first_token = {"value": False}
+
+    def send(text: str) -> None:
+        try:
+            client.send(text, to_user_id=to_user, context_token=ctx_token)
+        except Exception:
+            pass
+
+    def on_progress(event_type: str, payload: dict) -> None:
+        if event_type == "thinking":
+            send("⏳ 正在思考…")
+        elif event_type == "tool_start":
+            label = _progress_label(str(payload.get("name", "")))
+            index = payload.get("index")
+            prefix = f"#{index} " if index else ""
+            summary = str(payload.get("summary", "") or "").strip()
+            suffix = f"：{summary}" if summary else ""
+            send(f"⚙️ {prefix}{label}{suffix}…")
+        elif event_type == "tool_end":
+            label = _progress_label(str(payload.get("name", "")))
+            index = payload.get("index")
+            prefix = f"#{index} " if index else ""
+            elapsed = float(payload.get("elapsed_ms", 0)) / 1000
+            send(f"✅ {prefix}{label}（{elapsed:.1f}s）")
+        elif event_type == "retry":
+            attempt = int(payload.get("attempt", 1) or 1)
+            delay = float(payload.get("delay_s", 0) or 0)
+            delay_text = f"{delay:.0f}s" if delay == int(delay) else f"{delay:.1f}s"
+            send(f"⏳ 模型服务忙，{delay_text} 后自动重试（第 {attempt} 次）…")
+        elif event_type == "tool_limit":
+            max_tool_calls = int(payload.get("max_tool_calls", 0) or 0)
+            send(f"⏹️ 工具调用已到上限（{max_tool_calls} 次），正在整理已有结果…")
+        elif event_type == "first_token" and not sent_first_token["value"]:
+            sent_first_token["value"] = True
+            send("💬 开始生成回复…")
+
+    return on_progress
 
 
 def _guess_suffix_from_url(url: str, default: str = ".bin") -> str:
@@ -594,6 +1023,7 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
 
     # 发送"正在输入"状态
     client.send_typing(ctx_token)
+    on_progress = _make_progress_sender(client, from_user, ctx_token)
 
     # 调用 agent 处理
     if _reply_lock.locked():
@@ -602,6 +1032,7 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
 
     with _reply_lock:
         try:
+            on_progress("thinking", {})
             sess  = _get_or_create_session()
             model = sess["model_box"][0]
             reply = ""
@@ -619,7 +1050,7 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
                     )
                     if text:
                         prompt += f"\n\n用户补充：{text}"
-                    reply = _capture_turn(sess, prompt)
+                    reply = _streamed_turn(sess, prompt, on_progress)
                     _send_chunks(client, reply, from_user, ctx_token)
                     return
 
@@ -649,6 +1080,7 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
                             "type": "image_url",
                             "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
                         })
+                    on_progress("first_token", {})
                     reply = _capture_turn_multimodal(sess, content)
                 else:
                     parsed_ctx, parse_err = _build_parser_context(local_path, media_type=media.get("type", "file"))
@@ -666,9 +1098,9 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
                     if text:
                         user_text += f"\n\n用户补充：{text}"
                     user_text += "\n\n请根据已提取内容回答；若信息不足，再向用户追问。"
-                    reply = _capture_turn(sess, user_text)
+                    reply = _streamed_turn(sess, user_text, on_progress)
             else:
-                reply = _capture_turn(sess, text)
+                reply = _streamed_turn(sess, text, on_progress)
             # 微信消息长度限制约 4096，超出则分段发送
             _send_chunks(client, reply, from_user, ctx_token)
         except Exception as e:

--- a/sjtu_agent/agent/__init__.py
+++ b/sjtu_agent/agent/__init__.py
@@ -17,7 +17,7 @@ from sjtu_agent.agent.tools import (
     tool_execute_python, tool_get_user_profile, tool_update_user_profile,
     tool_list_canvas_courses, tool_get_canvas_course_announcements,
     tool_get_canvas_course_quizzes, tool_get_canvas_course_updates,
-    tool_get_canvas_todo, tool_configure_canvas_monitor,
+    tool_get_canvas_overview, tool_get_canvas_todo, tool_configure_canvas_monitor,
     tool_list_canvas_assignments, tool_submit_canvas_assignment,
     tool_refresh_mysjtu_catalog,
     _fetch_ddls_parallel, _ddl_cache_get,

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -329,6 +329,8 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 - Canvas 相关能力依赖 canvas_token；若缺失或失效，优先调用 setup_canvas，不要只说“去配置 token”。
 
+- 用户问跨课程的「Canvas 总览」「quiz」「最新通知/公告」「最近任务/待办」组合问题时，优先调用 get_canvas_overview；不要逐门课循环调用 get_canvas_course_updates。
+
 - 用户把文件拖入终端后会得到路径（如 `/Users/xxx/hw1.pdf`），说「帮我提交这个文件」「帮我交作业」→ submit_canvas_assignment
 
 - **提交流程（必须两步走）：**
@@ -487,6 +489,20 @@ def build_system_prompt(*extra_sections: str) -> str:
 
 _TOOL_LABELS = {
 
+    "list_canvas_courses":      "正在读取 Canvas 课程",
+
+    "get_canvas_course_announcements": "正在读取 Canvas 公告",
+
+    "get_canvas_course_quizzes": "正在读取 Canvas Quiz",
+
+    "get_canvas_course_updates": "正在汇总 Canvas 课程动态",
+
+    "get_canvas_overview": "正在汇总 Canvas 总览",
+
+    "get_canvas_todo":          "正在读取 Canvas 待办",
+
+    "configure_canvas_monitor": "正在配置 Canvas 监控",
+
     "list_canvas_assignments":  "正在列出 Canvas 作业",
 
     "submit_canvas_assignment": "正在上传并提交作业",
@@ -574,8 +590,5 @@ _TOOL_LABELS = {
     "qq_remove_user":         "正在删除 QQ 白名单用户…",
 
 }
-
-
-
 
 

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -498,6 +498,26 @@ TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "get_canvas_overview",
+            "description": "一次性汇总 Canvas 全局 todo、各课程近期公告和 quiz。用户问“最新通知、quiz、最近任务、Canvas 总览”等跨课程问题时优先调用，避免逐门课循环调用。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "description": "每类每门课最多返回数量，默认 5"},
+                    "course_limit": {"type": "integer", "description": "最多扫描课程数，默认 8"},
+                    "since_days": {"type": "integer", "description": "公告只看最近多少天，默认 14"},
+                    "include_past": {"type": "boolean", "description": "是否包含已过期 quiz，默认 false"},
+                    "include_todo": {"type": "boolean", "description": "是否包含全局 todo/planner，默认 true"},
+                    "include_announcements": {"type": "boolean", "description": "是否包含公告，默认 true"},
+                    "include_quizzes": {"type": "boolean", "description": "是否包含 quiz，默认 true"},
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_canvas_todo",
             "description": "查看 Canvas 全局 todo 和 planner items，用于回答近期待办。",
             "parameters": {
@@ -3344,6 +3364,62 @@ def tool_get_canvas_course_updates(
         return _canvas_error_payload(exc)
 
 
+def tool_get_canvas_overview(
+    limit: int = 5,
+    course_limit: int = 8,
+    since_days: int = 14,
+    include_past: bool = False,
+    include_todo: bool = True,
+    include_announcements: bool = True,
+    include_quizzes: bool = True,
+) -> dict:
+    try:
+        client = _make_canvas_client()
+        safe_limit = max(1, min(int(limit or 5), 20))
+        safe_course_limit = max(1, min(int(course_limit or 8), 20))
+        courses_result = client.list_courses(include_tabs=False, include_teachers=False)
+        courses = [
+            course for course in courses_result.get("courses", [])
+            if isinstance(course, dict)
+        ][:safe_course_limit]
+        overview_courses = []
+        warnings: list[str] = []
+
+        todo = client.list_todo(limit=safe_limit) if include_todo else {"ok": True, "count": 0, "items": []}
+
+        for course in courses:
+            course_id = course.get("course_id")
+            if course_id is None:
+                continue
+            item: dict = {"course": course}
+            if include_quizzes:
+                try:
+                    item["quizzes"] = client.list_quizzes(course_id, include_past=include_past)
+                except CanvasError as exc:
+                    warnings.append(f"{course.get('name') or course_id} quizzes: {exc.message}")
+            if include_announcements:
+                try:
+                    item["announcements"] = client.list_announcements(
+                        course_id,
+                        limit=safe_limit,
+                        since_days=since_days,
+                    )
+                except CanvasError as exc:
+                    warnings.append(f"{course.get('name') or course_id} announcements: {exc.message}")
+            overview_courses.append(item)
+
+        return {
+            "ok": True,
+            "courses_count": len(overview_courses),
+            "scanned_course_limit": safe_course_limit,
+            "todo": todo,
+            "courses": overview_courses,
+            "warnings": warnings,
+        }
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
 def tool_get_canvas_todo(limit: int = 20) -> dict:
     try:
         client = _make_canvas_client()
@@ -3571,6 +3647,7 @@ def run_tool(name: str, args: dict) -> str:
         elif name == "get_canvas_course_announcements": r = tool_get_canvas_course_announcements(**args)
         elif name == "get_canvas_course_quizzes": r = tool_get_canvas_course_quizzes(**args)
         elif name == "get_canvas_course_updates": r = tool_get_canvas_course_updates(**args)
+        elif name == "get_canvas_overview":       r = tool_get_canvas_overview(**args)
         elif name == "get_canvas_todo":          r = tool_get_canvas_todo(**args)
         elif name == "configure_canvas_monitor": r = tool_configure_canvas_monitor(**args)
         elif name == "list_canvas_assignments":  r = tool_list_canvas_assignments(**args)

--- a/sjtu_agent/canvas_client.py
+++ b/sjtu_agent/canvas_client.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 import hashlib
 import re
+import time
 from datetime import datetime, timedelta, timezone
 from html import unescape
 from typing import Any
 
 import requests
 
-from sjtu_agent.paths import CONFIG_PATH, read_json_safe
+from sjtu_agent.paths import CONFIG_PATH, DATA_DIR, atomic_write_json, read_json_safe
 
 DEFAULT_CANVAS_BASE_URL = "https://oc.sjtu.edu.cn"
+CANVAS_COURSES_CACHE_PATH = DATA_DIR / "canvas_courses_cache.json"
 CST = timezone(timedelta(hours=8))
 
 
@@ -56,6 +58,80 @@ def _truncate(value: str, limit: int = 240) -> str:
 
 def _hash_text(value: str) -> str:
     return hashlib.sha256((value or "").encode("utf-8")).hexdigest()[:16]
+
+
+def _course_lookup_text(course: dict) -> str:
+    return " ".join(
+        str(course.get(key, "") or "")
+        for key in ("name", "course_code")
+    ).lower()
+
+
+def _course_number_tokens(text: str) -> list[str]:
+    tokens = re.findall(r"\d{3,6}", text or "")
+    unique: list[str] = []
+    for token in tokens:
+        if token not in unique:
+            unique.append(token)
+    return unique
+
+
+def _slim_courses_for_cache(courses: list[dict]) -> list[dict]:
+    slim_courses = []
+    for course in courses:
+        if not isinstance(course, dict):
+            continue
+        slim_courses.append({
+            "course_id": course.get("course_id"),
+            "name": course.get("name", ""),
+            "course_code": course.get("course_code", ""),
+            "workflow_state": course.get("workflow_state", ""),
+            "default_view": course.get("default_view", ""),
+        })
+    return slim_courses
+
+
+def _save_course_cache(courses: list[dict]) -> None:
+    try:
+        atomic_write_json(CANVAS_COURSES_CACHE_PATH, {
+            "courses": _slim_courses_for_cache(courses),
+            "updated_at": datetime.now(CST).isoformat(),
+        })
+    except Exception:
+        pass
+
+
+def _load_course_cache() -> list[dict]:
+    data = read_json_safe(CANVAS_COURSES_CACHE_PATH, default={})
+    courses = data.get("courses", []) if isinstance(data, dict) else []
+    if not isinstance(courses, list):
+        return []
+    result = []
+    for course in courses:
+        if not isinstance(course, dict) or not course.get("course_id"):
+            continue
+        cached = dict(course)
+        cached["from_cache"] = True
+        result.append(cached)
+    return result
+
+
+def _match_courses_by_number(courses: list[dict], text: str) -> tuple[str, list[dict]]:
+    groups: list[tuple[int, int, int, str, list[dict]]] = []
+    for order, token in enumerate(_course_number_tokens(text)):
+        matches = []
+        for course in courses:
+            lookup = _course_lookup_text(course)
+            digits = "".join(re.findall(r"\d+", lookup))
+            course_id = str(course.get("course_id", ""))
+            if token == course_id or token in digits:
+                matches.append(course)
+        if matches:
+            groups.append((len(matches), -len(token), order, token, matches))
+    if not groups:
+        return "", []
+    _, _, _, token, matches = sorted(groups, key=lambda item: item[:4])[0]
+    return token, matches
 
 
 class CanvasClient:
@@ -128,20 +204,46 @@ class CanvasClient:
         current_params = params or {}
         pages = 0
         while next_url and pages < max_pages:
-            try:
-                response = self.session.get(next_url, params=current_params, timeout=self.timeout)
-            except requests.Timeout as exc:
-                raise CanvasError("timeout", f"Canvas 请求超时: {path}") from exc
-            except requests.RequestException as exc:
-                raise CanvasError("request_error", f"Canvas 请求失败: {exc}") from exc
-            try:
-                payload = response.json()
-            except Exception as exc:
+            response = None
+            payload = None
+            last_json_error: Exception | None = None
+            for attempt in range(3):
+                try:
+                    response = self.session.get(next_url, params=current_params, timeout=self.timeout)
+                except requests.Timeout as exc:
+                    if attempt < 2:
+                        time.sleep(0.3 * (attempt + 1))
+                        continue
+                    raise CanvasError("timeout", f"Canvas 请求超时: {path}") from exc
+                except requests.RequestException as exc:
+                    if attempt < 2:
+                        time.sleep(0.3 * (attempt + 1))
+                        continue
+                    raise CanvasError("request_error", f"Canvas 请求失败: {exc}") from exc
+                if response.status_code in (502, 503, 504) and attempt < 2:
+                    time.sleep(0.3 * (attempt + 1))
+                    continue
+                try:
+                    payload = response.json()
+                    break
+                except Exception as exc:
+                    last_json_error = exc
+                    if response.status_code in (502, 503, 504) and attempt < 2:
+                        time.sleep(0.3 * (attempt + 1))
+                        continue
+                    raise CanvasError(
+                        "invalid_json",
+                        f"Canvas 返回不是 JSON: {path}",
+                        status_code=response.status_code,
+                    ) from exc
+            if response is None:
+                raise CanvasError("request_error", f"Canvas 请求失败: {path}")
+            if payload is None:
                 raise CanvasError(
                     "invalid_json",
                     f"Canvas 返回不是 JSON: {path}",
                     status_code=response.status_code,
-                ) from exc
+                ) from last_json_error
             if response.status_code in (401, 403):
                 raise CanvasError(
                     "invalid_token",
@@ -183,10 +285,16 @@ class CanvasClient:
                 course["tabs"] = self.list_tabs(course_id).get("tabs", [])
             if include_teachers:
                 course["teachers"] = self.list_teachers(course_id).get("teachers", [])
+        _save_course_cache(courses)
         return {"ok": True, "count": len(courses), "courses": courses}
 
     def resolve_course(self, query: str | int) -> dict:
-        courses = self.list_courses()["courses"]
+        try:
+            courses = self.list_courses()["courses"]
+        except CanvasError:
+            courses = _load_course_cache()
+            if not courses:
+                raise
         text = str(query).strip()
         if text.isdigit():
             course_id = int(text)
@@ -216,6 +324,17 @@ class CanvasClient:
                 "error": "ambiguous_course",
                 "query": text,
                 "candidates": matches,
+            }
+        token, number_matches = _match_courses_by_number(courses, text)
+        if len(number_matches) == 1:
+            return {"ok": True, "course": number_matches[0], "matched_by": f"number:{token}"}
+        if len(number_matches) > 1:
+            return {
+                "ok": False,
+                "error": "ambiguous_course",
+                "query": text,
+                "matched_by": f"number:{token}",
+                "candidates": number_matches,
             }
         return {
             "ok": False,

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -620,6 +620,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
             try:
                 result = _agent.run_tool(fn_name, fn_args)
                 elapsed_ms = int((time.monotonic() - t0) * 1000)
+                preview = _result_preview(result)
                 yield _sse({
                     "tool_end": {
                         "id": start_payload["id"],
@@ -627,7 +628,8 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
                         "name": fn_name,
                         "label": start_payload["label"],
                         "elapsed_ms": elapsed_ms,
-                        "result_preview": _result_preview(result),
+                        "result_preview": preview,
+                        "result": preview,
                     }
                 })
             except Exception as exc:
@@ -642,6 +644,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
                         "elapsed_ms": elapsed_ms,
                         "error": str(exc),
                         "result_preview": result,
+                        "result": result,
                     }
                 })
 
@@ -778,6 +781,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
             try:
                 result = _agent.run_tool(fn_name, fn_args)
                 elapsed_ms = int((time.monotonic() - t0) * 1000)
+                preview = _result_preview(result)
                 yield _sse({
                     "tool_end": {
                         "id": start_payload["id"],
@@ -785,7 +789,8 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                         "name": fn_name,
                         "label": start_payload["label"],
                         "elapsed_ms": elapsed_ms,
-                        "result_preview": _result_preview(result),
+                        "result_preview": preview,
+                        "result": preview,
                     }
                 })
             except Exception as exc:
@@ -800,6 +805,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                         "elapsed_ms": elapsed_ms,
                         "error": str(exc),
                         "result_preview": result,
+                        "result": result,
                     }
                 })
 

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -638,97 +638,155 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
     global _chat_history
 
     messages = list(_chat_history)
+    full_text_all = ""
 
     for _round in range(max_rounds):
-        full_text = ""
+        attempts = len(_LLM_TRANSIENT_RETRY_DELAYS) + 1
+        text_so_far = ""
         tool_calls_map: dict[int, dict] = {}
 
-        try:
-            stream = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                tools=_agent.TOOLS,
-                tool_choice="auto",
-                stream=True,
-                timeout=180,
-            )
-            for chunk in stream:
-                if not chunk.choices:
-                    continue
-                delta = chunk.choices[0].delta
-                if delta.content:
-                    full_text += delta.content
-                    yield _sse({"token": delta.content})
-                if delta.tool_calls:
-                    for tc in delta.tool_calls:
-                        idx = tc.index
-                        if idx not in tool_calls_map:
-                            tool_calls_map[idx] = {"id": tc.id or "", "name": "", "arguments": ""}
-                        if tc.id:
-                            tool_calls_map[idx]["id"] = tc.id
-                        if tc.function:
-                            if tc.function.name:
-                                tool_calls_map[idx]["name"] = tc.function.name
-                            if tc.function.arguments:
-                                tool_calls_map[idx]["arguments"] += tc.function.arguments
-        except Exception as exc:
-            if _chat_history and _chat_history[-1]["role"] == "user":
-                _chat_history.pop()
-            yield _sse({"error": str(exc)})
-            return
+        for attempt in range(attempts):
+            text_so_far = ""
+            tool_calls_map = {}
+            try:
+                stream = client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    tools=_agent.TOOLS,
+                    tool_choice="auto",
+                    stream=True,
+                    timeout=180,
+                )
+                for chunk in stream:
+                    if not chunk.choices:
+                        continue
+                    delta = chunk.choices[0].delta
+                    if delta.content:
+                        text_so_far += delta.content
+                        full_text_all += delta.content
+                        yield _token_event(delta.content)
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            idx = tc.index
+                            if idx not in tool_calls_map:
+                                tool_calls_map[idx] = {"id": tc.id or "", "name": "", "arguments": ""}
+                            if tc.id:
+                                tool_calls_map[idx]["id"] = tc.id
+                            if tc.function:
+                                if tc.function.name:
+                                    tool_calls_map[idx]["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    tool_calls_map[idx]["arguments"] += tc.function.arguments
+                break
+            except Exception as exc:
+                if not _is_transient_llm_error(exc):
+                    if _chat_history and _chat_history[-1]["role"] == "user":
+                        _chat_history.pop()
+                    yield _sse({"error": str(exc)})
+                    return
+                if attempt >= attempts - 1:
+                    reply = _llm_busy_reply()
+                    _chat_history.append({"role": "assistant", "content": reply})
+                    yield _token_event(reply)
+                    return
+                delay = _LLM_TRANSIENT_RETRY_DELAYS[attempt]
+                yield _sse({
+                    "retry": {
+                        "attempt": attempt + 1,
+                        "delay_s": delay,
+                        "message": f"模型服务忙，{delay:g}s 后自动重试…",
+                    }
+                })
+                time.sleep(delay)
 
         if not tool_calls_map:
-            _chat_history.append({"role": "assistant", "content": full_text})
-            messages.append({"role": "assistant", "content": full_text})
+            _chat_history.append({"role": "assistant", "content": text_so_far})
+            messages.append({"role": "assistant", "content": text_so_far})
             return
 
-        # 构建 assistant 消息
-        from openai.types.chat import ChatCompletionMessageToolCall
-        from openai.types.chat.chat_completion_message_tool_call import Function
-        from openai.types.chat import ChatCompletionMessage
-
-        tc_objs = []
+        tool_calls_payload = []
         for idx in sorted(tool_calls_map):
-            e = tool_calls_map[idx]
-            tc_objs.append(ChatCompletionMessageToolCall(
-                id=e["id"], type="function",
-                function=Function(name=e["name"], arguments=e["arguments"]),
-            ))
-        assistant_msg = ChatCompletionMessage(
-            role="assistant", content=full_text or None, tool_calls=tc_objs,
-        )
+            entry = tool_calls_map[idx]
+            tool_calls_payload.append({
+                "id": entry["id"] or f"call_{idx + 1}",
+                "type": "function",
+                "function": {"name": entry["name"], "arguments": entry["arguments"]},
+            })
+
+        assistant_msg = {
+            "role": "assistant",
+            "content": text_so_far or None,
+            "tool_calls": tool_calls_payload,
+        }
         messages.append(assistant_msg)
 
-        # 执行工具
-        for tc in tc_objs:
-            fn_name = tc.function.name
-            fn_args = json.loads(tc.function.arguments or "{}")
-            yield _sse({"tool_start": {"name": fn_name, "input": fn_args}})
-            result = _agent.run_tool(fn_name, fn_args)
-            result_preview = result[:500] if len(result) > 500 else result
-            yield _sse({"tool_end": {"name": fn_name, "result": result_preview}})
-            messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})
+        repeated_tool_name = ""
+        for tc in tool_calls_payload:
+            fn_name = tc["function"]["name"]
+            try:
+                fn_args = json.loads(tc["function"]["arguments"] or "{}")
+            except Exception:
+                fn_args = {}
 
-    # 超出 max_rounds 仍在调工具：强制一次无工具调用合成最终回复
-    try:
-        fb_text = ""
-        fb_stream = client.chat.completions.create(
-            model=model,
-            messages=messages,
-            stream=True,
-            timeout=180,
-        )
-        for chunk in fb_stream:
-            if not chunk.choices:
-                continue
-            d = chunk.choices[0].delta
-            if d.content:
-                fb_text += d.content
-                yield _sse({"token": d.content})
-        _chat_history.append({"role": "assistant", "content": fb_text or full_text})
-    except Exception as exc:
-        yield _sse({"error": str(exc)})
-        _chat_history.append({"role": "assistant", "content": full_text})
+            start_payload = state.next_tool_start(fn_name, fn_args)
+            if start_payload is None:
+                reply = _tool_budget_reply(state.max_tool_calls)
+                yield _sse({
+                    "tool_limit": {
+                        "max_tool_calls": state.max_tool_calls,
+                        "message": "工具调用已到上限，正在整理已有结果…",
+                    }
+                })
+                _chat_history.append({"role": "assistant", "content": reply})
+                yield _token_event(reply)
+                return
+
+            yield _sse({"tool_start": start_payload})
+            t0 = time.monotonic()
+            try:
+                result = _agent.run_tool(fn_name, fn_args)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "result_preview": _result_preview(result),
+                    }
+                })
+            except Exception as exc:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                result = json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "error": str(exc),
+                        "result_preview": result,
+                    }
+                })
+
+            messages.append({"role": "tool", "tool_call_id": tc["id"], "content": result})
+
+            if state.record_signature(fn_name, fn_args) and not repeated_tool_name:
+                repeated_tool_name = fn_name
+
+        if repeated_tool_name:
+            reply = _repeated_tool_reply(_agent, repeated_tool_name)
+            _chat_history.append({"role": "assistant", "content": reply})
+            yield _token_event(reply)
+            return
+
+    reply = full_text_all or _max_rounds_reply()
+    if full_text_all:
+        reply = _max_rounds_reply()
+        yield _token_event(reply)
+    _chat_history.append({"role": "assistant", "content": reply})
 
 
 def _test_api(api_key: str, base_url: str, model: str) -> dict:

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -284,7 +284,139 @@ def _get_config_values() -> dict:
 
 # ── 聊天会话（内存，单用户） ────────────────────────────────────────────────────
 
+MAX_TOOL_ROUNDS = 20
+MAX_TOOL_CALLS = 12
+REPEATED_TOOL_LIMIT = 3
+_LLM_TRANSIENT_RETRY_DELAYS = (2.0, 5.0)
+
 _chat_history: list[dict] = []   # [{role, content}, ...]
+_chat_lock = threading.Lock()
+
+
+def _sse(obj: dict) -> str:
+    return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
+
+
+def _token_event(text: str) -> str:
+    return _sse({"token": text})
+
+
+def _done_event() -> str:
+    return _sse({"done": True})
+
+
+def _canonical_tool_signature(name: str, args: dict) -> str:
+    try:
+        args_text = json.dumps(args or {}, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        args_text = "{}"
+    return f"{name}:{args_text}"
+
+
+def _tool_label(_agent, tool_name: str) -> str:
+    labels = getattr(_agent, "_TOOL_LABELS", {})
+    return labels.get(tool_name, tool_name)
+
+
+def _summarize_tool_args(name: str, args: dict) -> str:
+    if not isinstance(args, dict):
+        return ""
+    parts: list[str] = []
+    course = args.get("course")
+    if course:
+        parts.append(f"course={course}")
+    include = args.get("include")
+    if include:
+        if isinstance(include, list):
+            include_text = ",".join(str(item) for item in include[:4])
+        else:
+            include_text = str(include)
+        parts.append(f"include={include_text}")
+    limit = args.get("limit")
+    if limit is not None:
+        parts.append(f"limit={limit}")
+    course_limit = args.get("course_limit")
+    if course_limit is not None:
+        parts.append(f"course_limit={course_limit}")
+    include_past = args.get("include_past")
+    if include_past:
+        parts.append("含过去项目")
+    return "；".join(parts[:4])
+
+
+def _result_preview(result: str, max_chars: int = 500) -> str:
+    text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    return text[:max_chars] if len(text) > max_chars else text
+
+
+def _is_transient_llm_error(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "concurrency limit exceeded",
+            "rate limit",
+            "too many requests",
+            "please retry later",
+        )
+    )
+
+
+def _llm_busy_reply() -> str:
+    return (
+        "模型服务现在有点忙，同一个账号的并发请求被上游限制了。\n"
+        "我已经自动重试过，还是没抢到空位。请稍等半分钟后再发一次。"
+    )
+
+
+def _tool_budget_reply(max_tool_calls: int = MAX_TOOL_CALLS) -> str:
+    return (
+        f"工具调用次数已经达到上限（{max_tool_calls} 次），我先停止继续查找，避免网页端一直卡住。\n"
+        "如果你要看 Canvas 的全局 quiz、通知和最近任务，请直接说“Canvas 总览”；"
+        "我会优先使用 get_canvas_overview 一次性汇总。"
+    )
+
+
+def _repeated_tool_reply(_agent, tool_name: str) -> str:
+    label = _tool_label(_agent, tool_name)
+    return (
+        f"连续调用「{label}」仍未得到可继续推进的结果。\n"
+        "这通常是课程名没有匹配到 Canvas 课程，或当前查询条件过于模糊。\n"
+        "请尽量改用课程代码/Canvas 课程名再试，例如 `ECE2300`。"
+    )
+
+
+def _max_rounds_reply() -> str:
+    return (
+        "这轮对话的工具调用次数过多，我先暂停以避免一直卡住。\n"
+        "请把问题缩小一点，或直接提供课程代码/作业名称后再试。"
+    )
+
+
+class _TurnState:
+    def __init__(self, _agent, max_tool_calls: int = MAX_TOOL_CALLS):
+        self._agent = _agent
+        self.max_tool_calls = max_tool_calls
+        self.total_tool_calls = 0
+        self.tool_counts: dict[str, int] = {}
+
+    def next_tool_start(self, name: str, args: dict) -> dict | None:
+        if self.total_tool_calls >= self.max_tool_calls:
+            return None
+        self.total_tool_calls += 1
+        return {
+            "id": f"tool-{self.total_tool_calls}",
+            "index": self.total_tool_calls,
+            "name": name,
+            "label": _tool_label(self._agent, name),
+            "summary": _summarize_tool_args(name, args),
+            "input": args,
+        }
+
+    def record_signature(self, name: str, args: dict) -> bool:
+        signature = _canonical_tool_signature(name, args)
+        self.tool_counts[signature] = self.tool_counts.get(signature, 0) + 1
+        return self.tool_counts[signature] >= REPEATED_TOOL_LIMIT
 
 
 def _get_chat_client():
@@ -345,53 +477,52 @@ def _get_chat_client():
 
 
 def _stream_chat(user_message: str):
-    """生成器：将 user_message 发给 LLM，支持完整 tool_use 循环，以 SSE 格式 yield 数据行。
-    事件类型：
-      {token: "..."} — 正文增量
-      {tool_start: {name, input}} — 工具调用开始
-      {tool_end: {name, result}} — 工具返回
-      {error: "..."} — 错误
-      [DONE] — 结束
-    """
+    """生成器：将 user_message 发给 LLM，支持 tool_use 循环，以 SSE 格式 yield 数据行。"""
     import datetime as _dt
     global _chat_history
 
-    # 延迟导入 agent 模块（避免循环依赖 + 启动时间）
-    sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
-    import agent as _agent
-
-    if not _chat_history:
-        _now = _dt.datetime.now()
-        _date_ctx = (
-            f"\n\n## 当前时间\n"
-            f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
-        )
-        _chat_history.append({"role": "system", "content": _agent.SYSTEM_PROMPT + _date_ctx})
-
-    _chat_history.append({"role": "user", "content": user_message})
-
-    try:
-        client, model, proto = _get_chat_client()
-    except Exception as exc:
-        _chat_history.pop()
-        yield f"data: {json.dumps({'error': f'创建客户端失败：{exc}'}, ensure_ascii=False)}\n\n"
-        yield "data: [DONE]\n\n"
+    if not _chat_lock.acquire(blocking=False):
+        yield _token_event("上一轮对话还在运行，请等它结束后再发送新消息。")
+        yield _done_event()
         return
 
-    MAX_TOOL_ROUNDS = 20
-
-    def _sse(obj):
-        return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
-
     try:
-        if proto == "anthropic":
-            yield from _stream_chat_anthropic(client, model, _agent, MAX_TOOL_ROUNDS, _sse)
-        else:
-            yield from _stream_chat_openai(client, model, _agent, MAX_TOOL_ROUNDS, _sse)
-    except Exception as exc:
-        yield _sse({"error": str(exc)})
+        yield _sse({"status": {"phase": "thinking", "message": "正在思考…"}})
 
-    yield "data: [DONE]\n\n"
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+        import agent as _agent
+
+        if not _chat_history:
+            _now = _dt.datetime.now()
+            _date_ctx = (
+                f"\n\n## 当前时间\n"
+                f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
+            )
+            _chat_history.append({"role": "system", "content": _agent.SYSTEM_PROMPT + _date_ctx})
+
+        _chat_history.append({"role": "user", "content": user_message})
+
+        try:
+            client, model, proto = _get_chat_client()
+        except Exception as exc:
+            if _chat_history and _chat_history[-1]["role"] == "user":
+                _chat_history.pop()
+            yield _sse({"error": f"创建客户端失败：{exc}"})
+            yield _done_event()
+            return
+
+        state = _TurnState(_agent)
+        try:
+            if proto == "anthropic":
+                yield from _stream_chat_anthropic(client, model, _agent, MAX_TOOL_ROUNDS, state)
+            else:
+                yield from _stream_chat_openai(client, model, _agent, MAX_TOOL_ROUNDS, state)
+        except Exception as exc:
+            yield _sse({"error": str(exc)})
+
+        yield _done_event()
+    finally:
+        _chat_lock.release()
 
 
 def _stream_chat_anthropic(client, model, _agent, max_rounds, _sse):

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -525,7 +525,7 @@ def _stream_chat(user_message: str):
         _chat_lock.release()
 
 
-def _stream_chat_anthropic(client, model, _agent, max_rounds, _sse):
+def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState):
     """Anthropic Messages API 流式 + tool_use 循环。"""
     global _chat_history
 
@@ -633,7 +633,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, _sse):
         _chat_history.append({"role": "assistant", "content": full_text})
 
 
-def _stream_chat_openai(client, model, _agent, max_rounds, _sse):
+def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
     """OpenAI Chat Completions 流式 + tool_calls 循环。"""
     global _chat_history
 

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -563,50 +563,98 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
     tools = _agent._anthropic_tools()
 
     for _round in range(max_rounds):
+        attempts = len(_LLM_TRANSIENT_RETRY_DELAYS) + 1
         full_text = ""
         content_blocks: list[dict] = []
         tool_inputs: dict[int, str] = {}
 
-        try:
-            with client.messages.stream(
-                model=model,
-                max_tokens=4096,
-                system=system_msg,
-                messages=api_msgs,
-                tools=tools,
-            ) as stream:
-                for event in stream:
-                    etype = getattr(event, "type", "")
-                    if etype == "content_block_start":
-                        block = event.content_block
-                        btype = getattr(block, "type", "")
-                        if btype == "text":
-                            content_blocks.append({"type": "text", "text": ""})
-                        elif btype == "tool_use":
-                            content_blocks.append({
-                                "type": "tool_use",
-                                "id": block.id,
-                                "name": block.name,
-                                "input": {},
-                            })
-                            tool_inputs[len(content_blocks) - 1] = ""
-                    elif etype == "content_block_delta":
-                        delta = event.delta
-                        dtype = getattr(delta, "type", "")
-                        if dtype == "text_delta":
-                            chunk = delta.text
-                            full_text += chunk
-                            if content_blocks and content_blocks[-1].get("type") == "text":
-                                content_blocks[-1]["text"] += chunk
-                            yield _token_event(chunk)
-                        elif dtype == "input_json_delta":
-                            idx = event.index
-                            tool_inputs[idx] = tool_inputs.get(idx, "") + delta.partial_json
-        except Exception as exc:
-            if _chat_history and _chat_history[-1]["role"] == "user":
-                _chat_history.pop()
-            yield _sse({"error": str(exc)})
-            return
+        for attempt in range(attempts):
+            full_text = ""
+            content_blocks = []
+            tool_inputs = {}
+            pending_text = ""
+            emitted_attempt_text = False
+
+            try:
+                with client.messages.stream(
+                    model=model,
+                    max_tokens=4096,
+                    system=system_msg,
+                    messages=api_msgs,
+                    tools=tools,
+                ) as stream:
+                    for event in stream:
+                        etype = getattr(event, "type", "")
+                        if etype == "content_block_start":
+                            if pending_text:
+                                emitted_attempt_text = True
+                                yield _token_event(pending_text)
+                                pending_text = ""
+                            block = event.content_block
+                            btype = getattr(block, "type", "")
+                            if btype == "text":
+                                content_blocks.append({"type": "text", "text": ""})
+                            elif btype == "tool_use":
+                                content_blocks.append({
+                                    "type": "tool_use",
+                                    "id": block.id,
+                                    "name": block.name,
+                                    "input": {},
+                                })
+                                tool_inputs[len(content_blocks) - 1] = ""
+                        elif etype == "content_block_delta":
+                            delta = event.delta
+                            dtype = getattr(delta, "type", "")
+                            if dtype == "text_delta":
+                                chunk = delta.text
+                                if pending_text:
+                                    emitted_attempt_text = True
+                                    yield _token_event(pending_text)
+                                full_text += chunk
+                                if content_blocks and content_blocks[-1].get("type") == "text":
+                                    content_blocks[-1]["text"] += chunk
+                                pending_text = chunk
+                            elif dtype == "input_json_delta":
+                                if pending_text:
+                                    emitted_attempt_text = True
+                                    yield _token_event(pending_text)
+                                    pending_text = ""
+                                idx = event.index
+                                tool_inputs[idx] = tool_inputs.get(idx, "") + delta.partial_json
+                    if pending_text:
+                        emitted_attempt_text = True
+                        yield _token_event(pending_text)
+                break
+            except Exception as exc:
+                if not _is_transient_llm_error(exc):
+                    if _chat_history and _chat_history[-1]["role"] == "user":
+                        _chat_history.pop()
+                    yield _sse({"error": str(exc)})
+                    return
+                if attempt >= attempts - 1:
+                    if emitted_attempt_text:
+                        yield _sse({
+                            "retry": {
+                                "attempt": attempt + 1,
+                                "delay_s": 0,
+                                "message": "模型服务仍然忙，正在停止重试…",
+                                "reset_text": True,
+                            }
+                        })
+                    reply = _llm_busy_reply()
+                    _chat_history.append({"role": "assistant", "content": reply})
+                    yield _token_event(reply)
+                    return
+                delay = _LLM_TRANSIENT_RETRY_DELAYS[attempt]
+                retry_payload = {
+                    "attempt": attempt + 1,
+                    "delay_s": delay,
+                    "message": f"模型服务忙，{delay:g}s 后自动重试…",
+                }
+                if emitted_attempt_text:
+                    retry_payload["reset_text"] = True
+                yield _sse({"retry": retry_payload})
+                time.sleep(delay)
 
         for idx, raw_json in tool_inputs.items():
             if idx < len(content_blocks) and content_blocks[idx].get("type") == "tool_use":
@@ -693,8 +741,6 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
     global _chat_history
 
     messages = list(_chat_history)
-    full_text_all = ""
-
     for _round in range(max_rounds):
         attempts = len(_LLM_TRANSIENT_RETRY_DELAYS) + 1
         text_so_far = ""
@@ -703,7 +749,8 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
         for attempt in range(attempts):
             text_so_far = ""
             tool_calls_map = {}
-            attempt_text_chunks: list[str] = []
+            pending_text = ""
+            emitted_attempt_text = False
             try:
                 stream = client.chat.completions.create(
                     model=model,
@@ -718,9 +765,16 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                         continue
                     delta = chunk.choices[0].delta
                     if delta.content:
+                        if pending_text:
+                            emitted_attempt_text = True
+                            yield _token_event(pending_text)
                         text_so_far += delta.content
-                        attempt_text_chunks.append(delta.content)
+                        pending_text = delta.content
                     if delta.tool_calls:
+                        if pending_text:
+                            emitted_attempt_text = True
+                            yield _token_event(pending_text)
+                            pending_text = ""
                         for tc in delta.tool_calls:
                             idx = tc.index
                             if idx not in tool_calls_map:
@@ -732,9 +786,9 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                                     tool_calls_map[idx]["name"] = tc.function.name
                                 if tc.function.arguments:
                                     tool_calls_map[idx]["arguments"] += tc.function.arguments
-                for text in attempt_text_chunks:
-                    full_text_all += text
-                    yield _token_event(text)
+                if pending_text:
+                    emitted_attempt_text = True
+                    yield _token_event(pending_text)
                 break
             except Exception as exc:
                 if not _is_transient_llm_error(exc):
@@ -743,18 +797,28 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                     yield _sse({"error": str(exc)})
                     return
                 if attempt >= attempts - 1:
+                    if emitted_attempt_text:
+                        yield _sse({
+                            "retry": {
+                                "attempt": attempt + 1,
+                                "delay_s": 0,
+                                "message": "模型服务仍然忙，正在停止重试…",
+                                "reset_text": True,
+                            }
+                        })
                     reply = _llm_busy_reply()
                     _chat_history.append({"role": "assistant", "content": reply})
                     yield _token_event(reply)
                     return
                 delay = _LLM_TRANSIENT_RETRY_DELAYS[attempt]
-                yield _sse({
-                    "retry": {
-                        "attempt": attempt + 1,
-                        "delay_s": delay,
-                        "message": f"模型服务忙，{delay:g}s 后自动重试…",
-                    }
-                })
+                retry_payload = {
+                    "attempt": attempt + 1,
+                    "delay_s": delay,
+                    "message": f"模型服务忙，{delay:g}s 后自动重试…",
+                }
+                if emitted_attempt_text:
+                    retry_payload["reset_text"] = True
+                yield _sse({"retry": retry_payload})
                 time.sleep(delay)
 
         if not tool_calls_map:

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -970,8 +970,14 @@ class _Handler(BaseHTTPRequestHandler):
                     break
         elif path == "/api/chat/clear":
             global _chat_history
-            _chat_history = []
-            self._send_json({"ok": True})
+            if not _chat_lock.acquire(blocking=False):
+                self._send_json({"ok": False, "error": "上一轮对话还在运行，请等它结束后再清空。"}, 409)
+                return
+            try:
+                _chat_history = []
+                self._send_json({"ok": True})
+            finally:
+                _chat_lock.release()
         elif path == "/api/feishu/start":
             self._send_json(_start_feishu_bot())
         else:

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -785,7 +785,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
     reply = full_text_all or _max_rounds_reply()
     if full_text_all:
         reply = _max_rounds_reply()
-        yield _token_event(reply)
+    yield _token_event(reply)
     _chat_history.append({"role": "assistant", "content": reply})
 
 

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -648,6 +648,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
         for attempt in range(attempts):
             text_so_far = ""
             tool_calls_map = {}
+            attempt_text_chunks: list[str] = []
             try:
                 stream = client.chat.completions.create(
                     model=model,
@@ -663,8 +664,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                     delta = chunk.choices[0].delta
                     if delta.content:
                         text_so_far += delta.content
-                        full_text_all += delta.content
-                        yield _token_event(delta.content)
+                        attempt_text_chunks.append(delta.content)
                     if delta.tool_calls:
                         for tc in delta.tool_calls:
                             idx = tc.index
@@ -677,6 +677,9 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                                     tool_calls_map[idx]["name"] = tc.function.name
                                 if tc.function.arguments:
                                     tool_calls_map[idx]["arguments"] += tc.function.arguments
+                for text in attempt_text_chunks:
+                    full_text_all += text
+                    yield _token_event(text)
                 break
             except Exception as exc:
                 if not _is_transient_llm_error(exc):
@@ -782,9 +785,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
             yield _token_event(reply)
             return
 
-    reply = full_text_all or _max_rounds_reply()
-    if full_text_all:
-        reply = _max_rounds_reply()
+    reply = _max_rounds_reply()
     yield _token_event(reply)
     _chat_history.append({"role": "assistant", "content": reply})
 

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -344,9 +344,34 @@ def _summarize_tool_args(name: str, args: dict) -> str:
     return "；".join(parts[:4])
 
 
-def _result_preview(result: str, max_chars: int = 500) -> str:
+def _result_text(result: str) -> str:
     text = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    return text
+
+
+def _result_preview(result: str, max_chars: int = 500) -> str:
+    text = _result_text(result)
     return text[:max_chars] if len(text) > max_chars else text
+
+
+def _is_wechat_qr_result(result: str) -> bool:
+    try:
+        payload = json.loads(_result_text(result))
+    except Exception:
+        return False
+    return (
+        isinstance(payload, dict)
+        and bool(payload.get("qr_base64"))
+        and bool(payload.get("qrcode_key"))
+    )
+
+
+def _tool_result_fields(result: str) -> dict:
+    preview = _result_preview(result)
+    fields = {"result_preview": preview, "result": preview}
+    if _is_wechat_qr_result(result):
+        fields["result"] = _result_text(result)
+    return fields
 
 
 def _is_transient_llm_error(exc: Exception) -> bool:
@@ -620,7 +645,6 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
             try:
                 result = _agent.run_tool(fn_name, fn_args)
                 elapsed_ms = int((time.monotonic() - t0) * 1000)
-                preview = _result_preview(result)
                 yield _sse({
                     "tool_end": {
                         "id": start_payload["id"],
@@ -628,8 +652,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
                         "name": fn_name,
                         "label": start_payload["label"],
                         "elapsed_ms": elapsed_ms,
-                        "result_preview": preview,
-                        "result": preview,
+                        **_tool_result_fields(result),
                     }
                 })
             except Exception as exc:
@@ -781,7 +804,6 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
             try:
                 result = _agent.run_tool(fn_name, fn_args)
                 elapsed_ms = int((time.monotonic() - t0) * 1000)
-                preview = _result_preview(result)
                 yield _sse({
                     "tool_end": {
                         "id": start_payload["id"],
@@ -789,8 +811,7 @@ def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):
                         "name": fn_name,
                         "label": start_payload["label"],
                         "elapsed_ms": elapsed_ms,
-                        "result_preview": preview,
-                        "result": preview,
+                        **_tool_result_fields(result),
                     }
                 })
             except Exception as exc:

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -573,7 +573,7 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
                             full_text += chunk
                             if content_blocks and content_blocks[-1].get("type") == "text":
                                 content_blocks[-1]["text"] += chunk
-                            yield _sse({"token": chunk})
+                            yield _token_event(chunk)
                         elif dtype == "input_json_delta":
                             idx = event.index
                             tool_inputs[idx] = tool_inputs.get(idx, "") + delta.partial_json
@@ -583,7 +583,6 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
             yield _sse({"error": str(exc)})
             return
 
-        # 解析 tool_use input
         for idx, raw_json in tool_inputs.items():
             if idx < len(content_blocks) and content_blocks[idx].get("type") == "tool_use":
                 try:
@@ -591,46 +590,76 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, state: _TurnState)
                 except Exception:
                     content_blocks[idx]["input"] = {}
 
-        has_tool_use = any(b.get("type") == "tool_use" for b in content_blocks)
         api_msgs.append({"role": "assistant", "content": content_blocks})
+        tool_blocks = [block for block in content_blocks if block.get("type") == "tool_use"]
 
-        if not has_tool_use:
+        if not tool_blocks:
             _chat_history.append({"role": "assistant", "content": full_text})
             return
 
-        # 执行工具
         tool_results = []
-        for b in content_blocks:
-            if b.get("type") != "tool_use":
-                continue
-            fn_name = b["name"]
-            fn_args = b["input"] if isinstance(b["input"], dict) else {}
-            yield _sse({"tool_start": {"name": fn_name, "input": fn_args}})
-            result = _agent.run_tool(fn_name, fn_args)
-            result_preview = result[:500] if len(result) > 500 else result
-            yield _sse({"tool_end": {"name": fn_name, "result": result_preview}})
-            tool_results.append({"type": "tool_result", "tool_use_id": b["id"], "content": result})
+        repeated_tool_name = ""
+        for block in tool_blocks:
+            fn_name = block["name"]
+            fn_args = block["input"] if isinstance(block.get("input"), dict) else {}
+            start_payload = state.next_tool_start(fn_name, fn_args)
+            if start_payload is None:
+                reply = _tool_budget_reply(state.max_tool_calls)
+                yield _sse({
+                    "tool_limit": {
+                        "max_tool_calls": state.max_tool_calls,
+                        "message": "工具调用已到上限，正在整理已有结果…",
+                    }
+                })
+                _chat_history.append({"role": "assistant", "content": reply})
+                yield _token_event(reply)
+                return
+
+            yield _sse({"tool_start": start_payload})
+            t0 = time.monotonic()
+            try:
+                result = _agent.run_tool(fn_name, fn_args)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "result_preview": _result_preview(result),
+                    }
+                })
+            except Exception as exc:
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+                result = json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+                yield _sse({
+                    "tool_end": {
+                        "id": start_payload["id"],
+                        "index": start_payload["index"],
+                        "name": fn_name,
+                        "label": start_payload["label"],
+                        "elapsed_ms": elapsed_ms,
+                        "error": str(exc),
+                        "result_preview": result,
+                    }
+                })
+
+            tool_results.append({"type": "tool_result", "tool_use_id": block["id"], "content": result})
+            if state.record_signature(fn_name, fn_args) and not repeated_tool_name:
+                repeated_tool_name = fn_name
+
         api_msgs.append({"role": "user", "content": tool_results})
 
-    # 超出 max_rounds 仍在调工具：强制一次无工具调用合成最终回复
-    try:
-        fb_text = ""
-        with client.messages.stream(
-            model=model,
-            max_tokens=4096,
-            system=system_msg,
-            messages=api_msgs,
-        ) as stream:
-            for event in stream:
-                if getattr(event, "type", "") == "content_block_delta":
-                    delta = event.delta
-                    if getattr(delta, "type", "") == "text_delta":
-                        fb_text += delta.text
-                        yield _sse({"token": delta.text})
-        _chat_history.append({"role": "assistant", "content": fb_text or full_text})
-    except Exception as exc:
-        yield _sse({"error": str(exc)})
-        _chat_history.append({"role": "assistant", "content": full_text})
+        if repeated_tool_name:
+            reply = _repeated_tool_reply(_agent, repeated_tool_name)
+            _chat_history.append({"role": "assistant", "content": reply})
+            yield _token_event(reply)
+            return
+
+    reply = _max_rounds_reply()
+    yield _token_event(reply)
+    _chat_history.append({"role": "assistant", "content": reply})
 
 
 def _stream_chat_openai(client, model, _agent, max_rounds, state: _TurnState):

--- a/sjtu_agent/web/static/index.html
+++ b/sjtu_agent/web/static/index.html
@@ -1543,13 +1543,14 @@ function appendToolCard(tool) {
   const msgs = document.getElementById('chat-messages');
   const card = document.createElement('div');
   const label = tool.label || TOOL_LABELS[tool.name] || tool.name;
+  const index = tool.index || '?';
   const summary = tool.summary ? `：${tool.summary}` : '';
   card.className = 'tool-card running';
   card.dataset.toolId = tool.id;
   card.innerHTML = `
     <div class="tool-head" onclick="this.parentElement.classList.toggle('expanded')">
       <div class="tool-icon"></div>
-      <span class="tool-name">#${tool.index || '?'} ${escapeHtml(label)}</span>
+      <span class="tool-name">#${escapeHtml(index)} ${escapeHtml(label)}</span>
       <span class="tool-summary">${escapeHtml(summary)}</span>
       <span class="tool-caret">▶</span>
     </div>
@@ -1605,6 +1606,7 @@ async function sendChat() {
   let fullText = '';
   let firstToken = true;
   const toolCards = new Map();
+  const legacyToolIds = [];
   let generatedToolId = 0;
   let streamDone = false;
   let terminalBubbleSet = false;
@@ -1672,15 +1674,19 @@ async function sendChat() {
 
         if (evt.tool_start) {
           const tool = evt.tool_start;
+          const hasServerToolId = Boolean(tool.id);
           const toolId = tool.id || `tool-local-${++generatedToolId}`;
           tool.id = toolId;
           const card = appendToolCard(tool);
           toolCards.set(toolId, card);
+          if (!hasServerToolId) {
+            legacyToolIds.push(toolId);
+          }
         }
 
         if (evt.tool_end) {
           const toolEnd = evt.tool_end;
-          const toolId = toolEnd.id || `tool-local-${++generatedToolId}`;
+          const toolId = toolEnd.id || legacyToolIds.shift() || `tool-local-${++generatedToolId}`;
           const card = toolCards.get(toolId);
           if (card) {
             markToolDone(card, toolEnd);

--- a/sjtu_agent/web/static/index.html
+++ b/sjtu_agent/web/static/index.html
@@ -549,17 +549,45 @@
     }
     @keyframes blink { 50% { opacity: 0; } }
 
-    /* 工具调用卡片 */
+    /* 工具调用时间线 */
+    .progress-row,
     .tool-card {
       align-self: flex-start;
       max-width: calc(100% - 50px);
       margin-left: 42px;
       background: var(--surface2);
       border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 10px 12px;
+      border-radius: 8px;
+      padding: 9px 12px;
       font-size: 13px;
       color: var(--text2);
+    }
+    .progress-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .progress-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--text3);
+      flex-shrink: 0;
+    }
+    .progress-row.running .progress-dot {
+      width: 14px;
+      height: 14px;
+      border: 2px solid var(--text3);
+      border-right-color: transparent;
+      background: transparent;
+      animation: spin .6s linear infinite;
+    }
+    .progress-row.done .progress-dot { background: var(--green); }
+    .progress-row.warn .progress-dot { background: var(--yellow); }
+    .progress-row.error .progress-dot { background: var(--red); }
+    .progress-text {
+      color: var(--text2);
+      line-height: 1.45;
     }
     .tool-card .tool-head {
       display: flex;
@@ -599,10 +627,20 @@
       animation: none;
       background: var(--red);
     }
+    .tool-card.limited .tool-icon {
+      border: none;
+      animation: none;
+      background: var(--yellow);
+    }
     .tool-card .tool-name {
       font-family: "SF Mono", "JetBrains Mono", Menlo, monospace;
       color: var(--text);
       font-size: 12.5px;
+    }
+    .tool-card .tool-summary {
+      color: var(--text3);
+      font-size: 12px;
+      overflow-wrap: anywhere;
     }
     .tool-card .tool-caret {
       margin-left: auto;
@@ -1409,19 +1447,80 @@ function renderMd(text) {
 
 let isSending = false;
 const TOOL_LABELS = {
-  get_ddls: '获取 DDL',
+  get_ddls: '获取作业 DDL',
   get_all: '获取全部信息',
-  get_next_lab: '获取实验安排',
-  get_schedule: '获取课表',
+  get_next_lab: '查询物理实验安排',
+  get_schedule: '查询课表',
   query_grades: '查询成绩',
   check_setup: '检查配置',
-  download_assignments: '下载作业',
-  search_campus: '搜索校园',
+  download_assignments: '下载作业材料',
+  search_campus: '搜索校园内容',
   browse_mysjtu: '浏览交大门户',
   list_reminders: '查看提醒',
   read_emails: '读取邮件',
   send_email: '发送邮件',
+  setup_canvas: '引导配置 Canvas',
+  list_canvas_courses: '读取 Canvas 课程',
+  get_canvas_course_announcements: '读取 Canvas 公告',
+  get_canvas_course_quizzes: '读取 Canvas Quiz',
+  get_canvas_course_updates: '汇总 Canvas 课程动态',
+  get_canvas_overview: '汇总 Canvas 总览',
+  get_canvas_todo: '读取 Canvas 待办',
+  configure_canvas_monitor: '配置 Canvas 监控',
+  list_canvas_assignments: '列出 Canvas 作业',
+  submit_canvas_assignment: '上传并提交作业',
 };
+
+function escapeHtml(text) {
+  return String(text ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function formatJson(value) {
+  if (value === undefined || value === null || value === '') return '(无)';
+  if (typeof value === 'string') {
+    try { return JSON.stringify(JSON.parse(value), null, 2); }
+    catch { return value; }
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function parseJsonObject(value) {
+  if (!value) return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function appendStatusRow(text, kind = 'running') {
+  const msgs = document.getElementById('chat-messages');
+  const row = document.createElement('div');
+  row.className = 'progress-row ' + kind;
+  row.innerHTML = `
+    <span class="progress-dot"></span>
+    <span class="progress-text">${escapeHtml(text)}</span>
+  `;
+  msgs.appendChild(row);
+  msgs.scrollTop = msgs.scrollHeight;
+  return row;
+}
+
+function appendRetryRow(retry) {
+  const msg = retry.message || `模型服务忙，${retry.delay_s || 0}s 后自动重试（第 ${retry.attempt || 1} 次）…`;
+  return appendStatusRow(msg, 'warn');
+}
+
+function appendLimitRow(limit) {
+  const msg = limit.message || `工具调用已到上限（${limit.max_tool_calls || '?'} 次），正在整理已有结果…`;
+  return appendStatusRow(msg, 'warn');
+}
 
 function appendMsg(role, html) {
   const msgs = document.getElementById('chat-messages');
@@ -1440,20 +1539,25 @@ function appendMsg(role, html) {
   return bubble;
 }
 
-function appendToolCard(name, input) {
+function appendToolCard(tool) {
   const msgs = document.getElementById('chat-messages');
   const card = document.createElement('div');
-  card.className = 'tool-card';
-  const label = TOOL_LABELS[name] || name;
+  const label = tool.label || TOOL_LABELS[tool.name] || tool.name;
+  const summary = tool.summary ? `：${tool.summary}` : '';
+  card.className = 'tool-card running';
+  card.dataset.toolId = tool.id;
   card.innerHTML = `
     <div class="tool-head" onclick="this.parentElement.classList.toggle('expanded')">
       <div class="tool-icon"></div>
-      <span class="tool-name">${label}</span>
+      <span class="tool-name">#${tool.index || '?'} ${escapeHtml(label)}</span>
+      <span class="tool-summary">${escapeHtml(summary)}</span>
       <span class="tool-caret">▶</span>
     </div>
     <div class="tool-body">
+      <div class="tool-label">工具</div>
+      <pre>${escapeHtml(tool.name || '')}</pre>
       <div class="tool-label">参数</div>
-      <pre>${JSON.stringify(input, null, 2) || '(无)'}</pre>
+      <pre>${escapeHtml(formatJson(tool.input))}</pre>
       <div class="tool-label">结果</div>
       <pre class="tool-result">等待中…</pre>
     </div>
@@ -1461,6 +1565,26 @@ function appendToolCard(name, input) {
   msgs.appendChild(card);
   msgs.scrollTop = msgs.scrollHeight;
   return card;
+}
+
+function markToolDone(card, toolEnd) {
+  card.classList.remove('running');
+  card.classList.add(toolEnd.error ? 'error' : 'done');
+  const result = card.querySelector('.tool-result');
+  if (result) {
+    const preview = toolEnd.result_preview ?? toolEnd.result ?? toolEnd.error ?? '';
+    result.textContent = formatJson(preview);
+  }
+  const rawResult = toolEnd.result ?? toolEnd.result_preview;
+  const parsed = parseJsonObject(rawResult);
+  if (parsed && parsed.qr_base64 && parsed.qrcode_key) {
+    _showWechatQR(parsed);
+  }
+  const name = card.querySelector('.tool-name');
+  if (name && toolEnd.elapsed_ms !== undefined) {
+    const seconds = (Number(toolEnd.elapsed_ms || 0) / 1000).toFixed(1);
+    name.textContent = `${name.textContent}（${seconds}s）`;
+  }
 }
 
 async function sendChat() {
@@ -1480,7 +1604,10 @@ async function sendChat() {
   let bubble = appendMsg('assistant', '<span style="color:var(--text3);font-style:italic">⏳ 正在思考…</span>');
   let fullText = '';
   let firstToken = true;
-  let currentToolCard = null;
+  const toolCards = new Map();
+  let generatedToolId = 0;
+  let streamDone = false;
+  let terminalBubbleSet = false;
 
   try {
     const res = await fetch('/api/chat', {
@@ -1503,13 +1630,36 @@ async function sendChat() {
       for (const line of lines) {
         if (!line.startsWith('data: ')) continue;
         const payload = line.slice(6).trim();
-        if (payload === '[DONE]') break;
+        if (payload === '[DONE]') {
+          streamDone = true;
+          break;
+        }
         let evt;
         try { evt = JSON.parse(payload); } catch { continue; }
 
-        if (evt.error) {
-          bubble.innerHTML = '<p style="color:var(--red)">❌ ' + evt.error + '</p>';
+        if (evt.done) {
+          streamDone = true;
           break;
+        }
+
+        if (evt.error) {
+          appendStatusRow(evt.error, 'error');
+          bubble.innerHTML = '<p style="color:var(--red)">❌ ' + escapeHtml(evt.error) + '</p>';
+          terminalBubbleSet = true;
+          streamDone = true;
+          break;
+        }
+
+        if (evt.status) {
+          appendStatusRow(evt.status.message || evt.status.phase || '正在处理…', evt.status.phase === 'done' ? 'done' : 'running');
+        }
+
+        if (evt.retry) {
+          appendRetryRow(evt.retry);
+        }
+
+        if (evt.tool_limit) {
+          appendLimitRow(evt.tool_limit);
         }
 
         if (evt.token) {
@@ -1521,43 +1671,36 @@ async function sendChat() {
         }
 
         if (evt.tool_start) {
-          currentToolCard = appendToolCard(evt.tool_start.name, evt.tool_start.input);
+          const tool = evt.tool_start;
+          const toolId = tool.id || `tool-local-${++generatedToolId}`;
+          tool.id = toolId;
+          const card = appendToolCard(tool);
+          toolCards.set(toolId, card);
         }
 
         if (evt.tool_end) {
-          if (currentToolCard) {
-            currentToolCard.classList.add('done');
-            const pre = currentToolCard.querySelector('.tool-result');
-            if (pre) {
-              try {
-                const parsed = JSON.parse(evt.tool_end.result);
-                // 检查是否有二维码
-                if (parsed.qr_base64 && parsed.qrcode_key) {
-                  _showWechatQR(parsed);
-                } else {
-                  pre.textContent = JSON.stringify(parsed, null, 2);
-                }
-              } catch {
-                pre.textContent = evt.tool_end.result;
-              }
-            }
-            currentToolCard = null;
+          const toolEnd = evt.tool_end;
+          const toolId = toolEnd.id || `tool-local-${++generatedToolId}`;
+          const card = toolCards.get(toolId);
+          if (card) {
+            markToolDone(card, toolEnd);
           }
         }
       }
+      if (streamDone) break;
     }
 
     // 移除光标，清除占位文字
     const cursor = bubble.querySelector('.cursor');
     if (cursor) cursor.remove();
-    if (fullText) {
+    if (!terminalBubbleSet && fullText) {
       bubble.innerHTML = renderMd(fullText);
-    } else if (firstToken) {
+    } else if (firstToken && !terminalBubbleSet) {
       // 没有收到任何 token（纯工具调用无文本回复）
       bubble.innerHTML = '<p style="color:var(--text3)">(已完成)</p>';
     }
   } catch (e) {
-    bubble.innerHTML = '<p style="color:var(--red)">❌ 请求失败：' + e.message + '</p>';
+    bubble.innerHTML = '<p style="color:var(--red)">❌ 请求失败：' + escapeHtml(e.message) + '</p>';
   } finally {
     isSending = false;
     document.getElementById('btn-send').disabled = false;

--- a/sjtu_agent/web/static/index.html
+++ b/sjtu_agent/web/static/index.html
@@ -1689,6 +1689,11 @@ async function sendChat() {
         }
 
         if (evt.retry) {
+          if (evt.retry.reset_text) {
+            fullText = '';
+            firstToken = true;
+            bubble.innerHTML = '<span style="color:var(--text3);font-style:italic">⏳ 正在重试…</span>';
+          }
           appendRetryRow(evt.retry);
         }
 
@@ -1791,7 +1796,13 @@ function _showWechatQR(data) {
 }
 
 async function clearChat() {
-  await fetch('/api/chat/clear', { method: 'POST' });
+  const res = await fetch('/api/chat/clear', { method: 'POST' });
+  if (!res.ok) {
+    let data = {};
+    try { data = await res.json(); } catch {}
+    showToast(data.error || '上一轮对话还在运行，请等它结束后再清空。', 'error');
+    return;
+  }
   const msgs = document.getElementById('chat-messages');
   msgs.innerHTML = `
     <div class="msg assistant">

--- a/sjtu_agent/web/static/index.html
+++ b/sjtu_agent/web/static/index.html
@@ -1576,7 +1576,7 @@ function markToolDone(card, toolEnd) {
     const preview = toolEnd.result_preview ?? toolEnd.result ?? toolEnd.error ?? '';
     result.textContent = formatJson(preview);
   }
-  const rawResult = toolEnd.result ?? toolEnd.result_preview;
+  const rawResult = toolEnd.result_full ?? toolEnd.result ?? toolEnd.result_preview;
   const parsed = parseJsonObject(rawResult);
   if (parsed && parsed.qr_base64 && parsed.qrcode_key) {
     _showWechatQR(parsed);
@@ -1586,6 +1586,18 @@ function markToolDone(card, toolEnd) {
     const seconds = (Number(toolEnd.elapsed_ms || 0) / 1000).toFixed(1);
     name.textContent = `${name.textContent}（${seconds}s）`;
   }
+}
+
+function markRunningToolsError(toolCards) {
+  toolCards.forEach(card => {
+    if (!card.classList.contains('running')) return;
+    card.classList.remove('running');
+    card.classList.add('error');
+    const result = card.querySelector('.tool-result');
+    if (result && result.textContent === '等待中…') {
+      result.textContent = '请求失败，工具调用未完成。';
+    }
+  });
 }
 
 async function sendChat() {
@@ -1607,9 +1619,18 @@ async function sendChat() {
   let firstToken = true;
   const toolCards = new Map();
   const legacyToolIds = [];
+  const runningStatusRows = [];
   let generatedToolId = 0;
   let streamDone = false;
   let terminalBubbleSet = false;
+
+  function finishRunningStatusRows(kind = 'done') {
+    for (const row of runningStatusRows.splice(0)) {
+      if (!row.classList.contains('running')) continue;
+      row.classList.remove('running');
+      row.classList.add(kind);
+    }
+  }
 
   try {
     const res = await fetch('/api/chat', {
@@ -1633,6 +1654,7 @@ async function sendChat() {
         if (!line.startsWith('data: ')) continue;
         const payload = line.slice(6).trim();
         if (payload === '[DONE]') {
+          finishRunningStatusRows('done');
           streamDone = true;
           break;
         }
@@ -1640,11 +1662,14 @@ async function sendChat() {
         try { evt = JSON.parse(payload); } catch { continue; }
 
         if (evt.done) {
+          finishRunningStatusRows('done');
           streamDone = true;
           break;
         }
 
         if (evt.error) {
+          finishRunningStatusRows('error');
+          markRunningToolsError(toolCards);
           appendStatusRow(evt.error, 'error');
           bubble.innerHTML = '<p style="color:var(--red)">❌ ' + escapeHtml(evt.error) + '</p>';
           terminalBubbleSet = true;
@@ -1653,7 +1678,14 @@ async function sendChat() {
         }
 
         if (evt.status) {
-          appendStatusRow(evt.status.message || evt.status.phase || '正在处理…', evt.status.phase === 'done' ? 'done' : 'running');
+          const kind = evt.status.phase === 'done' ? 'done' : 'running';
+          if (kind === 'done') {
+            finishRunningStatusRows('done');
+          }
+          const row = appendStatusRow(evt.status.message || evt.status.phase || '正在处理…', kind);
+          if (kind === 'running') {
+            runningStatusRows.push(row);
+          }
         }
 
         if (evt.retry) {
@@ -1665,7 +1697,11 @@ async function sendChat() {
         }
 
         if (evt.token) {
-          if (firstToken) { fullText = ''; firstToken = false; }
+          if (firstToken) {
+            finishRunningStatusRows('done');
+            fullText = '';
+            firstToken = false;
+          }
           fullText += evt.token;
           bubble.innerHTML = renderMd(fullText) + '<span class="cursor"></span>';
           document.getElementById('chat-messages').scrollTop =
@@ -1673,6 +1709,7 @@ async function sendChat() {
         }
 
         if (evt.tool_start) {
+          finishRunningStatusRows('done');
           const tool = evt.tool_start;
           const hasServerToolId = Boolean(tool.id);
           const toolId = tool.id || `tool-local-${++generatedToolId}`;
@@ -1706,6 +1743,8 @@ async function sendChat() {
       bubble.innerHTML = '<p style="color:var(--text3)">(已完成)</p>';
     }
   } catch (e) {
+    finishRunningStatusRows('error');
+    markRunningToolsError(toolCards);
     bubble.innerHTML = '<p style="color:var(--red)">❌ 请求失败：' + escapeHtml(e.message) + '</p>';
   } finally {
     isSending = false;

--- a/tests/test_canvas_client.py
+++ b/tests/test_canvas_client.py
@@ -38,6 +38,10 @@ class FakeSession:
         if key not in self.routes:
             raise AssertionError(f"unexpected GET {path} {params}")
         response = self.routes[key]
+        if isinstance(response, list):
+            if not response:
+                raise AssertionError(f"no fake responses left for {path} {params}")
+            response = response.pop(0)
         response.links = response.links or {}
         response.headers = response.headers or {"content-type": "application/json"}
         return response
@@ -53,6 +57,13 @@ def client(routes: dict[tuple[str, str], FakeResponse]) -> CanvasClient:
 
 def iso_from_now(days: int) -> str:
     return (datetime.now(timezone.utc) + timedelta(days=days)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@pytest.fixture(autouse=True)
+def isolate_canvas_course_cache(monkeypatch, tmp_path):
+    from sjtu_agent import canvas_client as cc
+
+    monkeypatch.setattr(cc, "CANVAS_COURSES_CACHE_PATH", tmp_path / "canvas_courses_cache.json")
 
 
 def test_list_courses_normalizes_active_courses():
@@ -86,6 +97,73 @@ def test_resolve_course_by_id_name_and_ambiguous_match():
     assert ambiguous["ok"] is False
     assert ambiguous["error"] == "ambiguous_course"
     assert [item["course_id"] for item in ambiguous["candidates"]] == [1, 2]
+
+
+def test_resolve_course_matches_short_numeric_course_reference():
+    c = client({
+        key("/api/v1/courses", {"enrollment_state": "active", "enrollment_type": "student", "per_page": 100}): FakeResponse(200, [
+            {"id": 92355, "name": "ECE2300JSU2026-1", "course_code": "ECE2300JSU2026-1"},
+            {"id": 92353, "name": "ECE2700JSU2026", "course_code": "ECE2700JSU2026"},
+        ])
+    })
+
+    result = c.resolve_course("230这门课")
+
+    assert result["ok"] is True
+    assert result["course"]["course_id"] == 92355
+
+
+def test_resolve_course_returns_ambiguous_for_short_numeric_multiple_matches():
+    c = client({
+        key("/api/v1/courses", {"enrollment_state": "active", "enrollment_type": "student", "per_page": 100}): FakeResponse(200, [
+            {"id": 1, "name": "ECE2300JSU2026-1", "course_code": "ECE2300JSU2026-1"},
+            {"id": 2, "name": "ME2301", "course_code": "ME2301"},
+        ])
+    })
+
+    result = c.resolve_course("230")
+
+    assert result["ok"] is False
+    assert result["error"] == "ambiguous_course"
+    assert [item["course_id"] for item in result["candidates"]] == [1, 2]
+
+
+def test_resolve_course_uses_cached_courses_when_canvas_list_fails(monkeypatch, tmp_path):
+    from sjtu_agent import canvas_client as cc
+
+    cache_path = tmp_path / "canvas_courses_cache.json"
+    monkeypatch.setattr(cc, "CANVAS_COURSES_CACHE_PATH", cache_path)
+    cc._save_course_cache([
+        {"course_id": 92355, "name": "ECE2300JSU2026-1", "course_code": "ECE2300JSU2026-1"},
+    ])
+    c = client({
+        key("/api/v1/courses", {"enrollment_state": "active", "enrollment_type": "student", "per_page": 100}): FakeResponse(502, "<html>bad gateway</html>"),
+    })
+
+    result = c.resolve_course("230这门课")
+
+    assert result["ok"] is True
+    assert result["course"]["course_id"] == 92355
+    assert result["course"]["from_cache"] is True
+
+
+def test_list_courses_retries_transient_bad_gateway():
+    routes = {
+        key("/api/v1/courses", {"enrollment_state": "active", "enrollment_type": "student", "per_page": 100}): [
+            FakeResponse(502, "<html>bad gateway</html>"),
+            FakeResponse(200, [
+                {"id": 92355, "name": "ECE2300JSU2026-1", "course_code": "ECE2300JSU2026-1"},
+            ]),
+        ]
+    }
+    fake_session = FakeSession(routes)
+    c = CanvasClient(base_url="https://oc.sjtu.edu.cn", token="tok", session=fake_session)
+
+    result = c.list_courses()
+
+    assert result["ok"] is True
+    assert result["courses"][0]["course_id"] == 92355
+    assert len(fake_session.calls) == 2
 
 
 def test_announcements_use_context_codes_and_normalize_html_summary():

--- a/tests/test_canvas_tools.py
+++ b/tests/test_canvas_tools.py
@@ -6,12 +6,19 @@ import sjtu_agent.agent.tools as tools
 
 
 class FakeCanvasClient:
-    def __init__(self):
+    def __init__(self, courses=None):
         self.calls = []
+        self.courses = courses or [
+            {"course_id": 1, "name": "Signals", "course_code": "ECE2300"},
+        ]
 
     def list_courses(self, include_tabs=False, include_teachers=False):
         self.calls.append(("list_courses", include_tabs, include_teachers))
-        return {"ok": True, "count": 1, "courses": [{"course_id": 1, "name": "Signals", "course_code": "ECE2300"}]}
+        return {
+            "ok": True,
+            "count": len(self.courses),
+            "courses": self.courses,
+        }
 
     def resolve_course(self, course):
         if str(course) == "many":
@@ -20,11 +27,18 @@ class FakeCanvasClient:
 
     def list_announcements(self, course_id, limit=20, since_days=None):
         self.calls.append(("announcements", course_id, limit, since_days))
-        return {"ok": True, "count": 1, "announcements": [{"id": 10, "title": "Exam"}]}
+        title = "Exam" if course_id == 1 else f"Exam {course_id}"
+        return {"ok": True, "count": 1, "announcements": [{"id": 10 + course_id, "title": title}]}
 
     def list_quizzes(self, course_id, include_past=False, include_assignment_backed=True):
         self.calls.append(("quizzes", course_id, include_past, include_assignment_backed))
-        return {"ok": True, "quiz_status": "enabled", "count": 1, "quizzes": [{"quiz_id": 5, "title": "Quiz"}], "warnings": []}
+        return {
+            "ok": True,
+            "quiz_status": "enabled",
+            "count": 1,
+            "quizzes": [{"quiz_id": 5 + course_id, "title": f"Quiz {course_id}"}],
+            "warnings": [],
+        }
 
     def get_course_updates(self, course_id, include=None, limit=10, include_past=False):
         self.calls.append(("updates", course_id, include, limit, include_past))
@@ -122,6 +136,31 @@ def test_run_tool_dispatches_canvas_tools(monkeypatch):
     assert fake.calls == [("todo", 3)]
 
 
+def test_canvas_overview_fetches_courses_quizzes_announcements_and_todo(monkeypatch):
+    fake = FakeCanvasClient(courses=[
+        {"course_id": 1, "name": "Signals", "course_code": "ECE2300"},
+        {"course_id": 2, "name": "Systems", "course_code": "ECE2700"},
+    ])
+    monkeypatch.setattr(tools._core, "_make_canvas_client", lambda: fake)
+
+    result = tools.tool_get_canvas_overview(limit=2, course_limit=2, since_days=7)
+
+    assert result["ok"] is True
+    assert result["courses_count"] == 2
+    assert result["todo"]["count"] == 1
+    assert result["courses"][0]["course"]["course_code"] == "ECE2300"
+    assert result["courses"][0]["quizzes"]["quizzes"][0]["title"] == "Quiz 1"
+    assert result["courses"][1]["announcements"]["announcements"][0]["title"] == "Exam 2"
+    assert fake.calls == [
+        ("list_courses", False, False),
+        ("todo", 2),
+        ("quizzes", 1, False, True),
+        ("announcements", 1, 2, 7),
+        ("quizzes", 2, False, True),
+        ("announcements", 2, 2, 7),
+    ]
+
+
 def test_list_canvas_assignments_uses_current_items_by_default(monkeypatch):
     fake = FakeCanvasClient()
     monkeypatch.setattr(tools._core, "_make_canvas_client", lambda: fake)
@@ -152,6 +191,7 @@ def test_tools_catalog_contains_canvas_tools():
     assert "get_canvas_course_announcements" in names
     assert "get_canvas_course_quizzes" in names
     assert "get_canvas_course_updates" in names
+    assert "get_canvas_overview" in names
     assert "get_canvas_todo" in names
 
 

--- a/tests/test_web_static.py
+++ b/tests/test_web_static.py
@@ -15,6 +15,16 @@ def _tool_labels_block() -> str:
     return match.group("body")
 
 
+def _function_block(name: str) -> str:
+    match = re.search(
+        rf"(?:async\s+)?function\s+{re.escape(name)}\s*\([^)]*\)\s*\{{(?P<body>.*?)\n\}}",
+        HTML,
+        re.S,
+    )
+    assert match, f"{name} function not found"
+    return match.group("body")
+
+
 def test_web_chat_has_canvas_tool_labels():
     labels = {
         "list_canvas_courses": "读取 Canvas 课程",
@@ -108,6 +118,24 @@ def test_web_chat_finalizes_running_status_rows():
     ), "terminal failures do not mark running status rows as errors"
 
 
+def test_web_chat_retry_can_reset_streamed_answer_text():
+    retry_match = re.search(
+        r"if\s*\(\s*evt\.retry\s*\)\s*\{(?P<body>.*?)appendRetryRow\(\s*evt\.retry\s*\)",
+        HTML,
+        re.S,
+    )
+    assert retry_match, "retry event block not found"
+    body = retry_match.group("body")
+
+    assert "evt.retry.reset_text" in body
+    assert re.search(r"fullText\s*=\s*['\"]{2}", body), (
+        "retry reset does not clear streamed assistant text"
+    )
+    assert re.search(r"firstToken\s*=\s*true", body), (
+        "retry reset does not restore first-token state"
+    )
+
+
 def test_web_chat_marks_running_tools_error_on_failure():
     assert re.search(
         r"function\s+markRunningToolsError\s*\(",
@@ -129,3 +157,26 @@ def test_web_chat_handles_structured_done_event():
         r"payload\s*===\s*['\"]\[DONE\]['\"]",
         HTML,
     ), "legacy [DONE] payload is not handled"
+
+
+def test_web_chat_clear_preserves_ui_when_backend_rejects_active_turn():
+    body = _function_block("clearChat")
+
+    assert re.search(
+        r"const\s+res\s*=\s*await\s+fetch\(\s*['\"]/api/chat/clear['\"]",
+        body,
+    ), "clearChat does not keep the clear response"
+    assert re.search(
+        r"if\s*\(\s*!res\.ok\s*\)",
+        body,
+    ), "clearChat does not handle non-2xx clear responses"
+    assert re.search(
+        r"showToast\([^)]*['\"]error['\"]",
+        body,
+        re.S,
+    ), "clearChat does not surface backend clear errors"
+    assert re.search(
+        r"if\s*\(\s*!res\.ok\s*\).*?return\s*;",
+        body,
+        re.S,
+    ), "clearChat must return before clearing UI when backend rejects"

--- a/tests/test_web_static.py
+++ b/tests/test_web_static.py
@@ -1,31 +1,54 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
-HTML = Path("sjtu_agent/web/static/index.html").read_text(encoding="utf-8")
+HTML = (
+    Path(__file__).resolve().parents[1] / "sjtu_agent/web/static/index.html"
+).read_text(encoding="utf-8")
+
+
+def _tool_labels_block() -> str:
+    match = re.search(r"const\s+TOOL_LABELS\s*=\s*\{(?P<body>.*?)\n\s*\};", HTML, re.S)
+    assert match, "TOOL_LABELS object not found"
+    return match.group("body")
 
 
 def test_web_chat_has_canvas_tool_labels():
-    for name in [
-        "list_canvas_courses",
-        "get_canvas_course_announcements",
-        "get_canvas_course_quizzes",
-        "get_canvas_course_updates",
-        "get_canvas_overview",
-        "get_canvas_todo",
-        "configure_canvas_monitor",
-        "list_canvas_assignments",
-        "submit_canvas_assignment",
-        "setup_canvas",
-    ]:
-        assert name in HTML
+    labels = {
+        "list_canvas_courses": "读取 Canvas 课程",
+        "get_canvas_course_announcements": "读取 Canvas 公告",
+        "get_canvas_course_quizzes": "读取 Canvas Quiz",
+        "get_canvas_course_updates": "汇总 Canvas 课程动态",
+        "get_canvas_overview": "汇总 Canvas 总览",
+        "get_canvas_todo": "读取 Canvas 待办",
+        "configure_canvas_monitor": "配置 Canvas 监控",
+        "list_canvas_assignments": "列出 Canvas 作业",
+        "submit_canvas_assignment": "上传并提交作业",
+        "setup_canvas": "引导配置 Canvas",
+    }
+    body = _tool_labels_block()
+    for name, label in labels.items():
+        pattern = rf"{re.escape(name)}\s*:\s*['\"]{re.escape(label)}['\"]"
+        assert re.search(pattern, body), (
+            f"missing TOOL_LABELS entry for {name} -> {label}"
+        )
 
 
 def test_web_chat_uses_keyed_tool_cards():
-    assert "const toolCards = new Map();" in HTML
-    assert "toolCards.set(toolId, card);" in HTML
-    assert "toolCards.get(toolId)" in HTML
+    assert re.search(
+        r"toolCards\s*=\s*new\s+Map\s*\(",
+        HTML,
+    ), "toolCards Map not initialized"
+    assert re.search(
+        r"toolCards\.set\(\s*toolId\s*,\s*card\s*\)",
+        HTML,
+    ), "toolCards not keyed by toolId on start"
+    assert re.search(
+        r"toolCards\.get\(\s*toolId\s*\)",
+        HTML,
+    ), "toolCards not looked up by toolId on end"
     assert "currentToolCard" not in HTML
 
 
@@ -37,9 +60,13 @@ def test_web_chat_renders_progress_events():
         "appendRetryRow",
         "appendLimitRow",
     ]:
-        assert f"function {helper}" in HTML
+        pattern = rf"(?:function\s+{helper}\s*\(|(?:const|let)\s+{helper}\s*=)"
+        assert re.search(pattern, HTML), f"missing helper {helper}"
 
 
 def test_web_chat_handles_structured_done_event():
-    assert "evt.done" in HTML
-    assert "payload === '[DONE]'" in HTML
+    assert re.search(r"evt\.done", HTML), "structured done event is not handled"
+    assert re.search(
+        r"payload\s*===\s*['\"]\[DONE\]['\"]",
+        HTML,
+    ), "legacy [DONE] payload is not handled"

--- a/tests/test_web_static.py
+++ b/tests/test_web_static.py
@@ -80,11 +80,47 @@ def test_web_chat_renders_progress_events():
         "appendStatusRow",
         "appendToolCard",
         "markToolDone",
+        "markRunningToolsError",
+        "finishRunningStatusRows",
         "appendRetryRow",
         "appendLimitRow",
     ]:
         pattern = rf"(?:function\s+{helper}\s*\(|(?:const|let)\s+{helper}\s*=)"
         assert re.search(pattern, HTML), f"missing helper {helper}"
+
+
+def test_web_chat_finalizes_running_status_rows():
+    assert re.search(
+        r"runningStatusRows\s*=\s*\[\s*\]",
+        HTML,
+    ), "running status rows are not tracked per chat turn"
+    assert re.search(
+        r"runningStatusRows\.push\(\s*row\s*\)",
+        HTML,
+    ), "running status rows are not added to the tracked list"
+    assert re.search(
+        r"finishRunningStatusRows\(\s*['\"]done['\"]\s*\)",
+        HTML,
+    ), "successful progress does not finalize running status rows"
+    assert re.search(
+        r"finishRunningStatusRows\(\s*['\"]error['\"]\s*\)",
+        HTML,
+    ), "terminal failures do not mark running status rows as errors"
+
+
+def test_web_chat_marks_running_tools_error_on_failure():
+    assert re.search(
+        r"function\s+markRunningToolsError\s*\(",
+        HTML,
+    ), "missing helper for marking running tool cards as errors"
+    assert re.search(
+        r"card\.classList\.remove\(\s*['\"]running['\"]\s*\)",
+        HTML,
+    ), "running tool card error helper does not remove running state"
+    assert re.search(
+        r"card\.classList\.add\(\s*['\"]error['\"]\s*\)",
+        HTML,
+    ), "running tool card error helper does not add error state"
 
 
 def test_web_chat_handles_structured_done_event():

--- a/tests/test_web_static.py
+++ b/tests/test_web_static.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+HTML = Path("sjtu_agent/web/static/index.html").read_text(encoding="utf-8")
+
+
+def test_web_chat_has_canvas_tool_labels():
+    for name in [
+        "list_canvas_courses",
+        "get_canvas_course_announcements",
+        "get_canvas_course_quizzes",
+        "get_canvas_course_updates",
+        "get_canvas_overview",
+        "get_canvas_todo",
+        "configure_canvas_monitor",
+        "list_canvas_assignments",
+        "submit_canvas_assignment",
+        "setup_canvas",
+    ]:
+        assert name in HTML
+
+
+def test_web_chat_uses_keyed_tool_cards():
+    assert "const toolCards = new Map();" in HTML
+    assert "toolCards.set(toolId, card);" in HTML
+    assert "toolCards.get(toolId)" in HTML
+    assert "currentToolCard" not in HTML
+
+
+def test_web_chat_renders_progress_events():
+    for helper in [
+        "appendStatusRow",
+        "appendToolCard",
+        "markToolDone",
+        "appendRetryRow",
+        "appendLimitRow",
+    ]:
+        assert f"function {helper}" in HTML
+
+
+def test_web_chat_handles_structured_done_event():
+    assert "evt.done" in HTML
+    assert "payload === '[DONE]'" in HTML

--- a/tests/test_web_static.py
+++ b/tests/test_web_static.py
@@ -52,6 +52,29 @@ def test_web_chat_uses_keyed_tool_cards():
     assert "currentToolCard" not in HTML
 
 
+def test_web_chat_pairs_legacy_tool_events_without_ids():
+    assert re.search(
+        r"legacyToolIds\s*=\s*\[\s*\]",
+        HTML,
+    ), "legacy no-id tool queue not initialized"
+    assert re.search(
+        r"legacyToolIds\.push\(\s*toolId\s*\)",
+        HTML,
+    ), "legacy no-id tool starts are not queued"
+    assert re.search(
+        r"legacyToolIds\.shift\(\s*\)",
+        HTML,
+    ), "legacy no-id tool ends do not consume the queued start id"
+
+
+def test_web_chat_escapes_tool_index():
+    assert re.search(
+        r"const\s+index\s*=\s*tool\.index\s*\|\|\s*['\"]\?['\"]",
+        HTML,
+    ), "tool index display fallback not normalized"
+    assert "escapeHtml(index)" in HTML, "tool index is not escaped in card title"
+
+
 def test_web_chat_renders_progress_events():
     for helper in [
         "appendStatusRow",

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -18,6 +18,35 @@ def _tool_call(name: str, arguments: str = "{}", index: int = 0, call_id: str = 
     )
 
 
+def _anthropic_tool_start(name: str, block_id: str):
+    return SimpleNamespace(
+        type="content_block_start",
+        content_block=SimpleNamespace(type="tool_use", id=block_id, name=name),
+    )
+
+
+def _anthropic_text_start():
+    return SimpleNamespace(
+        type="content_block_start",
+        content_block=SimpleNamespace(type="text"),
+    )
+
+
+def _anthropic_input_delta(partial_json: str, index: int = 0):
+    return SimpleNamespace(
+        type="content_block_delta",
+        index=index,
+        delta=SimpleNamespace(type="input_json_delta", partial_json=partial_json),
+    )
+
+
+def _anthropic_text_delta(text: str):
+    return SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(type="text_delta", text=text),
+    )
+
+
 def _events_from(chunks):
     events = []
     for chunk in chunks:
@@ -131,19 +160,105 @@ class FakePartialThenTransientClient:
         return [_chunk(content="成功回复。")]
 
 
-def _reset_web_server(monkeypatch, client):
+class FakeAnthropicStream:
+    def __init__(self, events):
+        self.events = events
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def __iter__(self):
+        return iter(self.events)
+
+
+class FakeAnthropicToolClient:
+    def __init__(self):
+        self.messages = SimpleNamespace(stream=self.stream)
+        self.calls = 0
+
+    def stream(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return FakeAnthropicStream([
+                _anthropic_tool_start("get_canvas_todo", "toolu_1"),
+                _anthropic_input_delta('{"limit": 1}', index=0),
+                _anthropic_tool_start("get_canvas_course_quizzes", "toolu_2"),
+                _anthropic_input_delta('{"course": "ECE2300"}', index=1),
+            ])
+        return FakeAnthropicStream([
+            _anthropic_text_start(),
+            _anthropic_text_delta("查好了。"),
+        ])
+
+
+class FakeAnthropicRotatingClient:
+    def __init__(self):
+        self.messages = SimpleNamespace(stream=self.stream)
+        self.calls = 0
+
+    def stream(self, **_kwargs):
+        self.calls += 1
+        return FakeAnthropicStream([
+            _anthropic_tool_start("get_canvas_course_updates", f"toolu_{self.calls}"),
+            _anthropic_input_delta(
+                json.dumps({"course": f"COURSE{self.calls}"}, ensure_ascii=False),
+                index=0,
+            ),
+        ])
+
+
+def _reset_web_server(monkeypatch, client, proto: str = "openai"):
     import agent
     import sjtu_agent.web.server as server
 
     monkeypatch.setattr(server, "_chat_history", [])
     monkeypatch.setattr(server, "_chat_lock", threading.Lock(), raising=False)
-    monkeypatch.setattr(server, "_get_chat_client", lambda: (client, "deepseek-chat", "openai"))
+    model = "claude-sonnet-4-5" if proto == "anthropic" else "deepseek-chat"
+    monkeypatch.setattr(server, "_get_chat_client", lambda: (client, model, proto))
     monkeypatch.setattr(agent, "run_tool", lambda name, args: '{"ok": true, "tool": "%s"}' % name)
+    monkeypatch.setattr(agent, "_anthropic_tools", lambda: [], raising=False)
     return server
 
 
 def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
     server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+
+    events = _events_from(server._stream_chat("看看 Canvas 待办和 ECE2300 quiz"))
+
+    starts = [event["tool_start"] for event in events if "tool_start" in event]
+    ends = [event["tool_end"] for event in events if "tool_end" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert events[0]["status"]["phase"] == "thinking"
+    assert [start["id"] for start in starts] == ["tool-1", "tool-2"]
+    assert [start["index"] for start in starts] == [1, 2]
+    assert starts[0]["label"] == "正在读取 Canvas 待办"
+    assert starts[0]["summary"] == "limit=1"
+    assert starts[1]["label"] == "正在读取 Canvas Quiz"
+    assert starts[1]["summary"] == "course=ECE2300"
+    assert [end["id"] for end in ends] == ["tool-1", "tool-2"]
+    assert [end["index"] for end in ends] == [1, 2]
+    assert [end["name"] for end in ends] == [
+        "get_canvas_todo",
+        "get_canvas_course_quizzes",
+    ]
+    assert [end["label"] for end in ends] == [
+        "正在读取 Canvas 待办",
+        "正在读取 Canvas Quiz",
+    ]
+    assert all(
+        isinstance(end["elapsed_ms"], int) and end["elapsed_ms"] >= 0
+        for end in ends
+    )
+    assert tokens == ["查好了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_anthropic_reports_keyed_tool_progress(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeAnthropicToolClient(), proto="anthropic")
 
     events = _events_from(server._stream_chat("看看 Canvas 待办和 ECE2300 quiz"))
 
@@ -211,6 +326,26 @@ def test_web_stream_chat_stops_after_total_tool_budget(monkeypatch):
 def test_web_stream_chat_emits_max_rounds_fallback_without_streamed_text(monkeypatch):
     client = FakeOpenAIRotatingClient()
     server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "MAX_TOOL_ROUNDS", 3, raising=False)
+
+    events = _events_from(server._stream_chat("持续查询 Canvas 动态"))
+
+    starts = [event for event in events if "tool_start" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert client.calls == 3
+    assert len(starts) == 3
+    assert server._max_rounds_reply() in tokens
+    assert server._chat_history[-1] == {
+        "role": "assistant",
+        "content": server._max_rounds_reply(),
+    }
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_anthropic_emits_max_rounds_fallback_without_streamed_text(monkeypatch):
+    client = FakeAnthropicRotatingClient()
+    server = _reset_web_server(monkeypatch, client, proto="anthropic")
     monkeypatch.setattr(server, "MAX_TOOL_ROUNDS", 3, raising=False)
 
     events = _events_from(server._stream_chat("持续查询 Canvas 动态"))

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -253,6 +253,8 @@ def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
         isinstance(end["elapsed_ms"], int) and end["elapsed_ms"] >= 0
         for end in ends
     )
+    assert all(end["result"] == end["result_preview"] for end in ends)
+    assert all('"ok": true' in end["result_preview"] for end in ends)
     assert tokens == ["查好了。"]
     assert events[-1] == {"done": True}
 
@@ -287,6 +289,8 @@ def test_web_stream_chat_anthropic_reports_keyed_tool_progress(monkeypatch):
         isinstance(end["elapsed_ms"], int) and end["elapsed_ms"] >= 0
         for end in ends
     )
+    assert all(end["result"] == end["result_preview"] for end in ends)
+    assert all('"ok": true' in end["result_preview"] for end in ends)
     assert tokens == ["查好了。"]
     assert events[-1] == {"done": True}
 

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -190,6 +190,26 @@ def test_web_stream_chat_stops_after_total_tool_budget(monkeypatch):
     assert events[-1] == {"done": True}
 
 
+def test_web_stream_chat_emits_max_rounds_fallback_without_streamed_text(monkeypatch):
+    client = FakeOpenAIRotatingClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "MAX_TOOL_ROUNDS", 3, raising=False)
+
+    events = _events_from(server._stream_chat("持续查询 Canvas 动态"))
+
+    starts = [event for event in events if "tool_start" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert client.calls == 3
+    assert len(starts) == 3
+    assert server._max_rounds_reply() in tokens
+    assert server._chat_history[-1] == {
+        "role": "assistant",
+        "content": server._max_rounds_reply(),
+    }
+    assert events[-1] == {"done": True}
+
+
 def test_web_stream_chat_retries_transient_concurrency_limit(monkeypatch):
     client = FakeTransientLimitClient()
     server = _reset_web_server(monkeypatch, client)

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -233,3 +233,26 @@ def test_web_stream_chat_rejects_concurrent_turn(monkeypatch):
 
     assert "上一轮对话还在运行" in tokens
     assert events[-1] == {"done": True}
+
+
+def test_web_chat_clear_rejects_during_active_turn(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+    existing_history = [{"role": "user", "content": "保留这轮对话"}]
+    monkeypatch.setattr(server, "_chat_history", existing_history)
+    responses = []
+    handler = SimpleNamespace(
+        path="/api/chat/clear",
+        _send_json=lambda data, status=200: responses.append((status, data)),
+    )
+
+    server._chat_lock.acquire()
+    try:
+        server._Handler.do_POST(handler)
+    finally:
+        server._chat_lock.release()
+
+    assert responses == [(
+        409,
+        {"ok": False, "error": "上一轮对话还在运行，请等它结束后再清空。"},
+    )]
+    assert server._chat_history == existing_history

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+
+def _chunk(*, content: str = "", tool_calls=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _tool_call(name: str, arguments: str = "{}", index: int = 0, call_id: str = "call_1"):
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _events_from(chunks):
+    events = []
+    for chunk in chunks:
+        for block in chunk.split("\n\n"):
+            block = block.strip()
+            if not block.startswith("data: "):
+                continue
+            payload = block.removeprefix("data: ").strip()
+            if payload == "[DONE]":
+                events.append({"done": True})
+                continue
+            events.append(json.loads(payload))
+    return events
+
+
+class FakeOpenAIToolClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return [
+                _chunk(tool_calls=[
+                    _tool_call("get_canvas_todo", '{"limit": 1}'),
+                    _tool_call(
+                        "get_canvas_course_quizzes",
+                        '{"course": "ECE2300"}',
+                        index=1,
+                        call_id="call_2",
+                    ),
+                ])
+            ]
+        return [_chunk(content="查好了。")]
+
+
+class FakeOpenAILoopingClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return [
+            _chunk(tool_calls=[
+                _tool_call("get_canvas_course_quizzes", '{"course": "电磁学"}')
+            ])
+        ]
+
+
+class FakeOpenAIRotatingClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return [
+            _chunk(tool_calls=[
+                _tool_call(
+                    "get_canvas_course_updates",
+                    json.dumps({"course": f"COURSE{self.calls}"}, ensure_ascii=False),
+                )
+            ])
+        ]
+
+
+class FailingStream:
+    def __iter__(self):
+        if False:
+            yield None
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
+
+
+class FakeTransientLimitClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls < 3:
+            return FailingStream()
+        return [_chunk(content="现在可以继续了。")]
+
+
+class FakePersistentLimitClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return FailingStream()
+
+
+def _reset_web_server(monkeypatch, client):
+    import agent
+    import sjtu_agent.web.server as server
+
+    server._chat_history = []
+    if hasattr(server, "_chat_lock") and server._chat_lock.locked():
+        server._chat_lock.release()
+    monkeypatch.setattr(server, "_get_chat_client", lambda: (client, "deepseek-chat", "openai"))
+    monkeypatch.setattr(agent, "run_tool", lambda name, args: '{"ok": true, "tool": "%s"}' % name)
+    return server
+
+
+def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+
+    events = _events_from(server._stream_chat("看看 Canvas 待办和 ECE2300 quiz"))
+
+    starts = [event["tool_start"] for event in events if "tool_start" in event]
+    ends = [event["tool_end"] for event in events if "tool_end" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert events[0]["status"]["phase"] == "thinking"
+    assert [start["id"] for start in starts] == ["tool-1", "tool-2"]
+    assert [start["index"] for start in starts] == [1, 2]
+    assert starts[0]["label"] == "正在读取 Canvas 待办"
+    assert starts[0]["summary"] == "limit=1"
+    assert starts[1]["label"] == "正在读取 Canvas Quiz"
+    assert starts[1]["summary"] == "course=ECE2300"
+    assert [end["id"] for end in ends] == ["tool-1", "tool-2"]
+    assert all(isinstance(end["elapsed_ms"], int) for end in ends)
+    assert tokens == ["查好了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_stops_repeated_tool_loop(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAILoopingClient())
+
+    events = _events_from(server._stream_chat("帮我看电磁学 quiz"))
+
+    starts = [event for event in events if "tool_start" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert len(starts) == 3
+    assert "连续调用" in tokens
+    assert "Canvas Quiz" in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_stops_after_total_tool_budget(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIRotatingClient())
+
+    events = _events_from(server._stream_chat("把所有 Canvas 动态都查一下"))
+
+    starts = [event for event in events if "tool_start" in event]
+    limits = [event["tool_limit"] for event in events if "tool_limit" in event]
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert len(starts) == 12
+    assert limits == [{
+        "max_tool_calls": 12,
+        "message": "工具调用已到上限，正在整理已有结果…",
+    }]
+    assert "工具调用次数已经达到上限" in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_retries_transient_concurrency_limit(monkeypatch):
+    client = FakeTransientLimitClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 3
+    assert [retry["attempt"] for retry in retries] == [1, 2]
+    assert tokens == ["现在可以继续了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_returns_friendly_message_when_limit_persists(monkeypatch):
+    client = FakePersistentLimitClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert client.calls == 3
+    assert "模型服务现在有点忙" in tokens
+    assert "Concurrency limit" not in tokens
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_rejects_concurrent_turn(monkeypatch):
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+    server._chat_lock.acquire()
+    try:
+        events = _events_from(server._stream_chat("第二个请求"))
+    finally:
+        server._chat_lock.release()
+
+    tokens = "".join(event.get("token", "") for event in events)
+
+    assert "上一轮对话还在运行" in tokens
+    assert events[-1] == {"done": True}

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -235,7 +235,7 @@ def test_web_stream_chat_rejects_concurrent_turn(monkeypatch):
     assert events[-1] == {"done": True}
 
 
-def test_web_chat_clear_rejects_during_active_turn(monkeypatch):
+def test_web_chat_clear_rejects_while_turn_is_active(monkeypatch):
     server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
     existing_history = [{"role": "user", "content": "保留这轮对话"}]
     monkeypatch.setattr(server, "_chat_history", existing_history)

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -91,6 +91,12 @@ class FailingStream:
         raise RuntimeError("Concurrency limit exceeded for user, please retry later")
 
 
+class PartialThenFailingStream:
+    def __iter__(self):
+        yield _chunk(content="先说一段。")
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
+
+
 class FakeTransientLimitClient:
     def __init__(self):
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
@@ -111,6 +117,18 @@ class FakePersistentLimitClient:
     def create(self, **_kwargs):
         self.calls += 1
         return FailingStream()
+
+
+class FakePartialThenTransientClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return PartialThenFailingStream()
+        return [_chunk(content="成功回复。")]
 
 
 def _reset_web_server(monkeypatch, client):
@@ -223,6 +241,22 @@ def test_web_stream_chat_retries_transient_concurrency_limit(monkeypatch):
     assert client.calls == 3
     assert [retry["attempt"] for retry in retries] == [1, 2]
     assert tokens == ["现在可以继续了。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_discards_partial_tokens_from_failed_retry_attempt(monkeypatch):
+    client = FakePartialThenTransientClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0,), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 2
+    assert [retry["attempt"] for retry in retries] == [1]
+    assert tokens == ["成功回复。"]
     assert events[-1] == {"done": True}
 
 

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from types import SimpleNamespace
 
 
@@ -116,9 +117,8 @@ def _reset_web_server(monkeypatch, client):
     import agent
     import sjtu_agent.web.server as server
 
-    server._chat_history = []
-    if hasattr(server, "_chat_lock") and server._chat_lock.locked():
-        server._chat_lock.release()
+    monkeypatch.setattr(server, "_chat_history", [])
+    monkeypatch.setattr(server, "_chat_lock", threading.Lock(), raising=False)
     monkeypatch.setattr(server, "_get_chat_client", lambda: (client, "deepseek-chat", "openai"))
     monkeypatch.setattr(agent, "run_tool", lambda name, args: '{"ok": true, "tool": "%s"}' % name)
     return server
@@ -141,7 +141,19 @@ def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
     assert starts[1]["label"] == "正在读取 Canvas Quiz"
     assert starts[1]["summary"] == "course=ECE2300"
     assert [end["id"] for end in ends] == ["tool-1", "tool-2"]
-    assert all(isinstance(end["elapsed_ms"], int) for end in ends)
+    assert [end["index"] for end in ends] == [1, 2]
+    assert [end["name"] for end in ends] == [
+        "get_canvas_todo",
+        "get_canvas_course_quizzes",
+    ]
+    assert [end["label"] for end in ends] == [
+        "正在读取 Canvas 待办",
+        "正在读取 Canvas Quiz",
+    ]
+    assert all(
+        isinstance(end["elapsed_ms"], int) and end["elapsed_ms"] >= 0
+        for end in ends
+    )
     assert tokens == ["查好了。"]
     assert events[-1] == {"done": True}
 

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -62,6 +62,15 @@ def _events_from(chunks):
     return events
 
 
+def _event_from_chunk(chunk: str):
+    block = chunk.strip()
+    assert block.startswith("data: ")
+    payload = block.removeprefix("data: ").strip()
+    if payload == "[DONE]":
+        return {"done": True}
+    return json.loads(payload)
+
+
 class FakeOpenAIToolClient:
     def __init__(self):
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
@@ -126,6 +135,32 @@ class PartialThenFailingStream:
         raise RuntimeError("Concurrency limit exceeded for user, please retry later")
 
 
+class MultiChunkThenFailingStream:
+    def __iter__(self):
+        yield _chunk(content="第一段")
+        yield _chunk(content="第二段")
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
+
+
+class ObservableOpenAIStream:
+    def __init__(self):
+        self.finished = False
+
+    def __iter__(self):
+        yield _chunk(content="第一段")
+        yield _chunk(content="第二段")
+        self.finished = True
+
+
+class FakeOpenAIRealtimeClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.stream = ObservableOpenAIStream()
+
+    def create(self, **_kwargs):
+        return self.stream
+
+
 class FakeTransientLimitClient:
     def __init__(self):
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
@@ -160,6 +195,28 @@ class FakePartialThenTransientClient:
         return [_chunk(content="成功回复。")]
 
 
+class FakeEmittedPartialThenTransientClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return MultiChunkThenFailingStream()
+        return [_chunk(content="成功回复。")]
+
+
+class FakePersistentVisiblePartialLimitClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return MultiChunkThenFailingStream()
+
+
 class FakeAnthropicStream:
     def __init__(self, events):
         self.events = events
@@ -172,6 +229,19 @@ class FakeAnthropicStream:
 
     def __iter__(self):
         return iter(self.events)
+
+
+class FailingAnthropicStream:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def __iter__(self):
+        if False:
+            yield None
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
 
 
 class FakeAnthropicToolClient:
@@ -191,6 +261,21 @@ class FakeAnthropicToolClient:
         return FakeAnthropicStream([
             _anthropic_text_start(),
             _anthropic_text_delta("查好了。"),
+        ])
+
+
+class FakeAnthropicTransientLimitClient:
+    def __init__(self):
+        self.messages = SimpleNamespace(stream=self.stream)
+        self.calls = 0
+
+    def stream(self, **_kwargs):
+        self.calls += 1
+        if self.calls < 3:
+            return FailingAnthropicStream()
+        return FakeAnthropicStream([
+            _anthropic_text_start(),
+            _anthropic_text_delta("现在可以继续了。"),
         ])
 
 
@@ -257,6 +342,20 @@ def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
     assert all('"ok": true' in end["result_preview"] for end in ends)
     assert tokens == ["查好了。"]
     assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_openai_yields_first_token_before_stream_finishes(monkeypatch):
+    client = FakeOpenAIRealtimeClient()
+    server = _reset_web_server(monkeypatch, client)
+
+    chunks = server._stream_chat("讲一个长一点的回复")
+    try:
+        assert _event_from_chunk(next(chunks))["status"]["phase"] == "thinking"
+        first_token = _event_from_chunk(next(chunks))
+        assert first_token == {"token": "第一段"}
+        assert client.stream.finished is False
+    finally:
+        chunks.close()
 
 
 def test_web_stream_chat_preserves_full_wechat_qr_tool_result(monkeypatch):
@@ -404,6 +503,22 @@ def test_web_stream_chat_retries_transient_concurrency_limit(monkeypatch):
     assert events[-1] == {"done": True}
 
 
+def test_web_stream_chat_anthropic_retries_transient_concurrency_limit(monkeypatch):
+    client = FakeAnthropicTransientLimitClient()
+    server = _reset_web_server(monkeypatch, client, proto="anthropic")
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 3
+    assert [retry["attempt"] for retry in retries] == [1, 2]
+    assert tokens == ["现在可以继续了。"]
+    assert events[-1] == {"done": True}
+
+
 def test_web_stream_chat_discards_partial_tokens_from_failed_retry_attempt(monkeypatch):
     client = FakePartialThenTransientClient()
     server = _reset_web_server(monkeypatch, client)
@@ -417,6 +532,38 @@ def test_web_stream_chat_discards_partial_tokens_from_failed_retry_attempt(monke
     assert client.calls == 2
     assert [retry["attempt"] for retry in retries] == [1]
     assert tokens == ["成功回复。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_marks_retry_reset_when_visible_partial_text_was_sent(monkeypatch):
+    client = FakeEmittedPartialThenTransientClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0,), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 2
+    assert retries[0]["reset_text"] is True
+    assert tokens == ["第一段", "成功回复。"]
+    assert events[-1] == {"done": True}
+
+
+def test_web_stream_chat_resets_visible_partial_text_before_final_busy_reply(monkeypatch):
+    client = FakePersistentVisiblePartialLimitClient()
+    server = _reset_web_server(monkeypatch, client)
+    monkeypatch.setattr(server, "_LLM_TRANSIENT_RETRY_DELAYS", (0,), raising=False)
+
+    events = _events_from(server._stream_chat("继续"))
+
+    retries = [event["retry"] for event in events if "retry" in event]
+    tokens = [event["token"] for event in events if "token" in event]
+
+    assert client.calls == 2
+    assert [retry.get("reset_text") for retry in retries] == [True, True]
+    assert tokens == ["第一段", "第一段", server._llm_busy_reply()]
     assert events[-1] == {"done": True}
 
 

--- a/tests/test_web_streaming.py
+++ b/tests/test_web_streaming.py
@@ -259,6 +259,27 @@ def test_web_stream_chat_openai_reports_keyed_tool_progress(monkeypatch):
     assert events[-1] == {"done": True}
 
 
+def test_web_stream_chat_preserves_full_wechat_qr_tool_result(monkeypatch):
+    import agent
+
+    server = _reset_web_server(monkeypatch, FakeOpenAIToolClient())
+    qr_payload = {
+        "qr_base64": "x" * 900,
+        "qrcode_key": "qr-key-123",
+        "ilink_base": "https://ilinkai.weixin.qq.com",
+    }
+    full_result = json.dumps(qr_payload, ensure_ascii=False)
+    monkeypatch.setattr(agent, "run_tool", lambda _name, _args: full_result)
+
+    events = _events_from(server._stream_chat("配置微信"))
+
+    tool_end = next(event["tool_end"] for event in events if "tool_end" in event)
+    assert "result_preview" in tool_end
+    assert "result" in tool_end
+    assert len(tool_end["result_preview"]) < len(tool_end["result"])
+    assert json.loads(tool_end["result"]) == qr_payload
+
+
 def test_web_stream_chat_anthropic_reports_keyed_tool_progress(monkeypatch):
     server = _reset_web_server(monkeypatch, FakeAnthropicToolClient(), proto="anthropic")
 

--- a/tests/test_wechat_progress.py
+++ b/tests/test_wechat_progress.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _chunk(*, content: str = "", tool_calls=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(delta=delta)])
+
+
+def _tool_call(name: str, arguments: str = "{}"):
+    return SimpleNamespace(
+        index=0,
+        id="call_1",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+class FakeOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls == 1:
+            return [
+                _chunk(
+                    tool_calls=[
+                        _tool_call("get_canvas_todo", '{"limit": 1}'),
+                    ],
+                )
+            ]
+        return [_chunk(content="查好了。")]
+
+
+class FakeThinkingOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return [
+            _chunk(content="<think>hidden reasoning</think>"),
+            _chunk(content="公开回答。"),
+        ]
+
+
+class FakeLoopingOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return [
+            _chunk(
+                tool_calls=[
+                    _tool_call("get_canvas_course_quizzes", '{"course": "电磁学"}'),
+                ],
+            )
+        ]
+
+
+class FakeMultiToolLoopingOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+    def create(self, **_kwargs):
+        return [
+            _chunk(
+                tool_calls=[
+                    _tool_call("get_canvas_course_quizzes", '{"course": "电磁学"}'),
+                    SimpleNamespace(
+                        index=1,
+                        id="call_2",
+                        function=SimpleNamespace(name="get_canvas_todo", arguments='{"limit": 1}'),
+                    ),
+                ],
+            )
+        ]
+
+
+class FakeRotatingCourseUpdatesClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return [
+            _chunk(
+                tool_calls=[
+                    _tool_call(
+                        "get_canvas_course_updates",
+                        f'{{"course": "COURSE{self.calls}", "include": ["announcements", "quizzes"]}}',
+                    ),
+                ],
+            )
+        ]
+
+
+class FailingStream:
+    def __iter__(self):
+        if False:
+            yield None
+        raise RuntimeError("Concurrency limit exceeded for user, please retry later")
+
+
+class FakeTransientLimitOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        if self.calls < 3:
+            return FailingStream()
+        return [_chunk(content="现在可以继续了。")]
+
+
+class FakePersistentLimitOpenAIClient:
+    def __init__(self):
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+        self.calls = 0
+
+    def create(self, **_kwargs):
+        self.calls += 1
+        return FailingStream()
+
+
+def test_wechat_streamed_turn_reports_openai_tool_progress(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    events: list[tuple[str, dict]] = []
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [FakeOpenAIClient()],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(wechat.agent, "run_tool", lambda name, args: '{"ok": true}')
+
+    reply = wechat._streamed_turn(
+        sess,
+        "看看 Canvas 待办",
+        lambda event_type, payload: events.append((event_type, payload)),
+    )
+
+    assert reply == "查好了。"
+    assert events[0][0] == "tool_start"
+    assert events[0][1]["name"] == "get_canvas_todo"
+    assert events[0][1]["index"] == 1
+    assert events[1][0] == "tool_end"
+    assert events[1][1]["name"] == "get_canvas_todo"
+    assert events[1][1]["index"] == 1
+    assert isinstance(events[1][1]["elapsed_ms"], int)
+    assert events[2] == ("first_token", {})
+
+
+def test_wechat_streamed_turn_does_not_expose_think_tags(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [FakeThinkingOpenAIClient()],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+
+    reply = wechat._streamed_turn(sess, "解释一下", lambda *_args: None)
+
+    assert reply == "公开回答。"
+    assert "hidden reasoning" not in reply
+    assert "<think>" not in reply
+
+
+def test_wechat_streamed_turn_stops_repeated_tool_loop(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    events: list[tuple[str, dict]] = []
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [FakeLoopingOpenAIClient()],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(wechat.agent, "run_tool", lambda name, args: '{"ok": false, "error": "course_not_found"}')
+
+    reply = wechat._streamed_turn(
+        sess,
+        "帮我看看电磁学的quiz",
+        lambda event_type, payload: events.append((event_type, payload)),
+        max_rounds=8,
+    )
+
+    assert "连续调用" in reply
+    assert "Canvas Quiz" in reply
+    assert [event for event, _payload in events].count("tool_start") == 3
+    assert [event for event, _payload in events].count("tool_end") == 3
+
+
+def test_wechat_streamed_turn_finishes_peer_tools_before_loop_stop(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [FakeMultiToolLoopingOpenAIClient()],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(wechat.agent, "run_tool", lambda name, args: '{"ok": false}')
+
+    wechat._streamed_turn(sess, "帮我看看电磁学的quiz和todo", lambda *_args: None, max_rounds=8)
+
+    last_tool_call_idx = next(
+        i for i in range(len(sess["messages"]) - 1, -1, -1)
+        if sess["messages"][i].get("role") == "assistant" and sess["messages"][i].get("tool_calls")
+    )
+    last_tool_call_msg = sess["messages"][last_tool_call_idx]
+    following = sess["messages"][last_tool_call_idx + 1 :]
+    tool_ids = [tc["id"] for tc in last_tool_call_msg["tool_calls"]]
+    answered_ids = [m.get("tool_call_id") for m in following if m.get("role") == "tool"]
+
+    assert tool_ids == ["call_1", "call_2"]
+    assert answered_ids[:2] == tool_ids
+
+
+def test_wechat_streamed_turn_stops_after_total_tool_budget(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    events: list[tuple[str, dict]] = []
+    executed: list[tuple[str, dict]] = []
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [FakeRotatingCourseUpdatesClient()],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(
+        wechat.agent,
+        "run_tool",
+        lambda name, args: executed.append((name, args)) or '{"ok": true}',
+    )
+
+    reply = wechat._streamed_turn(
+        sess,
+        "帮我看看 quiz 和最新通知，还有最近任务",
+        lambda event_type, payload: events.append((event_type, payload)),
+        max_rounds=8,
+        max_tool_calls=3,
+    )
+
+    assert len(executed) == 3
+    assert "工具调用次数已经达到上限" in reply
+    assert "get_canvas_overview" in reply
+    assert events[-1][0] == "tool_limit"
+    assert events[-1][1]["max_tool_calls"] == 3
+
+
+def test_wechat_system_context_includes_canvas_course_index(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    monkeypatch.setattr(
+        wechat,
+        "_get_canvas_course_index",
+        lambda: [
+            {"course_id": 92355, "name": "ECE2300JSU2026-1", "course_code": "ECE2300JSU2026-1"},
+            {"course_id": 92353, "name": "ECE2700JSU2026", "course_code": "ECE2700JSU2026"},
+        ],
+    )
+
+    context = wechat._build_system_ctx()
+
+    assert "当前 Canvas 课程索引" in context
+    assert "92355 | ECE2300JSU2026-1 | ECE2300JSU2026-1" in context
+    assert "用户说“230这门课”时" in context
+
+
+def test_wechat_progress_sender_sends_visible_status_messages():
+    import scripts.wechat_bot as wechat
+
+    sent: list[str] = []
+
+    class FakeClient:
+        def send(self, text: str, to_user_id: str = "", context_token: str = ""):
+            sent.append(text)
+            assert to_user_id == "user-1"
+            assert context_token == "ctx-1"
+
+    on_progress = wechat._make_progress_sender(FakeClient(), "user-1", "ctx-1")
+
+    on_progress("thinking", {})
+    on_progress("tool_start", {"name": "get_canvas_todo", "index": 2, "summary": "limit=3"})
+    on_progress("tool_end", {"name": "get_canvas_todo", "index": 2, "elapsed_ms": 1234})
+    on_progress("retry", {"attempt": 1, "delay_s": 2})
+    on_progress("tool_limit", {"max_tool_calls": 12})
+    on_progress("first_token", {})
+
+    assert sent == [
+        "⏳ 正在思考…",
+        "⚙️ #2 正在读取 Canvas 待办：limit=3…",
+        "✅ #2 正在读取 Canvas 待办（1.2s）",
+        "⏳ 模型服务忙，2s 后自动重试（第 1 次）…",
+        "⏹️ 工具调用已到上限（12 次），正在整理已有结果…",
+        "💬 开始生成回复…",
+    ]
+
+
+def test_wechat_streamed_turn_retries_transient_concurrency_limit(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    events: list[tuple[str, dict]] = []
+    client = FakeTransientLimitOpenAIClient()
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [client],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(wechat, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    reply = wechat._streamed_turn(
+        sess,
+        "继续",
+        lambda event_type, payload: events.append((event_type, payload)),
+    )
+
+    assert reply == "现在可以继续了。"
+    assert client.calls == 3
+    assert [event for event, _payload in events] == ["retry", "retry", "first_token"]
+
+
+def test_wechat_streamed_turn_returns_friendly_message_when_concurrency_limit_persists(monkeypatch):
+    import scripts.wechat_bot as wechat
+
+    client = FakePersistentLimitOpenAIClient()
+    sess = {
+        "messages": [],
+        "model_box": ["deepseek-chat"],
+        "client_box": [client],
+    }
+
+    monkeypatch.setattr(wechat.agent, "_is_anthropic_model", lambda _model: False)
+    monkeypatch.setattr(wechat, "_LLM_TRANSIENT_RETRY_DELAYS", (0, 0), raising=False)
+
+    reply = wechat._streamed_turn(sess, "继续", lambda *_args: None)
+
+    assert client.calls == 3
+    assert "模型服务现在有点忙" in reply
+    assert "Concurrency limit" not in reply
+    assert sess["messages"][-1] == {"role": "assistant", "content": reply}


### PR DESCRIPTION
## Why

- WeChat bot course recognition and progress updates were still easy to stall on vague Canvas references, repeated tool loops, and transient upstream rate/concurrency errors.
- The local web agent now has better streaming progress behavior, but those web fixes were still only local and needed to ship with the related WeChat and Canvas robustness work.
- Canvas course resolution was too strict and fragile when the course list endpoint briefly returned 502/503 responses.

## What Changed

- Added the web agent streaming/progress fixes from the current detached-head work: better token streaming, retry reset behavior, Anthropic retry parity, and safer `/api/chat/clear` handling.
- Improved `scripts/wechat_bot.py` with Canvas course-index context, visible progress events, retry/tool-budget/repeated-tool guards, and hidden `<think>` stripping so WeChat users see clearer status without leaking reasoning text.
- Added `get_canvas_overview`, expanded Canvas tool guidance/labels, and taught `CanvasClient` to retry transient 502/503 course-list failures, cache a slim course index, and resolve short numeric references such as `230这门课` against codes like `ECE2300JSU2026-1`.
- Added regression coverage for the web SSE flow, WeChat progress sender/turn runner, Canvas cache fallback, short-number matching, and the new overview tool.
