### PR TITLE
chore: bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.3.3"
+version = "0.3.4"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
## Summary

Patch release — v0.3.3 → v0.3.4.

### Changes since v0.3.3

**API 适配:**
- course.sjtu.plus: Playwright form-fill login, CSRF token, search param fix (search→q), 301 redirect
- share.dyweb.sjtu.cn: OAuth2 JWT login, api-v2 subdomain, material parsing (classes[].materials[])

**安全修复 (P1-P4 + re-audit, 16→0):**
- Path traversal, CORS, command injection, XSS, SSRF
- File permissions, env var stripping, dependency lock
- Web auth: URL token → HttpOnly cookie

**测试:**
- 42 new feishu_bot tests (74→116 total)
- conftest.py for CI config injection

**LLM:**
- Prompt fixes preventing URL fabrication and fetch_url misuse