### PR TITLE
add: Canvas file browsing + tracking system ([#86])

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kuan-er
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -521,6 +521,17 @@ _TOOL_LABELS = {
 
     "setup_canvas":          "正在引导配置 Canvas",
 
+    "list_canvas_folders":     "正在浏览 Canvas 文件夹",
+    "list_canvas_files":       "正在列出 Canvas 文件",
+    "canvas_file_tree":        "正在构建 Canvas 文件树",
+    "download_canvas_file":    "正在下载 Canvas 文件",
+    "canvas_track_mark":       "正在标记文件已处理",
+    "canvas_track_unmark":     "正在取消标记",
+    "canvas_track_list":       "正在列出已处理文件",
+    "canvas_track_status":     "正在查看处理进度",
+    "canvas_track_diff":       "正在查看未处理文件",
+    "canvas_track_mark_course":"正在标记全部文件已处理",
+
     "setup_shuiyuan":          "正在授权水源社区",
 
     "add_mcp_server":          "正在添加自定义 MCP Server",

--- a/sjtu_agent/agent/tools/_canvas_files.py
+++ b/sjtu_agent/agent/tools/_canvas_files.py
@@ -1,0 +1,427 @@
+"""sjtu_agent/agent/tools/_canvas_files.py — Canvas file browsing, download & tracking tools.
+
+Exports:
+- ``TOOLS_ENTRIES`` — list of OpenAI function-calling schema dicts
+- ``tool_*`` functions — each returns a dict; dispatched by ``run_tool()``
+"""
+
+from __future__ import annotations
+
+from sjtu_agent.canvas_client import CanvasError
+from sjtu_agent.canvas_files import CanvasFilesTracker
+from sjtu_agent.agent.tools._canvas_utils import (
+    _make_canvas_client,
+    _canvas_error_payload,
+    _resolve_canvas_course_or_error,
+)
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Tool schema definitions
+# ══════════════════════════════════════════════════════════════════════════════
+
+TOOLS_ENTRIES = [
+    {
+        "type": "function",
+        "function": {
+            "name": "list_canvas_folders",
+            "description": (
+                "列出 Canvas 课程中的文件夹。可以指定某个文件夹 ID 来列出其子文件夹。"
+                "用课程名称/代码/ID 来定位课程。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id，如「高等数学」「MATH1201」「92337」",
+                    },
+                    "folder_id": {
+                        "type": "integer",
+                        "description": "可选，指定文件夹 ID 以列出子文件夹",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_canvas_files",
+            "description": (
+                "列出 Canvas 课程中的文件。可以按文件夹 ID 或搜索关键词筛选。"
+                "用于查找课程资料、课件、作业文件等。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id",
+                    },
+                    "folder_id": {
+                        "type": "integer",
+                        "description": "可选，只列出指定文件夹中的文件",
+                    },
+                    "search": {
+                        "type": "string",
+                        "description": "可选，按文件名搜索（支持 Canvas search_term 参数）",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_file_tree",
+            "description": (
+                "显示 Canvas 课程中所有文件夹和文件的完整目录树。"
+                "包含文件夹层级结构和每个文件的 size/mime 信息。"
+                "参数需要课程名/代码或数字 course_id。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "download_canvas_file",
+            "description": (
+                "根据文件 ID 下载 Canvas 课程文件到本地。"
+                "下载路径默认为 canvas_downloads 目录，可自定义。"
+                "先通过 list_canvas_files 或 canvas_file_tree 获取文件 ID。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_id": {
+                        "type": "integer",
+                        "description": "Canvas 文件 ID（从 list_canvas_files 或 canvas_file_tree 获取）",
+                    },
+                    "output_dir": {
+                        "type": "string",
+                        "description": "可选，下载目录路径。默认为 canvas_downloads 目录",
+                    },
+                },
+                "required": ["file_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_mark",
+            "description": (
+                "将 Canvas 文件标记为「已处理」（已整合到笔记）。"
+                "可以添加备注说明该文件被整合到了哪里。"
+                "用户说「把这个文件标记为已读」「标记为已处理」「这个课件我已经整理了」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_id": {
+                        "type": "integer",
+                        "description": "Canvas 文件 ID",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "可选，文件名称。不提供则自动从 Canvas 获取",
+                    },
+                    "course_id": {
+                        "type": "integer",
+                        "description": "可选，课程 ID。不提供则自动从 Canvas 获取",
+                    },
+                    "notes": {
+                        "type": "string",
+                        "description": "可选备注，如「已整理到第3章笔记」「已做思维导图」",
+                    },
+                },
+                "required": ["file_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_unmark",
+            "description": (
+                "取消 Canvas 文件的「已处理」标记，将其从处理列表中移除。"
+                "用户说「取消标记」「这个文件还没整理」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "file_id": {
+                        "type": "integer",
+                        "description": "Canvas 文件 ID",
+                    },
+                },
+                "required": ["file_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_list",
+            "description": (
+                "列出所有已标记为已处理的 Canvas 文件（跨全部课程）。"
+                "按处理时间倒序排列。用户说「列出已处理的文件」「哪些课件我已经整理过了」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_status",
+            "description": (
+                "显示 Canvas 课程的文件处理进度。在文件树中标注 ✅ 已处理 / ⏳ 未处理，"
+                "并在末尾显示完成百分比。用户说「看看这门课还有多少没整理」「课件处理进度」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_diff",
+            "description": (
+                "只显示 Canvas 课程中尚未处理的文件（新增/未整理）。"
+                "用于快速查看有哪些课件还没看。用户说「有哪些新文件」「哪些课件没看」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "canvas_track_mark_course",
+            "description": (
+                "将 Canvas 课程中的全部文件标记为已处理。"
+                "适用于初次同步时批量标记。用户说「标记这门课的所有文件」「这门课已经全部整理完了」时调用。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "course": {
+                        "type": "string",
+                        "description": "课程名称、课程代码或 course_id",
+                    },
+                },
+                "required": ["course"],
+            },
+        },
+    },
+]
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Tool implementations
+# ══════════════════════════════════════════════════════════════════════════════
+
+def tool_list_canvas_folders(course: str, folder_id: int | None = None) -> dict:
+    """List folders in a Canvas course."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        result = client.list_folders(course_info["course_id"], folder_id=folder_id)
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_list_canvas_files(
+    course: str,
+    folder_id: int | None = None,
+    search: str | None = None,
+) -> dict:
+    """List files in a Canvas course."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        result = client.list_files(
+            course_info["course_id"],
+            folder_id=folder_id,
+            search=search,
+        )
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_canvas_file_tree(course: str) -> dict:
+    """Show folder/file tree for a Canvas course."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        result = client.get_folder_tree(course_info["course_id"])
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_download_canvas_file(file_id: int, output_dir: str = "") -> dict:
+    """Download a Canvas file by file ID."""
+    try:
+        client = _make_canvas_client()
+        od = output_dir if output_dir else None
+        result = client.download_file(file_id, output_dir=od)
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_canvas_track_mark(
+    file_id: int,
+    name: str = "",
+    course_id: int | None = None,
+    notes: str = "",
+) -> dict:
+    """Mark a file as processed."""
+    tracker = CanvasFilesTracker()
+    display_name = name
+    resolved_course_id = course_id
+
+    # If name or course_id missing, fetch from Canvas API
+    if not display_name or resolved_course_id is None:
+        try:
+            client = _make_canvas_client()
+            info = client.get_file(file_id)
+            if info.get("ok"):
+                fdata = info["file"]
+                if not display_name:
+                    display_name = fdata.get("display_name", str(file_id))
+                if resolved_course_id is None:
+                    resolved_course_id = fdata.get("course_id")
+        except Exception:
+            if not display_name:
+                display_name = str(file_id)
+
+    return tracker.mark(file_id, display_name, course_id=resolved_course_id, notes=notes)
+
+
+def tool_canvas_track_unmark(file_id: int) -> dict:
+    """Remove a file from the processed list."""
+    tracker = CanvasFilesTracker()
+    try:
+        return tracker.unmark(file_id)
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+
+
+def tool_canvas_track_list() -> dict:
+    """List all processed files."""
+    tracker = CanvasFilesTracker()
+    return tracker.list_all()
+
+
+def tool_canvas_track_status(course: str) -> dict:
+    """Show course file tree with processed/unprocessed markers."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        course_id = course_info["course_id"]
+
+        tree = client.get_folder_tree(course_id)
+        if not tree.get("ok"):
+            return tree
+
+        tracker = CanvasFilesTracker()
+        result = tracker.get_course_status(course_id, tree)
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_canvas_track_diff(course: str) -> dict:
+    """Show only unprocessed files in a course."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        course_id = course_info["course_id"]
+
+        tree = client.get_folder_tree(course_id)
+        if not tree.get("ok"):
+            return tree
+
+        tracker = CanvasFilesTracker()
+        result = tracker.get_course_diff(course_id, tree)
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)
+
+
+def tool_canvas_track_mark_course(course: str) -> dict:
+    """Mark all files in a course as processed."""
+    try:
+        client = _make_canvas_client()
+        resolved = _resolve_canvas_course_or_error(client, course)
+        if not resolved.get("ok"):
+            return resolved
+        course_info = resolved["course"]
+        course_id = course_info["course_id"]
+
+        # Get flat list of ALL files
+        files_result = client.list_files(course_id)
+        files_list = files_result.get("files", [])
+
+        tracker = CanvasFilesTracker()
+        result = tracker.mark_course(course_id, files_list)
+        result["course"] = course_info
+        return result
+    except CanvasError as exc:
+        return _canvas_error_payload(exc)

--- a/sjtu_agent/agent/tools/_canvas_utils.py
+++ b/sjtu_agent/agent/tools/_canvas_utils.py
@@ -1,0 +1,39 @@
+"""sjtu_agent/agent/tools/_canvas_utils.py — shared Canvas helpers.
+
+These are used by both ``_core.py`` and ``_canvas_files.py`` to avoid
+circular imports when submodules need Canvas client access.
+"""
+
+from __future__ import annotations
+
+from sjtu_agent.canvas_client import CanvasError, make_client_from_config
+
+_CANVAS_DEFAULT_BASE_URL = "https://oc.sjtu.edu.cn"
+
+
+def _canvas_settings_url(base_url: str) -> str:
+    return base_url.rstrip("/") + "/profile/settings"
+
+
+def _make_canvas_client():
+    """Create a CanvasClient from config.json."""
+    return make_client_from_config()
+
+
+def _canvas_error_payload(exc: CanvasError) -> dict:
+    """Format a CanvasError into a dict the LLM can understand."""
+    import ddl_checker as dc
+    payload = exc.to_dict()
+    if exc.code in ("missing_token", "invalid_token"):
+        base = dc.load_config().get("canvas_base_url", _CANVAS_DEFAULT_BASE_URL)
+        payload["settings_url"] = _canvas_settings_url(base)
+        payload["next_action"] = "请先调用 setup_canvas 获取或刷新 Canvas Token。"
+    return payload
+
+
+def _resolve_canvas_course_or_error(client, course) -> dict:
+    """Resolve a course by name/code/id. Returns {"ok": True, "course": ...} or error."""
+    resolved = client.resolve_course(course)
+    if not resolved.get("ok"):
+        return resolved
+    return {"ok": True, "course": resolved["course"]}

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -54,6 +54,12 @@ except ImportError:
 
 import ddl_checker as dc
 from sjtu_agent.canvas_client import CanvasError, make_client_from_config
+from sjtu_agent.agent.tools._canvas_utils import (
+    _make_canvas_client,
+    _canvas_error_payload,
+    _resolve_canvas_course_or_error,
+    _canvas_settings_url,
+)
 from sjtu_agent.canvas_monitor import update_canvas_monitor_config
 
 from sjtu_agent.agent.tools._reminders import (
@@ -84,6 +90,14 @@ from sjtu_agent.agent.tools._platforms import (
 from sjtu_agent.agent.tools._mcp_skills import (
     TOOLS_ENTRIES as _MCP_SKILLS_TOOLS,
     tool_add_mcp_server, tool_add_skill, tool_create_skill, tool_list_skills, tool_manage_skill,
+)
+
+from sjtu_agent.agent.tools._canvas_files import (
+    TOOLS_ENTRIES as _CANVAS_FILES_TOOLS,
+    tool_list_canvas_folders, tool_list_canvas_files, tool_canvas_file_tree,
+    tool_download_canvas_file,
+    tool_canvas_track_mark, tool_canvas_track_unmark, tool_canvas_track_list,
+    tool_canvas_track_status, tool_canvas_track_diff, tool_canvas_track_mark_course,
 )
 
 TOOLS = [
@@ -829,6 +843,7 @@ TOOLS = [
         },
     },
     *_EMAIL_TOOLS,
+    *_CANVAS_FILES_TOOLS,
 ]
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -941,10 +956,6 @@ _MYSJTU_CATEGORY_ALIASES: dict[str, list[str]] = {
 _MYSJTU_SEARCH_ONLY_HINTS = {
     "图书馆", "教务", "教务服务", "校园卡", "信息服务", "生活服务", "财务", "后勤",
 }
-
-
-def _canvas_settings_url(base_url: str) -> str:
-    return base_url.rstrip("/") + "/profile/settings"
 
 
 def _canvas_openid_connect_url(base_url: str) -> str:
@@ -3209,26 +3220,6 @@ def tool_download_assignments(
     }
 
 
-def _make_canvas_client():
-    return make_client_from_config()
-
-
-def _canvas_error_payload(exc: CanvasError) -> dict:
-    payload = exc.to_dict()
-    if exc.code in ("missing_token", "invalid_token"):
-        base = dc.load_config().get("canvas_base_url", _CANVAS_DEFAULT_BASE_URL)
-        payload["settings_url"] = _canvas_settings_url(base)
-        payload["next_action"] = "请先调用 setup_canvas 获取或刷新 Canvas Token。"
-    return payload
-
-
-def _resolve_canvas_course_or_error(client, course) -> dict:
-    resolved = client.resolve_course(course)
-    if not resolved.get("ok"):
-        return resolved
-    return {"ok": True, "course": resolved["course"]}
-
-
 def tool_list_canvas_courses(include_tabs: bool = False, include_teachers: bool = False) -> dict:
     try:
         client = _make_canvas_client()
@@ -3528,6 +3519,16 @@ def run_tool(name: str, args: dict) -> str:
         elif name == "configure_canvas_monitor": r = tool_configure_canvas_monitor(**args)
         elif name == "list_canvas_assignments":  r = tool_list_canvas_assignments(**args)
         elif name == "submit_canvas_assignment": r = tool_submit_canvas_assignment(**args)
+        elif name == "list_canvas_folders":      r = tool_list_canvas_folders(**args)
+        elif name == "list_canvas_files":        r = tool_list_canvas_files(**args)
+        elif name == "canvas_file_tree":         r = tool_canvas_file_tree(**args)
+        elif name == "download_canvas_file":     r = tool_download_canvas_file(**args)
+        elif name == "canvas_track_mark":        r = tool_canvas_track_mark(**args)
+        elif name == "canvas_track_unmark":      r = tool_canvas_track_unmark(**args)
+        elif name == "canvas_track_list":        r = tool_canvas_track_list()
+        elif name == "canvas_track_status":      r = tool_canvas_track_status(**args)
+        elif name == "canvas_track_diff":        r = tool_canvas_track_diff(**args)
+        elif name == "canvas_track_mark_course": r = tool_canvas_track_mark_course(**args)
         elif name == "read_emails":              r = tool_read_emails(**args)
         elif name == "search_emails":            r = tool_search_emails(**args)
         elif name == "send_email":               r = tool_send_email(**args)

--- a/sjtu_agent/canvas_client.py
+++ b/sjtu_agent/canvas_client.py
@@ -4,6 +4,7 @@ import hashlib
 import re
 from datetime import datetime, timedelta, timezone
 from html import unescape
+from pathlib import Path
 from typing import Any
 
 import requests
@@ -415,6 +416,248 @@ class CanvasClient:
             "warnings": warnings,
         }
 
+    # ── File / Folder Methods ────────────────────────────────────────────
+
+    def list_folders(self, course_id: int, folder_id: int | None = None) -> dict:
+        """List folders in a course or inside a specific folder."""
+        if folder_id:
+            path = f"/api/v1/folders/{folder_id}/folders"
+        else:
+            path = f"/api/v1/courses/{course_id}/folders"
+        payload = self._get_all_pages(path, {"per_page": 100})
+        folders = [
+            {
+                "id": f["id"],
+                "name": f.get("name", ""),
+                "full_name": f.get("full_name", ""),
+                "parent_folder_id": f.get("parent_folder_id"),
+                "context_type": f.get("context_type", ""),
+                "context_id": f.get("context_id"),
+                "files_count": f.get("files_count", 0),
+                "folders_count": f.get("folders_count", 0),
+                "created_at": f.get("created_at"),
+                "updated_at": f.get("updated_at"),
+            }
+            for f in payload
+            if isinstance(f, dict)
+        ]
+        return {"ok": True, "count": len(folders), "folders": folders}
+
+    def list_files(
+        self,
+        course_id: int,
+        folder_id: int | None = None,
+        search: str | None = None,
+    ) -> dict:
+        """List files in a course, optionally under a specific folder or filtered by search term."""
+        if folder_id:
+            path = f"/api/v1/folders/{folder_id}/files"
+        else:
+            path = f"/api/v1/courses/{course_id}/files"
+        params: dict = {"per_page": 100}
+        if search:
+            params["search_term"] = search
+        payload = self._get_all_pages(path, params)
+        files = [
+            {
+                "id": f["id"],
+                "display_name": f.get("display_name", ""),
+                "filename": f.get("filename", ""),
+                "size": f.get("size", 0),
+                "size_human": _format_size(f.get("size", 0)),
+                "mime_class": f.get("mime_class", ""),
+                "content_type": f.get("content-type", ""),
+                "folder_id": f.get("folder_id"),
+                "url": f.get("url", ""),
+                "updated_at": f.get("updated_at"),
+            }
+            for f in payload
+            if isinstance(f, dict)
+        ]
+        return {"ok": True, "count": len(files), "files": files}
+
+    def get_file(self, file_id: int) -> dict:
+        """Get file metadata by file ID."""
+        payload, _ = self._get_json(f"/api/v1/files/{file_id}")
+        if not isinstance(payload, dict):
+            raise CanvasError("unexpected_schema", "文件信息不是对象")
+        return {
+            "ok": True,
+            "file": {
+                "id": payload.get("id"),
+                "display_name": payload.get("display_name", ""),
+                "filename": payload.get("filename", ""),
+                "size": payload.get("size", 0),
+                "size_human": _format_size(payload.get("size", 0)),
+                "mime_class": payload.get("mime_class", ""),
+                "content_type": payload.get("content-type", ""),
+                "folder_id": payload.get("folder_id"),
+                "url": payload.get("url", ""),
+                "updated_at": payload.get("updated_at"),
+                "created_at": payload.get("created_at"),
+            },
+        }
+
+    def _fetch_all_folders(self, course_id: int) -> dict[int, dict]:
+        """Fetch all folders in a course, returning {folder_id: folder_dict}."""
+        raw = self._get_all_pages(f"/api/v1/courses/{course_id}/folders", {"per_page": 100})
+        return {f["id"]: f for f in raw if isinstance(f, dict)}
+
+    def get_folder_tree(self, course_id: int) -> dict:
+        """Get the full folder/file tree for a course."""
+        folders_dict = self._fetch_all_folders(course_id)
+
+        # Build parent-child folder mapping
+        folder_children: dict[int, list[dict]] = {}
+        root_folders: list[dict] = []
+        for fid, f in folders_dict.items():
+            pid = f.get("parent_folder_id")
+            if pid and pid in folders_dict:
+                folder_children.setdefault(pid, []).append(f)
+            else:
+                root_folders.append(f)
+
+        # Sort by name
+        for pid in folder_children:
+            folder_children[pid].sort(key=lambda x: x.get("name", "").lower())
+        root_folders.sort(key=lambda x: x.get("name", "").lower())
+
+        # Warn count estimate
+        total_folders = len(folders_dict)
+
+        def _build_node(folder: dict, depth: int = 0) -> dict:
+            """Recursively build a tree node with files and subfolders."""
+            node: dict = {
+                "id": folder["id"],
+                "name": folder.get("name", "?"),
+                "full_name": folder.get("full_name", ""),
+                "depth": depth,
+                "files": [],
+                "folders": [],
+            }
+
+            # Fetch files in this folder
+            try:
+                files_raw = self._get_all_pages(
+                    f"/api/v1/folders/{folder['id']}/files",
+                    {"per_page": 100},
+                )
+                files_raw.sort(key=lambda x: x.get("display_name", "").lower())
+                for f in files_raw:
+                    if not isinstance(f, dict):
+                        continue
+                    node["files"].append({
+                        "id": f["id"],
+                        "display_name": f.get("display_name", "?"),
+                        "size": f.get("size", 0),
+                        "size_human": _format_size(f.get("size")),
+                        "mime_class": f.get("mime_class", ""),
+                        "folder_id": f.get("folder_id"),
+                        "updated_at": f.get("updated_at"),
+                    })
+            except CanvasError:
+                node.setdefault("warnings", []).append(f"Could not fetch files for folder {folder['id']}")
+
+            # Recurse into subfolders
+            for child in folder_children.get(folder["id"], []):
+                node["folders"].append(_build_node(child, depth + 1))
+
+            return node
+
+        tree: list[dict] = []
+        if not root_folders:
+            # Try root-level files
+            try:
+                files_raw = self._get_all_pages(
+                    f"/api/v1/courses/{course_id}/files",
+                    {"per_page": 100},
+                )
+                files_raw.sort(key=lambda x: x.get("display_name", "").lower())
+                root_files = [
+                    {
+                        "id": f["id"],
+                        "display_name": f.get("display_name", "?"),
+                        "size": f.get("size", 0),
+                        "size_human": _format_size(f.get("size")),
+                        "mime_class": f.get("mime_class", ""),
+                        "folder_id": f.get("folder_id"),
+                        "updated_at": f.get("updated_at"),
+                    }
+                    for f in files_raw
+                    if isinstance(f, dict)
+                ]
+                if root_files:
+                    tree.append({
+                        "id": None,
+                        "name": "(root)",
+                        "full_name": "",
+                        "depth": 0,
+                        "files": root_files,
+                        "folders": [],
+                    })
+            except CanvasError:
+                pass
+        else:
+            for folder in root_folders:
+                tree.append(_build_node(folder))
+
+        return {
+            "ok": True,
+            "course_id": course_id,
+            "total_folders": total_folders,
+            "tree": tree,
+        }
+
+    def download_file(self, file_id: int, output_dir: str | None = None) -> dict:
+        """Download a Canvas file by file ID.
+
+        Step 1: Get file metadata to obtain the download URL.
+        Step 2: Stream the download to disk.
+        """
+        # Get file metadata
+        file_info = self.get_file(file_id)
+        if not file_info.get("ok"):
+            return file_info
+        meta = file_info["file"]
+        download_url = meta.get("url")
+        if not download_url:
+            raise CanvasError("no_download_url", f"文件 {file_id} 没有下载 URL")
+
+        display_name = meta.get("display_name", f"file_{file_id}")
+        safe_name = _sanitize_filename(display_name)
+        out_dir = Path(output_dir) if output_dir else _canvas_downloads_dir()
+        out_dir = out_dir.resolve()
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        output_path = out_dir / safe_name
+
+        try:
+            # Download — use a fresh session without auth header for the CDN redirect
+            dl_response = requests.get(download_url, timeout=300, stream=True)
+            dl_response.raise_for_status()
+            with open(output_path, "wb") as fh:
+                for chunk in dl_response.iter_content(chunk_size=8192):
+                    fh.write(chunk)
+        except requests.HTTPError as exc:
+            raise CanvasError(
+                "download_error",
+                f"下载失败: HTTP {exc.response.status_code if exc.response else '?'}",
+            ) from exc
+        except requests.RequestException as exc:
+            raise CanvasError("download_error", f"下载失败: {exc}") from exc
+
+        file_size = meta.get("size", 0)
+        return {
+            "success": True,
+            "file_id": file_id,
+            "display_name": display_name,
+            "saved_to": str(output_path),
+            "size": file_size,
+            "size_human": _format_size(file_size),
+        }
+
+    # ── Normalize helpers ────────────────────────────────────────────────
+
     def _normalize_course(self, course: dict) -> dict:
         return {
             "course_id": course.get("id"),
@@ -526,6 +769,28 @@ def _parse_dt(value: str | None):
         return dt.astimezone(CST)
     except Exception:
         return None
+
+
+def _format_size(size_bytes: int | None) -> str:
+    """Human-readable file size."""
+    if size_bytes is None:
+        return "?"
+    for unit in ("B", "KB", "MB", "GB"):
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}" if unit != "B" else f"{size_bytes} B"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} TB"
+
+
+def _sanitize_filename(name: str) -> str:
+    """Replace unsafe filename characters with underscores."""
+    return re.sub(r'[^\w\-\. ]', '_', name)
+
+
+def _canvas_downloads_dir() -> Path:
+    """Get the default Canvas downloads directory (lazy import to avoid circular deps)."""
+    from sjtu_agent.paths import CANVAS_DOWNLOADS_DIR
+    return CANVAS_DOWNLOADS_DIR
 
 
 def _is_current_canvas_item(item: dict) -> bool:

--- a/sjtu_agent/canvas_client.py
+++ b/sjtu_agent/canvas_client.py
@@ -632,8 +632,11 @@ class CanvasClient:
         output_path = out_dir / safe_name
 
         try:
-            # Download — use a fresh session without auth header for the CDN redirect
-            dl_response = requests.get(download_url, timeout=300, stream=True)
+            # Download using the authenticated session so CDN URLs that require
+            # the Bearer token work.  requests strips the Authorization header
+            # on cross-origin redirects, so the token won't leak to third-party
+            # CDNs.
+            dl_response = self.session.get(download_url, timeout=300, stream=True)
             dl_response.raise_for_status()
             with open(output_path, "wb") as fh:
                 for chunk in dl_response.iter_content(chunk_size=8192):

--- a/sjtu_agent/canvas_files.py
+++ b/sjtu_agent/canvas_files.py
@@ -28,6 +28,7 @@ import shutil
 from pathlib import Path
 from typing import Any
 
+from sjtu_agent.canvas_client import _format_size
 from sjtu_agent.paths import (
     CANVAS_PROCESSED_FILES_PATH,
     PROJECT_ROOT,
@@ -118,7 +119,7 @@ class CanvasFilesTracker:
                 "processed_at": info.get("processed_at", ""),
                 "notes": info.get("notes", ""),
                 "size": size_val,
-                "size_human": _format_size_human(size_val) if size_val else "?",
+                "size_human": _format_size(size_val),
             })
         items.sort(key=lambda x: x.get("processed_at") or "", reverse=True)
         return {"ok": True, "count": len(items), "files": items}
@@ -241,15 +242,3 @@ class CanvasFilesTracker:
         if legacy.exists() and legacy.is_file():
             self._path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(legacy, self._path)
-
-
-def _format_size_human(size_bytes: int | None) -> str:
-    """Human-readable file size (standalone copy to avoid circular import)."""
-    if size_bytes is None:
-        return "?"
-    s = float(size_bytes)
-    for unit in ("B", "KB", "MB", "GB"):
-        if s < 1024:
-            return f"{s:.1f} {unit}" if unit != "B" else f"{int(s)} B"
-        s /= 1024
-    return f"{s:.1f} TB"

--- a/sjtu_agent/canvas_files.py
+++ b/sjtu_agent/canvas_files.py
@@ -1,0 +1,255 @@
+"""sjtu_agent/canvas_files.py — Canvas processed-file tracking.
+
+CanvasFilesTracker persists which Canvas course files have been "processed"
+(integrated into notes).  The state file lives at CANVAS_PROCESSED_FILES_PATH
+inside the runtime data directory and uses atomic writes to avoid corruption.
+
+Schema (compatible with the standalone canvas/ skill)::
+
+    {
+      "13339023": {
+        "display_name": "255-su260512.pdf",
+        "course_id": 92337,
+        "size": 12345,
+        "processed_at": "2026-06-16T17:32:57.787886",
+        "notes": "线性方程组与矩阵"
+      }
+    }
+
+On first init, if the state file doesn't exist but a legacy file is found at
+``canvas/processed_files.json`` relative to the project root, it is copied
+automatically.
+"""
+
+from __future__ import annotations
+
+import datetime
+import shutil
+from pathlib import Path
+from typing import Any
+
+from sjtu_agent.paths import (
+    CANVAS_PROCESSED_FILES_PATH,
+    PROJECT_ROOT,
+    atomic_write_json,
+    read_json_safe,
+)
+
+
+def _now_iso() -> str:
+    return datetime.datetime.now().isoformat()
+
+
+class CanvasFilesTracker:
+    """Track which Canvas course files have been processed.
+
+    Usage::
+
+        tracker = CanvasFilesTracker()
+        tracker.mark(13339023, "slides.pdf", course_id=92337, notes="已整理")
+        status = tracker.get_course_status(92337, tree)
+    """
+
+    def __init__(self, path: Path | None = None):
+        self._path = path or CANVAS_PROCESSED_FILES_PATH
+        # One-time migration from legacy canvas/processed_files.json
+        self._migrate_if_needed()
+
+    # ── public API ───────────────────────────────────────────────────────
+
+    def mark(
+        self,
+        file_id: int,
+        display_name: str,
+        course_id: int | None = None,
+        notes: str = "",
+    ) -> dict:
+        """Mark a file as processed.
+
+        Returns a dict with ``success``, ``file_id``, ``display_name``, …
+        """
+        db = self._load()
+        key = str(file_id)
+        entry = db.get(key, {})
+        entry["display_name"] = display_name
+        if course_id is not None:
+            entry["course_id"] = course_id
+        entry["processed_at"] = _now_iso()
+        if notes:
+            entry["notes"] = notes
+        db[key] = entry
+        self._save(db)
+        return {
+            "success": True,
+            "file_id": file_id,
+            "display_name": display_name,
+            "course_id": course_id,
+            "notes": notes,
+        }
+
+    def unmark(self, file_id: int) -> dict:
+        """Remove a file from the processed list.
+
+        Raises ValueError if the file was not tracked.
+        """
+        db = self._load()
+        key = str(file_id)
+        if key not in db:
+            raise ValueError(f"文件 {file_id} 不在已处理列表中")
+        info = db.pop(key)
+        self._save(db)
+        return {
+            "success": True,
+            "file_id": file_id,
+            "display_name": info.get("display_name", ""),
+            "action": "unmarked",
+        }
+
+    def list_all(self) -> dict:
+        """Return all processed files across all courses, most recent first."""
+        db = self._load()
+        items: list[dict] = []
+        for fid, info in db.items():
+            size_val = info.get("size")
+            items.append({
+                "file_id": int(fid),
+                "display_name": info.get("display_name", "?"),
+                "course_id": info.get("course_id"),
+                "processed_at": info.get("processed_at", ""),
+                "notes": info.get("notes", ""),
+                "size": size_val,
+                "size_human": _format_size_human(size_val) if size_val else "?",
+            })
+        items.sort(key=lambda x: x.get("processed_at") or "", reverse=True)
+        return {"ok": True, "count": len(items), "files": items}
+
+    def get_course_status(self, course_id: int, tree: dict) -> dict:
+        """Annotate a folder tree with processed/unprocessed status.
+
+        ``tree`` should be the result of ``CanvasClient.get_folder_tree()``
+        (``{"ok": True, "tree": [...]}``).
+
+        Returns the same tree shape with each file node gaining a
+        ``processed`` (bool) field, plus summary counts.
+        """
+        db = self._load()
+        stats = {"processed": 0, "unprocessed": 0}
+
+        def _annotate_node(node: dict) -> dict:
+            annotated_files = []
+            for f in node.get("files", []):
+                fid = str(f.get("id", ""))
+                is_proc = fid in db
+                entry = dict(f)
+                entry["processed"] = is_proc
+                if is_proc:
+                    stats["processed"] += 1
+                else:
+                    stats["unprocessed"] += 1
+                annotated_files.append(entry)
+            return {
+                **node,
+                "files": annotated_files,
+                "folders": [_annotate_node(child) for child in node.get("folders", [])],
+            }
+
+        annotated_tree = [_annotate_node(n) for n in tree.get("tree", [])]
+        total = stats["processed"] + stats["unprocessed"]
+        pct = (stats["processed"] / total * 100) if total > 0 else 0
+
+        return {
+            "ok": True,
+            "course_id": course_id,
+            "processed_count": stats["processed"],
+            "unprocessed_count": stats["unprocessed"],
+            "total": total,
+            "pct": round(pct, 1),
+            "tree": annotated_tree,
+        }
+
+    def get_course_diff(self, course_id: int, tree: dict) -> dict:
+        """Return only unprocessed files from a folder tree.
+
+        Each returned item includes its folder path for context.
+        """
+        db = self._load()
+        unprocessed: list[dict] = []
+
+        def _extract(node: dict, folder_path: str = ""):
+            current_path = f"{folder_path}/{node.get('name','')}" if folder_path else node.get("name", "")
+            for f in node.get("files", []):
+                fid = str(f.get("id", ""))
+                if fid not in db:
+                    entry = dict(f)
+                    entry["folder_path"] = current_path or "/"
+                    unprocessed.append(entry)
+            for child in node.get("folders", []):
+                _extract(child, current_path)
+
+        for n in tree.get("tree", []):
+            _extract(n)
+
+        return {
+            "ok": True,
+            "course_id": course_id,
+            "count": len(unprocessed),
+            "files": unprocessed,
+        }
+
+    def mark_course(self, course_id: int, files_list: list[dict]) -> dict:
+        """Mark all files in a course as processed.
+
+        ``files_list`` is a flat list of dicts with ``id`` and ``display_name``
+        keys (e.g. from ``CanvasClient.list_files()["files"]``).
+        """
+        db = self._load()
+        now = _now_iso()
+        count = 0
+        for f in files_list:
+            fid = str(f.get("id", ""))
+            if not fid:
+                continue
+            if fid not in db:
+                db[fid] = {
+                    "display_name": f.get("display_name", ""),
+                    "course_id": course_id,
+                    "size": f.get("size"),
+                    "processed_at": now,
+                }
+                count += 1
+        self._save(db)
+        return {
+            "success": True,
+            "course_id": course_id,
+            "files_marked": count,
+            "total_in_course": len(files_list),
+        }
+
+    # ── internal ─────────────────────────────────────────────────────────
+
+    def _load(self) -> dict[str, dict]:
+        return read_json_safe(self._path, default={})
+
+    def _save(self, data: dict[str, dict]) -> None:
+        atomic_write_json(self._path, data)
+
+    def _migrate_if_needed(self) -> None:
+        """Copy legacy canvas/processed_files.json if it exists."""
+        if self._path.exists():
+            return
+        legacy = PROJECT_ROOT / "canvas" / "processed_files.json"
+        if legacy.exists() and legacy.is_file():
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(legacy, self._path)
+
+
+def _format_size_human(size_bytes: int | None) -> str:
+    """Human-readable file size (standalone copy to avoid circular import)."""
+    if size_bytes is None:
+        return "?"
+    s = float(size_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if s < 1024:
+            return f"{s:.1f} {unit}" if unit != "B" else f"{int(s)} B"
+        s /= 1024
+    return f"{s:.1f} TB"

--- a/sjtu_agent/paths.py
+++ b/sjtu_agent/paths.py
@@ -42,6 +42,8 @@ AGENT_CONFIG_PATH = DATA_DIR / "agent_config.json"
 REMINDERS_PATH = DATA_DIR / "reminders.json"
 REMIND_STATE_PATH = DATA_DIR / "remind_state.json"
 CANVAS_MONITOR_STATE_PATH = DATA_DIR / "canvas_monitor_state.json"
+CANVAS_PROCESSED_FILES_PATH = DATA_DIR / "canvas_processed_files.json"
+CANVAS_DOWNLOADS_DIR = DATA_DIR / "canvas_downloads"
 MYSJTU_CATALOG_PATH = DATA_DIR / "mysjtu_catalog.json"
 SCHEDULE_CACHE_PATH = DATA_DIR / ".schedule_cache.json"
 
@@ -172,6 +174,8 @@ def describe_runtime_paths() -> dict[str, str]:
         "agent_config_path": str(AGENT_CONFIG_PATH),
         "reminders_path": str(REMINDERS_PATH),
         "canvas_monitor_state_path": str(CANVAS_MONITOR_STATE_PATH),
+        "canvas_processed_files_path": str(CANVAS_PROCESSED_FILES_PATH),
+        "canvas_downloads_dir": str(CANVAS_DOWNLOADS_DIR),
         "mysjtu_catalog_path": str(MYSJTU_CATALOG_PATH),
         "schedule_cache_path": str(SCHEDULE_CACHE_PATH),
     }


### PR DESCRIPTION
## Add:

- **Canvas file browsing**: New CanvasClient methods — list_folders(), list_files(), get_file(), get_folder_tree(), download_file() — for exploring and downloading course files from Canvas LMS.
- **Canvas file tracking system** (sjtu_agent/canvas_files.py): CanvasFilesTracker class for marking files as processed (integrated into notes) and tracking progress per course. Persists state in DATA_DIR/canvas_processed_files.json with atomic writes. Auto-migrates legacy data from canvas/processed_files.json.
- **10 new agent tools** in sjtu_agent/agent/tools/_canvas_files.py:
  - list_canvas_folders / list_canvas_files / canvas_file_tree — browse Canvas course file structure
  - download_canvas_file — download any Canvas file to local disk
  - canvas_track_mark / canvas_track_unmark / canvas_track_list — manage processed-file records
  - canvas_track_status / canvas_track_diff — view course-level processing progress and discover new files
  - canvas_track_mark_course — batch-mark all files in a course