### PR TITLE
fix: treat canteen crowdness rate=0 as no-data, not '空闲'

### DIFF
--- a/sjtu_agent/agent/tools/_dining.py
+++ b/sjtu_agent/agent/tools/_dining.py
@@ -247,26 +247,40 @@ def tool_get_canteen_crowd(campus: str = "", canteen_id: int = 0) -> dict:
         if not detail["ok"]:
             return {"ok": False, "error": detail.get("error", "获取失败")}
         d = detail["detail"]
+
+        def _sub_info(s: dict) -> dict:
+            """Extract sub-area info, treating rate=0 as no-data."""
+            rates = s.get("curRates")
+            if not rates:
+                return {
+                    "name": s.get("name", "?"),
+                    "is_open": bool(s.get("isOpen")),
+                    "close_desc": s.get("closeDesc") or "",
+                    "current_rate": None,
+                    "current_label": "无数据",
+                }
+            rate = rates[-1]["rate"]
+            if rate == 0:
+                return {
+                    "name": s.get("name", "?"),
+                    "is_open": bool(s.get("isOpen")),
+                    "close_desc": s.get("closeDesc") or "",
+                    "current_rate": None,
+                    "current_label": "无数据",
+                }
+            return {
+                "name": s.get("name", "?"),
+                "is_open": bool(s.get("isOpen")),
+                "close_desc": s.get("closeDesc") or "",
+                "current_rate": round(rate, 1),
+                "current_label": _crowd_label(rate),
+            }
+
         return {
             "ok": True,
             "canteen_id": canteen_id,
             "schedule_desc": d.get("scheduleDesc", ""),
-            "subs": [
-                {
-                    "name": s.get("name", "?"),
-                    "is_open": bool(s.get("isOpen")),
-                    "close_desc": s.get("closeDesc") or "",
-                    "current_rate": (
-                        round(s["curRates"][-1]["rate"], 1)
-                        if s.get("curRates") else None
-                    ),
-                    "current_label": (
-                        _crowd_label(s["curRates"][-1]["rate"])
-                        if s.get("curRates") else "无数据"
-                    ),
-                }
-                for s in d.get("subs", [])
-            ],
+            "subs": [_sub_info(s) for s in d.get("subs", [])],
         }
 
     # Return all canteens overview

--- a/sjtu_agent/data/canteen_crowd.py
+++ b/sjtu_agent/data/canteen_crowd.py
@@ -159,6 +159,21 @@ class CanteenCrowdChecker:
                 current_rate = latest["rate"]
                 current_time = _parse_time(latest["time"])
 
+                # A rate of 0 is almost certainly "no data" (closed / not yet
+                # serving / sensor offline), not genuinely empty.  Treat it as
+                # unknown so we don't report "空闲" for a closed canteen.
+                if current_rate == 0:
+                    subs.append({
+                        "name": sub.get("name", "?"),
+                        "is_open": bool(sub.get("isOpen")),
+                        "close_desc": sub.get("closeDesc") or "",
+                        "current_rate": None,
+                        "current_label": "无数据",
+                        "trend": "—",
+                        "last_updated": latest["time"],
+                    })
+                    continue
+
                 # Trend: compare with 10 min ago
                 trend = "—"
                 if len(rates) >= 10:

--- a/tests/test_dining.py
+++ b/tests/test_dining.py
@@ -675,6 +675,118 @@ class TestToolGetCanteenCrowd:
         r = tool_get_canteen_crowd()
         assert r["ok"] is False
 
