### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.3.4"
+version = "0.4.0"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/email_watcher.py
+++ b/scripts/email_watcher.py
@@ -79,14 +79,16 @@ def _extract_body(msg) -> str:
                 try:
                     payload = part.get_payload(decode=True)
                     if payload:
-                        body_parts.append(payload.decode("utf-8", errors="replace"))
+                        charset = part.get_content_charset() or "utf-8"
+                        body_parts.append(payload.decode(charset, errors="replace"))
                 except Exception:
                     pass
     else:
         try:
             payload = msg.get_payload(decode=True)
             if payload:
-                body_parts.append(payload.decode("utf-8", errors="replace"))
+                charset = msg.get_content_charset() or "utf-8"
+                body_parts.append(payload.decode(charset, errors="replace"))
         except Exception:
             pass
 
@@ -99,7 +101,8 @@ def _extract_body(msg) -> str:
                     payload = part.get_payload(decode=True)
                     if payload:
                         import re
-                        html = payload.decode("utf-8", errors="replace")
+                        charset = part.get_content_charset() or "utf-8"
+                        html = payload.decode(charset, errors="replace")
                         text = re.sub(r"<[^>]+>", "", html).strip()
                 except Exception:
                     pass

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.4"
+__version__ = "0.4.0"


### PR DESCRIPTION
## Changes since `v0.3.4`

- **Canvas file browsing + tracking** (#87) — 10 new agent tools for browsing, downloading, and tracking Canvas course files. Thanks @JackyTJie!
- **fix: email_watcher charset** — decode email body with declared charset (GBK/GB2312) instead of hardcoded UTF-8
- **LICENSE** — MIT License added

## Version bump

`0.3.4` → `0.4.0` (minor: new Canvas feature subsystem)