### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.4.0"
+version = "0.5.0"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Changes since `v0.4.0`

### New Features
- **Feishu campus news** — `/news` command for on-demand campus news digest + scheduled daily push via news-digest/aihot-push scheduler tasks
- **`/news_block` `/news_reset`** — block news categories and reset user profile for personalized news ranking
- **Dynamic report label** — digest header now shows 早报/午报/日报/晚报/简报 based on time of day

### Security Fixes (v0.4.0 audit)
- **SSRF**: URL validation in `tool_fetch_url` and `tool_browse_mysjtu`
- **Path traversal**: `is_relative_to()` guards in `tool_read_assignment_file` and `tool_parse_local_file`
- **Missing auth**: `_check_auth()` on `/api/wechat/qr_status`
- **MATLAB injection**: single-quote escaping in `-batch` command
- **Temp file cleanup**: `atexit.register()` for `mkdtemp` in telegram/qq/wechat bots

### Refactoring
- **Feishu bot architecture split** (#89) — extracted `sjtu_agent/feishu/rendering.py` (Markdown→post) and `conversations.py` (multi-conversation manager)

### Fixes
- Email watcher GBK/GB2312 charset support
- Feishu italic rendering (`_italic_` markdown)
- `/news` reply delivery via `_reply_text` instead of `_send_to_chat`

## Version bump

`0.4.0` → `0.5.0` (minor: Feishu news feature + security fixes + architecture refactoring)