+    def test_overview_rate_zero_treated_as_no_data(self, monkeypatch):
+        """A canteen sub-area with rate=0 should appear as '无数据', not '空闲'."""
+        fake = FakeCanteenCrowdChecker()
+        monkeypatch.setattr(
+            "sjtu_agent.data.canteen_crowd.CanteenCrowdChecker",
+            lambda: fake,
+        )
+        from sjtu_agent.agent.tools._dining import tool_get_canteen_crowd
+        r = tool_get_canteen_crowd(canteen_id=300)
+        assert r["ok"] is True
+        for sub in r["subs"]:
+            if sub["current_rate"] is None:
+                assert sub["current_label"] == "无数据"
+
+    def test_detail_rate_zero_treated_as_no_data(self, monkeypatch):
+        """tool_get_canteen_crowd detail path: rate=0 → None + '无数据'."""
+        fake = FakeCanteenCrowdChecker()
+        monkeypatch.setattr(
+            "sjtu_agent.data.canteen_crowd.CanteenCrowdChecker",
+            lambda: fake,
+        )
+        from sjtu_agent.agent.tools._dining import tool_get_canteen_crowd
+        r = tool_get_canteen_crowd(canteen_id=300)
+        assert r["ok"] is True
+        for sub in r["subs"]:
+            if sub["current_rate"] is None:
+                assert sub["current_label"] == "无数据"
+
+
+class TestCanteenCrowdCheckerGetAllCrowd:
+    """Direct tests for CanteenCrowdChecker.get_all_crowd() with mocked HTTP."""
+
+    def test_rate_zero_sub_area_is_no_data(self, monkeypatch):
+        """Sub-area with curRates=[{rate:0}] → current_rate=None, label='无数据'."""
+        from sjtu_agent.data.canteen_crowd import CanteenCrowdChecker
+
+        def mock_get_all_canteens(self):
+            return {
+                "ok": True,
+                "canteens": [{"id": 100, "name": "第一餐饮大楼", "campus": "闵行", "isOpen": True}],
+            }
+
+        def mock_get_canteen_detail(self, canteen_id):
+            return {
+                "ok": True,
+                "detail": {
+                    "scheduleStatus": 1,
+                    "scheduleDesc": "午餐",
+                    "subs": [
+                        {
+                            "name": "一楼餐厅",
+                            "isOpen": False,
+                            "closeDesc": "",
+                            "curRates": [{"rate": 0, "time": "2026-06-20 12:00:00"}],
+                        },
+                    ],
+                },
+            }
+
+        monkeypatch.setattr(CanteenCrowdChecker, "get_all_canteens", mock_get_all_canteens)
+        monkeypatch.setattr(CanteenCrowdChecker, "get_canteen_detail", mock_get_canteen_detail)
+
+        checker = CanteenCrowdChecker()
+        result = checker.get_all_crowd()
+        assert result["ok"] is True
+        assert len(result["canteens"]) == 1
+        c = result["canteens"][0]
+        assert len(c["subs"]) == 1
+        sub = c["subs"][0]
+        assert sub["current_rate"] is None
+        assert sub["current_label"] == "无数据"
+        assert c["overall_rate"] is None
+        assert c["overall_label"] == "非就餐时间"
+
+    def test_rate_zero_with_open_sub_area_treated_as_no_data(self, monkeypatch):
+        """Even when isOpen=True, rate=0 should still be treated as no-data."""
+        from sjtu_agent.data.canteen_crowd import CanteenCrowdChecker
+
+        def mock_get_all_canteens(self):
+            return {
+                "ok": True,
+                "canteens": [{"id": 100, "name": "第一餐饮大楼", "campus": "闵行", "isOpen": True}],
+            }
+
+        def mock_get_canteen_detail(self, canteen_id):
+            return {
+                "ok": True,
+                "detail": {
+                    "scheduleStatus": 1,
+                    "scheduleDesc": "午餐",
+                    "subs": [
+                        {
+                            "name": "一楼餐厅",
+                            "isOpen": True,
+                            "closeDesc": "",
+                            "curRates": [{"rate": 0, "time": "2026-06-20 12:00:00"}],
+                        },
+                    ],
+                },
+            }
+
+        monkeypatch.setattr(CanteenCrowdChecker, "get_all_canteens", mock_get_all_canteens)
+        monkeypatch.setattr(CanteenCrowdChecker, "get_canteen_detail", mock_get_canteen_detail)
+
+        checker = CanteenCrowdChecker()
+        result = checker.get_all_crowd()
+        assert result["ok"] is True
+        c = result["canteens"][0]
+        sub = c["subs"][0]
+        assert sub["current_rate"] is None
+        assert sub["current_label"] == "无数据"
+
 
 class TestToolRecommendCanteen:
     """tool_recommend_canteen combines crowd + history + knowledge."""


### PR DESCRIPTION
After days of test, I found that 哈乐餐厅 always return rate 0. When the API returns curRates with rate=0, it means no valid data (closed area, sensor offline, etc.), not genuinely empty.  Map it to current_rate=None / label='无数据' instead of '空闲'.