### PR TITLE
feat: 日报定制化 + DDL智能分类

### DIFF
--- a/ddl_checker.py
+++ b/ddl_checker.py
@@ -114,8 +114,9 @@ def make_session(cookies: dict, referer: str = "") -> requests.Session:
 
 # ── Platform 1: Canvas LMS ────────────────────────────────────────────────────
 
-def fetch_canvas(cfg: dict, include_past: bool = False) -> list[dict]:
-    """通过 Canvas REST API 获取作业。include_past=True 时包含已过期的历史作业。"""
+def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) -> list[dict]:
+    """通过 Canvas REST API 获取作业。include_past=True 时包含已过期的历史作业。
+    classify=True 时额外返回 description 和 submission_types 字段用于智能分类。"""
     token = cfg.get("canvas_token", "").strip()
     base = cfg.get("canvas_base_url", "https://oc.sjtu.edu.cn").rstrip("/")
     if not token or token.startswith("YOUR_"):
@@ -165,7 +166,11 @@ def fetch_canvas(cfg: dict, include_past: bool = False) -> list[dict]:
                 due = parse_dt(a.get("due_at", ""))
                 if not include_past and (not due or due < datetime.now(CST)):
                     continue
-                pending.append({"id": a["id"], "name": a.get("name", "未知作业"), "due": due})
+                item = {"id": a["id"], "name": a.get("name", "未知作业"), "due": due}
+                if classify:
+                    item["description"] = a.get("description", "") or ""
+                    item["submission_types"] = a.get("submission_types", []) or []
+                pending.append(item)
             asgn_url = r.links.get("next", {}).get("url")
             asgn_params = {}
 
@@ -189,7 +194,7 @@ def fetch_canvas(cfg: dict, include_past: bool = False) -> list[dict]:
             print(f"[Canvas] 查询 {cname} 提交状态失败：{e}")
 
         for a in pending:
-            results.append({
+            entry = {
                 "platform": "Canvas",
                 "course": cname,
                 "name": a["name"],
@@ -198,7 +203,11 @@ def fetch_canvas(cfg: dict, include_past: bool = False) -> list[dict]:
                 "course_id": cid,
                 "assignment_id": a["id"],
                 "url": f"{base}/courses/{cid}/assignments/{a['id']}",
-            })
+            }
+            if classify:
+                entry["description"] = a.get("description", "")
+                entry["submission_types"] = a.get("submission_types", [])
+            results.append(entry)
 
     return results
 

--- a/docs/superpowers/plans/2026-07-05-daily-report-customization-and-ddl-classification.md
+++ b/docs/superpowers/plans/2026-07-05-daily-report-customization-and-ddl-classification.md
@@ -1,0 +1,1069 @@
+# Daily Report Customization & DDL Classification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable users to customize daily report content via natural conversation (preferences persisted), and intelligently classify Canvas assignments as real homework vs. course notifications using LLM-based content analysis.
+
+**Architecture:** Two independent phases. Phase 1 adds DDL classification: `fetch_canvas()` reads assignment descriptions, a new `_classify_canvas_ddls()` function uses LLM to batch-classify, results are cached alongside the existing 15-min DDL cache, and `_serialize_ddl()` + `tool_get_ddls()` expose type info. Phase 2 adds report preferences: a new `_report_prefs.py` tool module stores section toggles and custom instructions in `config.json`, `daily_report.py` reads them to dynamically build the LLM prompt instead of the hardcoded 6-section template.
+
+**Tech Stack:** Python 3.11+, existing project patterns (TOOLS_ENTRIES + tool_xxx functions, atomic_write_json, ConfigStore), Canvas REST API, OpenAI-compatible LLM client.
+
+## Global Constraints
+
+- Follow existing code patterns: tool modules use `TOOLS_ENTRIES` list + `tool_xxx()` functions, imported by `_core.py`
+- Use `atomic_write_json()` from `sjtu_agent.paths` for config writes to prevent corruption
+- DDL cache TTL remains 900s (15 minutes); classification results share the same cache entry
+- Classification LLM call uses the same client as daily report generation (via `agent._make_client()`)
+- Default behavior unchanged: without `classify=True`, DDLs behave exactly as before (backward compatible)
+- All user-facing text in Chinese
+- Follow project naming: private functions prefixed with `_`, tools are `tool_xxx`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `ddl_checker.py` | Modify | `fetch_canvas()` gains `classify` param, pulls `description` field from Canvas API |
+| `sjtu_agent/agent/tools/_core.py` | Modify | New `_classify_canvas_ddls()`, updated `_serialize_ddl()`, updated `tool_get_ddls()`, new tool definitions for report prefs, updated `run_tool()` dispatch |
+| `sjtu_agent/agent/tools/_report_prefs.py` | Create | `tool_update_report_preferences()`, `tool_get_report_preferences()`, `TOOLS_ENTRIES` |
+| `sjtu_agent/agent/prompts.py` | Modify | SYSTEM_PROMPT additions for report pref modification behavior and DDL classification awareness |
+| `scripts/daily_report.py` | Modify | `_collect_data()` passes `classify=True`, `build_report()` reads prefs and dynamically builds prompt |
+
+---
+
+### Task 1: Enhance `fetch_canvas()` to pull assignment descriptions
+
+**Files:**
+- Modify: `ddl_checker.py:117-203`
+
+**Interfaces:**
+- Consumes: Canvas REST API `/api/v1/courses/{cid}/assignments` (existing)
+- Produces: Each result dict gains `description` (str, HTML), `submission_types` (list[str])
+
+**Description:** When `classify=True`, the function additionally fetches the full assignment object
+(which already contains `description` in the Canvas API response — no extra API call needed) and
+stores `description` and `submission_types` in the result dict.
+
+- [ ] **Step 1: Modify `fetch_canvas()` signature and body**
+
+Add `classify: bool = False` parameter. When True, store extra fields from the Canvas API response.
+
+In `ddl_checker.py`, change lines 117 and 162-170, 191-201:
+
+```python
+def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) -> list[dict]:
+    """通过 Canvas REST API 获取作业。include_past=True 时包含已过期的历史作业。
+    classify=True 时额外返回 description 和 submission_types 字段用于智能分类。"""
+    # ... token/base/session setup unchanged (lines 119-126) ...
+
+    # ... courses fetch unchanged (lines 128-141) ...
+
+    results: list[dict] = []
+
+    for course in courses:
+        cid = course["id"]
+        cname = course.get("name", f"课程{cid}")
+
+        pending: list[dict] = []
+        asgn_url: str | None = f"{base}/api/v1/courses/{cid}/assignments"
+        asgn_params: dict = {"per_page": 100, "order_by": "due_at"}
+        while asgn_url:
+            try:
+                r = session.get(asgn_url, params=asgn_params, timeout=15)
+                r.raise_for_status()
+            except requests.RequestException as e:
+                print(f"[Canvas] 获取 {cname} 作业失败：{e}")
+                raise
+            for a in r.json():
+                if a.get("workflow_state") == "deleted":
+                    continue
+                due = parse_dt(a.get("due_at", ""))
+                if not include_past and (not due or due < datetime.now(CST)):
+                    continue
+                item = {
+                    "id": a["id"],
+                    "name": a.get("name", "未知作业"),
+                    "due": due,
+                }
+                if classify:
+                    item["description"] = a.get("description", "") or ""
+                    item["submission_types"] = a.get("submission_types", []) or []
+                pending.append(item)
+            asgn_url = r.links.get("next", {}).get("url")
+            asgn_params = {}
+
+        if not pending:
+            continue
+
+        # ... submissions check unchanged (lines 175-189) ...
+
+        for a in pending:
+            entry = {
+                "platform": "Canvas",
+                "course": cname,
+                "name": a["name"],
+                "due": a["due"],
+                "submitted": a["id"] in submitted_ids,
+                "course_id": cid,
+                "assignment_id": a["id"],
+                "url": f"{base}/courses/{cid}/assignments/{a['id']}",
+            }
+            if classify:
+                entry["description"] = a.get("description", "")
+                entry["submission_types"] = a.get("submission_types", [])
+            results.append(entry)
+
+    return results
+```
+
+- [ ] **Step 2: Verify existing behavior unchanged**
+
+Run: `python -c "import ddl_checker as dc; cfg = dc.load_config(); r = dc.fetch_canvas(cfg, include_past=False); print(f'Got {len(r)} DDLs'); print(r[0].keys() if r else 'no DDLs')"`
+
+Expected: Output shows DDL count and keys WITHOUT `description` or `submission_types` (backward compatible when classify not passed).
+
+- [ ] **Step 3: Verify classify mode works**
+
+Run: `python -c "import ddl_checker as dc; cfg = dc.load_config(); r = dc.fetch_canvas(cfg, include_past=False, classify=True); print(r[0].keys() if r else 'no DDLs')"`
+
+Expected: Output shows keys including `description` and `submission_types`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ddl_checker.py
+git commit -m "feat: add classify param to fetch_canvas() — pull description and submission_types"
+```
+
+---
+
+### Task 2: Add `_classify_canvas_ddls()` in `_core.py`
+
+**Files:**
+- Modify: `sjtu_agent/agent/tools/_core.py` (insert after line ~2129, before `_prefetch_ddls_background`)
+
+**Interfaces:**
+- Consumes: `agent.load_agent_config()` (from `chat_loop.py`), `agent._make_client()` (from `runner.py`)
+- Produces: `_classify_canvas_ddls(ddls: list[dict]) -> list[dict]` — mutates each dict in-place, adding `type` and `type_confidence`
+
+**Description:** Takes a list of Canvas DDL dicts (with `description` and `submission_types` fields), applies rule-based pre-screening, then sends remaining items to LLM for batch classification. Results are written back in-place.
+
+- [ ] **Step 1: Add the classification function**
+
+Insert after line 2129 in `_core.py` (after `_fetch_ddls_parallel`):
+
+```python
+def _classify_canvas_ddls(ddls: list) -> list:
+    """对 Canvas DDL 列表进行智能分类（作业 / 通知 / 其他）。
+    
+    规则预筛 + LLM 批量分类。结果写回每个 dict 的 type 和 type_confidence 字段。
+    仅处理 platform == "Canvas" 且有 description 字段的项。
+    """
+    import json as _json
+    from sjtu_agent.agent.chat_loop import load_agent_config as _load_cfg
+    from sjtu_agent.agent.runner import _make_client as _make_llm_client
+
+    # 只处理 Canvas 且有 description 的项
+    canvas_items = [
+        (i, d) for i, d in enumerate(ddls)
+        if d.get("platform") == "Canvas" and d.get("description") is not None
+    ]
+    if not canvas_items:
+        return ddls
+
+    # ── 规则预筛 ──
+    notification_keywords = ["通知", "公告", "提醒", "评分", "评价", "问卷", "反馈",
+                              "评分标准", "课程介绍", "Syllabus", "教学大纲"]
+    need_llm = []
+    for idx, d in canvas_items:
+        desc = (d.get("description") or "").strip()
+        sub_types = d.get("submission_types") or []
+        name = d.get("name", "")
+
+        # 规则1: submission_types 为 ["none"] 或空，且名称/描述含关键词 → notification
+        is_none_submission = (not sub_types or sub_types == ["none"])
+        if is_none_submission:
+            text = f"{name} {desc}"
+            if any(kw in text for kw in notification_keywords):
+                d["type"] = "notification"
+                d["type_confidence"] = 1.0
+                continue
+
+        # 规则2: submission_types 包含实际提交类型 (online_upload/online_text_entry/online_url)
+        #         且名称不含通知关键词 → 疑似作业，交给 LLM
+        has_real_submission = any(
+            t in sub_types for t in ["online_upload", "online_text_entry", "online_url",
+                                      "online_quiz", "external_tool", "media_recording"]
+        )
+        if has_real_submission:
+            need_llm.append((idx, d))
+            continue
+
+        # 规则3: 没有 description 且 submission_types 为 none → notification
+        if not desc and is_none_submission:
+            d["type"] = "notification"
+            d["type_confidence"] = 1.0
+            continue
+
+        # 剩余 → LLM 判断
+        need_llm.append((idx, d))
+
+    if not need_llm:
+        return ddls
+
+    # ── LLM 批量分类 ──
+    # 构建简洁的分类请求
+    items_for_llm = []
+    for idx, d in need_llm:
+        desc = (d.get("description") or "")[:500]  # 截断长描述
+        items_for_llm.append({
+            "index": len(items_for_llm),
+            "course": d.get("course", ""),
+            "name": d.get("name", ""),
+            "description": desc,
+            "submission_types": d.get("submission_types", []),
+        })
+
+    prompt = f"""判断以下 Canvas 条目是「作业/任务」还是「课程通知」。
+    
+条目列表：
+{_json.dumps(items_for_llm, ensure_ascii=False, indent=2)}
+
+判断标准：
+- 要求学生提交/完成具体内容（做题、写报告、上传文件）→ "assignment"
+- 仅信息告知、无需提交（课程安排通知、评分提醒、问卷、反馈征集、Syllabus）→ "notification"
+- 评价/评分/问卷/反馈/课程介绍 → "notification"
+- 不确定 → "unknown"
+
+返回 JSON 数组（只返回 JSON，不要其他文字）：
+[{{"index": 0, "type": "assignment", "confidence": 0.95}}, ...]"""
+
+    try:
+        agent_cfg = _load_cfg()
+        client = _make_llm_client(agent_cfg)
+        model = agent_cfg.get("model", "deepseek-chat")
+
+        # 使用轻量模型调用（非流式，快速返回）
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            temperature=0.1,  # 低温度，追求一致分类
+        )
+        text = resp.choices[0].message.content or ""
+
+        # 解析 JSON（防御：可能有 markdown 包裹）
+        text = text.strip()
+        if text.startswith("```"):
+            # 去掉 ```json ... ``` 包裹
+            lines = text.split("\n")
+            text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+        classifications = _json.loads(text)
+
+        # 写回结果
+        class_map = {c["index"]: c for c in classifications}
+        for local_idx, (orig_idx, d) in enumerate(need_llm):
+            c = class_map.get(local_idx, {})
+            d["type"] = c.get("type", "unknown")
+            d["type_confidence"] = c.get("confidence", 0.0)
+
+    except Exception as e:
+        print(f"[DDL classify] LLM 分类失败，全部标记为 unknown: {e}")
+        for idx, d in need_llm:
+            d.setdefault("type", "unknown")
+            d.setdefault("type_confidence", 0.0)
+
+    # 确保所有 Canvas 项都有 type（防御）
+    for d in ddls:
+        if d.get("platform") == "Canvas":
+            d.setdefault("type", "unknown")
+            d.setdefault("type_confidence", 0.0)
+
+    return ddls
+```
+
+- [ ] **Step 2: Verify classification with test data**
+
+Create a quick test script:
+
+```bash
+python -c "
+import ddl_checker as dc, json
+from sjtu_agent.agent.tools._core import _classify_canvas_ddls
+cfg = dc.load_config()
+ddls = dc.fetch_canvas(cfg, classify=True)
+print(f'Fetched {len(ddls)} DDLs with descriptions')
+_classify_canvas_ddls(ddls)
+for d in ddls:
+    print(f'  [{d.get(\"type\",\"?\")}] {d[\"course\"]} · {d[\"name\"]} (confidence={d.get(\"type_confidence\",0)})')
+"
+```
+
+Expected: Each DDL has a `type` field with value "assignment", "notification", or "unknown".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sjtu_agent/agent/tools/_core.py
+git commit -m "feat: add _classify_canvas_ddls() — rule+LLM batch classification"
+```
+
+---
+
+### Task 3: Update `_serialize_ddl()` and `tool_get_ddls()` signatures
+
+**Files:**
+- Modify: `sjtu_agent/agent/tools/_core.py:1429-1443` (`_serialize_ddl`)
+- Modify: `sjtu_agent/agent/tools/_core.py:2229-2242` (`tool_get_ddls`)
+- Modify: `sjtu_agent/agent/tools/_core.py:110-126` (TOOLS entry for `get_ddls`)
+
+**Interfaces:**
+- Produces: `_serialize_ddl()` returns dict with `type` and `type_confidence` fields
+- Produces: `tool_get_ddls(classify=False, include_notifications=False)` 
+
+- [ ] **Step 1: Update `_serialize_ddl()`**
+
+Replace lines 1429-1443:
+
+```python
+def _serialize_ddl(item: dict, now=None) -> dict:
+    import datetime as _dt
+    if now is None:
+        now = _dt.datetime.now(dc.CST)
+    total_seconds = (item["due"] - now).total_seconds()
+    hours_left    = int(total_seconds / 3600)
+    result = {
+        "platform":   item["platform"],
+        "course":     item["course"],
+        "name":       item["name"],
+        "due":        item["due"].strftime("%Y-%m-%d %H:%M"),
+        "hours_left": hours_left,
+        "expired":    total_seconds < 0,
+        "submitted":  item.get("submitted", False),
+    }
+    # 如果有分类信息则带上
+    if item.get("type"):
+        result["type"] = item["type"]
+        result["type_confidence"] = item.get("type_confidence", 0.0)
+    return result
+```
+
+- [ ] **Step 2: Update `tool_get_ddls()` signature and body**
+
+Replace lines 2229-2242:
+
+```python
+def tool_get_ddls(skip_canvas=False, skip_aihaoke=False, skip_icourse=False,
+                  classify: bool = False, include_notifications: bool = False):
+    import datetime as _dt
+    cfg = dc.load_config()
+    now = _dt.datetime.now(dc.CST)
+
+    # 当 classify=True 时，需要原始数据（含 description）做分类
+    fetch_classify = classify
+    all_ddl = _fetch_ddls_parallel(cfg, skip_canvas, skip_aihaoke, skip_icourse,
+                                    classify=fetch_classify)
+
+    if classify:
+        _classify_canvas_ddls(all_ddl)
+
+    all_ddl.sort(key=lambda x: x["due"])
+    warnings = []
+    if not skip_canvas and not (cfg.get("canvas_token") and not cfg.get("canvas_token", "").startswith("YOUR_")):
+        warnings.append("Canvas 未配置 token；请先调用 setup_canvas 获取引导，生成后再用 save_credentials 保存。")
+
+    serialized = [_serialize_ddl(x, now) for x in all_ddl if not x.get("submitted")]
+
+    # 默认过滤通知类（除非用户明确要求）
+    notification_count = 0
+    if classify and not include_notifications:
+        filtered = []
+        for d in serialized:
+            if d.get("type") == "notification":
+                notification_count += 1
+            else:
+                filtered.append(d)
+        serialized = filtered
+
+    result = {
+        "current_time": now.strftime("%Y-%m-%d %H:%M"),
+        "ddls": serialized,
+        "warnings": warnings,
+    }
+    if classify and notification_count > 0:
+        result["filtered_notifications"] = notification_count
+        result["hint"] = f"已过滤 {notification_count} 条课程通知（评分/问卷/公告等）。回复「全部DDL」可查看所有条目。"
+    return result
+```
+
+- [ ] **Step 3: Update TOOLS definition for `get_ddls`**
+
+Replace lines 113-125:
+
+```python
+    {
+        "type": "function",
+        "function": {
+            "name": "get_ddls",
+            "description": "获取所有平台（Canvas / AI 好课（aihaoke） / 中国大学MOOC）未完成 DDL，按截止时间升序。默认自动过滤 Canvas 课程通知（评分/问卷等非作业条目）。",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skip_canvas":  {"type": "boolean"},
+                    "skip_aihaoke": {"type": "boolean"},
+                    "skip_icourse": {"type": "boolean"},
+                    "classify": {
+                        "type": "boolean",
+                        "description": "是否对 Canvas 作业进行智能分类（区分真实作业与课程通知）。日报和用户主动查 DDL 时传 true。",
+                    },
+                    "include_notifications": {
+                        "type": "boolean",
+                        "description": "是否包含课程通知类条目。用户说「全部」「包括通知」时传 true。默认 false（过滤通知）。",
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+```
+
+- [ ] **Step 4: Update `_fetch_ddls_parallel()` to pass `classify` through**
+
+Replace lines 2100-2129:
+
+```python
+def _fetch_ddls_parallel(cfg: dict, skip_canvas=False, skip_aihaoke=False,
+                          skip_icourse=False, classify: bool = False) -> list:
+    """并行拉取各平台 DDL，返回合并列表（未排序）。
+    优先使用 15 分钟内的磁盘缓存。
+    classify=True 时使用独立缓存键（含 description/type），避免缓存污染。
+    """
+    import concurrent.futures as _cf
+
+    cache_key = f"{skip_canvas},{skip_aihaoke},{skip_icourse}"
+    if classify:
+        cache_key += ",classify"
+    cached = _ddl_cache_get(cache_key)
+    if cached is not None:
+        return cached
+
+    tasks = []
+    if not skip_canvas:
+        tasks.append(("canvas",  lambda: dc.fetch_canvas(cfg, classify=classify)))
+    if not skip_aihaoke:
+        tasks.append(("aihaoke", lambda: dc.fetch_aihaoke(cfg)))
+    if not skip_icourse:
+        tasks.append(("icourse", lambda: dc.fetch_icourse(cfg)))
+
+    all_ddl: list = []
+    if not tasks:
+        return all_ddl
+
+    with _cf.ThreadPoolExecutor(max_workers=len(tasks)) as pool:
+        futures = {pool.submit(fn): name for name, fn in tasks}
+        for fut in _cf.as_completed(futures):
+            try:
+                all_ddl.extend(fut.result())
+            except Exception as e:
+                print(f"[DDL] {futures[fut]} 拉取失败：{e}")
+
+    _ddl_cache_set(cache_key, all_ddl)
+    return all_ddl
+```
+
+- [ ] **Step 5: Update `run_tool()` dispatch for `get_ddls`**
+
+Line 3543 already dispatches `get_ddls` — no change needed since `tool_get_ddls` accepts `**args`.
+
+- [ ] **Step 6: Verify backward compatibility**
+
+Run: `python -c "from sjtu_agent.agent.tools._core import tool_get_ddls; import json; r = tool_get_ddls(); print(json.dumps(r, ensure_ascii=False, indent=2)[:500])"`
+
+Expected: DDL list without `type` fields and without `filtered_notifications` hint (classify defaults to False).
+
+- [ ] **Step 7: Verify classification mode**
+
+Run: `python -c "from sjtu_agent.agent.tools._core import tool_get_ddls; import json; r = tool_get_ddls(classify=True); print('filtered_notifications:', r.get('filtered_notifications', 0)); print('hint:', r.get('hint', 'none'))"`
+
+Expected: Shows filtered count and hint if any notifications were detected.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add sjtu_agent/agent/tools/_core.py
+git commit -m "feat: update tool_get_ddls() with classify + include_notifications params"
+```
+
+---
+
+### Task 4: Create `_report_prefs.py` tool module
+
+**Files:**
+- Create: `sjtu_agent/agent/tools/_report_prefs.py`
+
+**Interfaces:**
+- Produces: `TOOLS_ENTRIES` (list of 2 tool definitions), `tool_update_report_preferences()`, `tool_get_report_preferences()`
+- Consumes: `CONFIG_PATH` from `sjtu_agent.paths`, `atomic_write_json` from `sjtu_agent.paths`
+
+- [ ] **Step 1: Create the module**
+
+```python
+"""Report preferences tools — customize daily report sections and instructions."""
+
+import json
+
+from sjtu_agent.paths import CONFIG_PATH, atomic_write_json
+
+# ── 默认偏好 ─────────────────────────────────────────────────────────────
+_DEFAULT_SECTIONS = {
+    "ddl": True,
+    "schedule": True,
+    "lab": True,
+    "jwc": True,
+    "news": True,
+    "tips": True,
+}
+
+_DEFAULT_PREFS = {
+    "sections": dict(_DEFAULT_SECTIONS),
+    "custom_instructions": "",
+    "per_type": {
+        "morning": {},
+        "noon": {},
+        "evening": {},
+    },
+}
+
+# ── 工具定义 ─────────────────────────────────────────────────────────────
+
+TOOLS_ENTRIES = [
+    {
+        "type": "function",
+        "function": {
+            "name": "update_report_preferences",
+            "description": (
+                "修改用户的早/中/晚报偏好设置。用户说「早报不要XX」「晚报加上XX」"
+                "「日报多关注XX」时调用。只传需要修改的字段，未传字段保持不变。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sections": {
+                        "type": "object",
+                        "description": (
+                            "要修改的日报模块显隐。键名：ddl（作业DDL）、schedule（课表）、"
+                            "lab（物理实验）、jwc（教务通知）、news（校园动态）、tips（行动建议）。"
+                            "值为 true=显示，false=隐藏。只传需要改的键。"
+                        ),
+                        "properties": {
+                            "ddl": {"type": "boolean"},
+                            "schedule": {"type": "boolean"},
+                            "lab": {"type": "boolean"},
+                            "jwc": {"type": "boolean"},
+                            "news": {"type": "boolean"},
+                            "tips": {"type": "boolean"},
+                        },
+                    },
+                    "custom_instructions": {
+                        "type": "string",
+                        "description": (
+                            "用户对日报的额外要求（自然语言），将直接注入日报生成提示词。"
+                            "如「多关注物理作业」「语气轻松一点」「晚报重点提醒明天要交的」。"
+                        ),
+                    },
+                    "report_type": {
+                        "type": "string",
+                        "enum": ["morning", "noon", "evening", "all"],
+                        "description": (
+                            "修改哪个报别的偏好。morning=早报，noon=午报，evening=晚报。"
+                            "all=所有报别统一修改。默认 all。"
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_report_preferences",
+            "description": "查看用户当前的日报偏好设置（各模块显隐状态和自定义要求）。",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+# ── 内部 ────────────────────────────────────────────────────────────────
+
+def _load_prefs() -> dict:
+    """从 config.json 加载日报偏好，不存在时返回默认值。"""
+    try:
+        if CONFIG_PATH.exists():
+            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+            prefs = cfg.get("report_preferences")
+            if prefs and isinstance(prefs, dict):
+                # 确保默认结构完整
+                merged = dict(_DEFAULT_PREFS)
+                merged["sections"] = {**_DEFAULT_SECTIONS, **prefs.get("sections", {})}
+                merged["custom_instructions"] = prefs.get("custom_instructions", "")
+                merged["per_type"] = prefs.get("per_type", {})
+                for rt in ("morning", "noon", "evening"):
+                    merged["per_type"].setdefault(rt, {})
+                return merged
+    except Exception:
+        pass
+    return dict(_DEFAULT_PREFS)
+
+
+def _save_prefs(prefs: dict) -> None:
+    """将日报偏好写回 config.json。"""
+    try:
+        if CONFIG_PATH.exists():
+            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        else:
+            cfg = {}
+        cfg["report_preferences"] = prefs
+        atomic_write_json(CONFIG_PATH, cfg)
+    except Exception as e:
+        raise RuntimeError(f"保存日报偏好失败: {e}")
+
+# ── 工具实现 ────────────────────────────────────────────────────────────
+
+def tool_get_report_preferences() -> dict:
+    """查看当前日报偏好。"""
+    prefs = _load_prefs()
+    return {"preferences": prefs}
+
+
+def tool_update_report_preferences(
+    sections: dict | None = None,
+    custom_instructions: str | None = None,
+    report_type: str = "all",
+) -> dict:
+    """更新日报偏好。只修改传入的字段。"""
+    prefs = _load_prefs()
+    changes = []
+
+    # 确定要修改的目标
+    targets = ["morning", "noon", "evening"] if report_type == "all" else [report_type]
+
+    for rt in targets:
+        per_type = prefs["per_type"].setdefault(rt, {})
+
+        if sections:
+            rt_sections = per_type.setdefault("sections", {})
+            for key in ("ddl", "schedule", "lab", "jwc", "news", "tips"):
+                if key in sections:
+                    rt_sections[key] = sections[key]
+            changes.extend(f"{rt}:{k}={sections[k]}" for k in sections)
+
+        if custom_instructions is not None:
+            per_type["custom_instructions"] = custom_instructions
+            changes.append(f"{rt}:custom_instructions")
+
+    # 如果 report_type == "all"，同时更新顶层默认值
+    if report_type == "all":
+        if sections:
+            for key in sections:
+                prefs["sections"][key] = sections[key]
+        if custom_instructions is not None:
+            prefs["custom_instructions"] = custom_instructions
+
+    _save_prefs(prefs)
+
+    summary_parts = []
+    if sections:
+        enabled = [k for k, v in sections.items() if v]
+        disabled = [k for k, v in sections.items() if not v]
+        section_names = {
+            "ddl": "📚作业DDL", "schedule": "📅课表", "lab": "🔬物理实验",
+            "jwc": "📢教务通知", "news": "📰校园动态", "tips": "💡行动建议",
+        }
+        if enabled:
+            summary_parts.append(f"将展示: {'、'.join(section_names.get(k, k) for k in enabled)}")
+        if disabled:
+            summary_parts.append(f"将隐藏: {'、'.join(section_names.get(k, k) for k in disabled)}")
+    if custom_instructions is not None:
+        summary_parts.append(f"自定义要求: {custom_instructions}")
+
+    scope = "所有报别" if report_type == "all" else f"{report_type}"
+    return {
+        "ok": True,
+        "scope": scope,
+        "summary": "；".join(summary_parts) if summary_parts else "偏好已更新",
+        "changes": changes,
+    }
+```
+
+- [ ] **Step 2: Verify the module loads**
+
+Run: `python -c "from sjtu_agent.agent.tools._report_prefs import TOOLS_ENTRIES, tool_get_report_preferences, tool_update_report_preferences; print('Module OK'); r = tool_get_report_preferences(); print(r)"`
+
+Expected: Module loads without errors; shows default preferences.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sjtu_agent/agent/tools/_report_prefs.py
+git commit -m "feat: add _report_prefs.py — report customization tools"
+```
+
+---
+
+### Task 5: Wire report prefs tools into `_core.py`
+
+**Files:**
+- Modify: `sjtu_agent/agent/tools/_core.py` (imports, TOOLS list, `run_tool()` dispatch)
+
+- [ ] **Step 1: Add import**
+
+After line 69 (after `_user_profile` import block):
+
+```python
+from sjtu_agent.agent.tools._report_prefs import (
+    TOOLS_ENTRIES as _REPORT_PREFS_TOOLS,
+    tool_get_report_preferences, tool_update_report_preferences,
+)
+```
+
+- [ ] **Step 2: Add to TOOLS list**
+
+After line 828 (`*_USER_PROFILE_TOOLS,`):
+
+```python
+    *_REPORT_PREFS_TOOLS,
+```
+
+- [ ] **Step 3: Add to `run_tool()` dispatch**
+
+After line 3594 (`elif name == "get_user_profile":`):
+
+```python
+        elif name == "update_report_preferences": r = tool_update_report_preferences(**args)
+        elif name == "get_report_preferences":    r = tool_get_report_preferences()
+```
+
+- [ ] **Step 4: Add tool label**
+
+After line 618 (`"get_dining_history": "正在查看就餐历史",`):
+
+```python
+    "update_report_preferences": "正在更新日报偏好",
+    "get_report_preferences":    "正在读取日报偏好",
+```
+
+- [ ] **Step 5: Verify wiring**
+
+Run: `python -c "from sjtu_agent.agent.tools._core import run_tool; print(run_tool('get_report_preferences', {}))"`
+
+Expected: JSON output showing preferences dict.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sjtu_agent/agent/tools/_core.py
+git commit -m "feat: wire report_prefs tools into _core.py"
+```
+
+---
+
+### Task 6: Update SYSTEM_PROMPT in `prompts.py`
+
+**Files:**
+- Modify: `sjtu_agent/agent/prompts.py` (insert new sections)
+
+- [ ] **Step 1: Add DDL classification behavior guidance**
+
+Insert after line 131 (after the DDL query section "无待完成任务时明确告知"):
+
+```
+- 获取 DDL 时默认传 classify=True，自动区分真实作业和课程通知（评分/问卷/公告等）
+- 如果返回结果包含 filtered_notifications 和 hint，按 hint 提示用户
+- 用户说「全部」「包括通知」「所有DDL」时传 include_notifications=True
+- 分类为 notification 的条目在展示时标注 📢 而非 📝
+```
+
+- [ ] **Step 2: Add report preference modification guidance**
+
+Insert before the "## 提醒事项管理" section (before line 367):
+
+```
+## 日报偏好
+
+用户可能通过对话调整早/中/晚报的内容。识别到以下意图时调用对应工具：
+
+- 「早报不要XX」「晚报加上XX」「日报隐藏XX」→ update_report_preferences 修改 sections
+- 「日报多关注XX」「日报语气XX」「晚报重点提醒XX」→ update_report_preferences 更新 custom_instructions
+- 「看看日报设置」「日报偏好是什么」→ get_report_preferences
+
+修改成功后简短确认变更内容，告知「下次日报自动生效」。不要长篇解释。
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sjtu_agent/agent/prompts.py
+git commit -m "feat: add DDL classify + report prefs behavior to SYSTEM_PROMPT"
+```
+
+---
+
+### Task 7: Update `daily_report.py` — classification and dynamic prompts
+
+**Files:**
+- Modify: `scripts/daily_report.py:146-170` (`_collect_data`)
+- Modify: `scripts/daily_report.py:193-394` (`build_report`)
+
+- [ ] **Step 1: Update `_collect_data()` to request classification**
+
+Replace line 153 (`"ddls": lambda: agent.tool_get_ddls(),`):
+
+```python
+        "ddls":     lambda: agent.tool_get_ddls(classify=True),
+```
+
+- [ ] **Step 2: Add preference loading helper**
+
+Insert before `build_report()` (before line 193):
+
+```python
+def _load_report_preferences(report_type: str) -> dict:
+    """加载日报偏好，合并通用设置和报别特定设置。"""
+    try:
+        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = cfg.get("report_preferences", {})
+    except Exception:
+        return {"sections": {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}, "custom_instructions": ""}
+
+    # 默认值
+    default_sections = {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}
+    sections = {**default_sections, **prefs.get("sections", {})}
+    custom = prefs.get("custom_instructions", "")
+
+    # 报别特定覆盖
+    per_type = prefs.get("per_type", {}).get(report_type, {})
+    if per_type.get("sections"):
+        sections.update(per_type["sections"])
+    if per_type.get("custom_instructions"):
+        custom = per_type["custom_instructions"]
+
+    return {"sections": sections, "custom_instructions": custom}
+```
+
+- [ ] **Step 3: Replace hardcoded prompt in `build_report()` with dynamic prompt**
+
+Replace lines 291-356 (from `schedule_section_label` assignment through `{_build_care_note()}`):
+
+```python
+    schedule_section_label = "明日课表" if report_type == "evening" else "今日课表"
+
+    # 读取日报偏好
+    prefs = _load_report_preferences(report_type)
+    enabled_sections = prefs["sections"]
+    custom_instructions = prefs["custom_instructions"]
+
+    # --- 动态构建 AI 提示词 ---
+    section_templates = {
+        "ddl": (f"📚 <b>作业 DDL</b>：列出今日/本周截止任务（如无则写"暂无紧急 DDL ✅"）；每条注明距截止时间\n"
+                f"今日截止（{len(today_ddls)} 项）：\n{chr(10).join(_fmt_ddl(d) for d in today_ddls) or '（无）'}\n"
+                f"本周内截止（{len(week_ddls)} 项）：\n{chr(10).join(_fmt_ddl(d) for d in week_ddls) or '（无）'}"),
+        "schedule": (f"📅 <b>{schedule_prompt_header}</b>：课程名+时间（如无课则写"无课"）\n"
+                     f"{_fmt_schedule(schedule_raw)}"),
+        "lab": (f"🔬 <b>下次实验</b>：时间、地点（如无则写"暂无安排"）\n"
+                f"{_fmt_lab(lab_raw)}"),
+        "jwc": (f"📢 <b>教务通知</b>：最多2条关键通知摘要（如无则写"暂无新通知"）\n"
+                f"{_fmt_jwc(jwc_raw)}"),
+        "news": (f"📰 <b>校园动态</b>：从校园新闻中选取1-2条最相关或有趣的摘要（如无则写"暂无"）\n"
+                 f"{news_raw or '（暂无）'}"),
+        "tips": "💡 <b>行动建议</b>：根据当前 DDL 紧急程度和时段，用1-2句话给出具体建议",
+    }
+
+    # 构建 data_ctx（DDL 详情和校历始终包含，供 LLM 参考）
+    data_ctx = f"""当前时间：{date_str} {now.strftime('%H:%M')}
+
+    【DDL 汇总（共 {len(all_ddls)} 项未完成）】
+    今日截止（{len(today_ddls)} 项）：
+    {chr(10).join(_fmt_ddl(d) for d in today_ddls) or "（无）"}
+
+    本周内截止（{len(week_ddls)} 项）：
+    {chr(10).join(_fmt_ddl(d) for d in week_ddls) or "（无）"}
+
+    更远期（{len(far_ddls)} 项）：
+    {chr(10).join(_fmt_ddl(d) for d in far_ddls) or "（无）"}
+
+    【{schedule_section_label}】
+    {_fmt_schedule(schedule_raw)}
+
+    【下次物理实验】
+    {_fmt_lab(lab_raw)}
+
+    【教务处最新通知】
+    {_fmt_jwc(jwc_raw)}
+
+    【校园新闻/水源热帖（近24h）】
+    {news_raw or "（暂无）"}"""
+
+    # 校历
+    try:
+        from sjtu_agent.calendar import AcademicCalendar
+        from sjtu_agent.paths import DATA_DIR
+        cal_ctx = AcademicCalendar(DATA_DIR).get_context(now.date())
+        if cal_ctx:
+            data_ctx += f"\n\n【校历提醒】\n{cal_ctx}"
+    except Exception:
+        pass
+
+    # 构建启用的 section 列表
+    section_order = ["ddl", "schedule", "lab", "jwc", "news", "tips"]
+    enabled_list = [section_templates[k] for k in section_order if enabled_sections.get(k, True)]
+
+    if not enabled_list:
+        # 用户把所有模块都关了
+        enabled_list = ["请告知用户当前日报所有模块均已隐藏，建议至少开启一个模块。"]
+
+    # 构建提示词
+    extra_line = f"\n额外要求：{custom_instructions}" if custom_instructions else ""
+    prompt = f"""你是一个贴心的学习助手，请根据以下数据为上海交通大学学生生成一份{label}。
+
+    要求：
+    - 使用 Telegram HTML 格式（只用 <b> <i> 标签，不用 Markdown），不要用 * # 符号
+    - 语气友好简洁，像朋友发消息，不要太正式
+    - 全部用中文
+    - 时间段：现在是{report_type}（{hint}）
+    - 按以下结构输出（只输出启用的模块，顺序不变）：
+
+    第1行：📊 <b>{date_str} {label}</b>
+
+    然后依次输出以下启用的模块（每节空一行）：
+    {chr(10).join(enabled_list)}{extra_line}
+
+    以下是收集到的数据：
+    {data_ctx}
+    {_build_care_note()}"""
+```
+
+- [ ] **Step 4: Verify daily report generation**
+
+Run: `python scripts/daily_report.py --test --type morning`
+
+Expected: Report generated with all 6 default sections. No errors.
+
+- [ ] **Step 5: Test with modified preferences**
+
+Create a quick test:
+
+```bash
+python -c "
+import json
+from sjtu_agent.paths import CONFIG_PATH
+cfg = json.loads(CONFIG_PATH.read_text(encoding='utf-8'))
+cfg['report_preferences'] = {'sections': {'ddl': True, 'schedule': True, 'lab': False, 'jwc': False, 'news': False, 'tips': True}, 'custom_instructions': '语气活泼一点', 'per_type': {}}
+import sjtu_agent.paths as p
+p.atomic_write_json(CONFIG_PATH, cfg)
+print('Prefs set: jwc+news+lab disabled, tips kept')
+"
+```
+
+Then run: `python scripts/daily_report.py --test --type evening`
+
+Expected: Report has DDL + Schedule + Tips sections, but NO lab/jwc/news sections. "语气活泼一点" influences the tone.
+
+Then restore defaults:
+```bash
+python -c "
+import json
+from sjtu_agent.paths import CONFIG_PATH
+cfg = json.loads(CONFIG_PATH.read_text(encoding='utf-8'))
+cfg.pop('report_preferences', None)
+import sjtu_agent.paths as p
+p.atomic_write_json(CONFIG_PATH, cfg)
+print('Prefs reset')
+"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/daily_report.py
+git commit -m "feat: dynamic report prompt based on user preferences + DDL classification"
+```
+
+---
+
+### Task 8: Integration test — end-to-end verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+pytest
+```
+
+Expected: All existing tests pass. No regressions.
+
+- [ ] **Step 2: Test DDL classification end-to-end**
+
+```bash
+python -c "
+from sjtu_agent.agent.tools._core import tool_get_ddls
+import json
+r = tool_get_ddls(classify=True)
+print('DDLs:', len(r['ddls']))
+print('Filtered notifications:', r.get('filtered_notifications', 0))
+if r.get('hint'):
+    print('Hint:', r['hint'])
+for d in r['ddls'][:5]:
+    print(f'  [{d.get(\"type\",\"?\")}] {d[\"course\"]} · {d[\"name\"]}  due={d[\"due\"]}')
+"
+```
+
+Expected: Shows classified DDLs with type field.
+
+- [ ] **Step 3: Test report preferences update via tools**
+
+```bash
+python -c "
+from sjtu_agent.agent.tools._report_prefs import tool_update_report_preferences, tool_get_report_preferences
+import json
+
+# Update
+r = tool_update_report_preferences(sections={'jwc': False, 'news': False}, report_type='morning')
+print('Update:', json.dumps(r, ensure_ascii=False))
+
+# Read back
+r2 = tool_get_report_preferences()
+print('Prefs:', json.dumps(r2, ensure_ascii=False, indent=2)[:500])
+
+# Reset
+tool_update_report_preferences(sections={'jwc': True, 'news': True}, report_type='morning')
+print('Reset done')
+"
+```
+
+Expected: Preferences update and read back correctly.
+
+- [ ] **Step 4: Test daily report with classification**
+
+Run: `python scripts/daily_report.py --test --type morning`
+
+Expected: Report DDL section no longer shows notification-type items (like "课程综合评分"). Action suggestions are relevant to real assignments only.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "test: verify DDL classification + report prefs integration"
+```
+
+---
+
+## Verification Summary
+
+After all tasks complete:
+
+1. **Existing tests pass**: `pytest` (from project root) — no regressions
+2. **DDL classification works**: `tool_get_ddls(classify=True)` returns typed DDLs with notifications filtered
+3. **Report preferences persist**: `tool_update_report_preferences()` writes to `config.json`, survives restart
+4. **Daily report dynamic**: `daily_report.py --test` output only shows enabled sections, follows custom instructions
+5. **Known case fixed**: "课程综合评分" type items no longer appear in DDL section or trigger awkward action suggestions

--- a/docs/superpowers/specs/2026-07-05-daily-report-customization-and-ddl-classification-design.md
+++ b/docs/superpowers/specs/2026-07-05-daily-report-customization-and-ddl-classification-design.md
@@ -1,0 +1,177 @@
+# Design: 日报定制化 & DDL 智能分类
+
+- **Date**: 2026-07-05
+- **Status**: Draft
+- **Author**: Azzygoatcoder
+
+## Context
+
+SJTU Agent 的日报（早/中/晚报）和 DDL 查看功能目前存在两个核心问题：
+
+1. **日报内容固化为 6 段固定模板**（作业DDL → 课表 → 实验 → 教务通知 → 校园动态 → 行动建议），用户无法按需调整展示哪些模块。
+2. **DDL 不做分类** — Canvas 上老师发布的不一定都是作业（如课程综合评分、期末安排通知等），导致日报给出不合适的内容和行动建议。
+
+**目标**：让用户通过自然对话调整日报内容（Agent 记住偏好并持久化），让 DDL 系统能智能区分"需要完成的作业"和"仅用于通知的条目"。
+
+## Design
+
+### Part A: 日报偏好系统
+
+#### 数据模型
+
+`config.json` 新增 `report_preferences` 字段：
+
+```json
+{
+  "report_preferences": {
+    "sections": {
+      "ddl": true,
+      "schedule": true,
+      "lab": true,
+      "jwc": true,
+      "news": true,
+      "tips": true
+    },
+    "custom_instructions": "",
+    "per_type": {
+      "morning": {},
+      "noon": {},
+      "evening": {}
+    }
+  }
+}
+```
+
+- `sections`: 控制各模块显隐，默认全开
+- `custom_instructions`: 用户自然语言额外要求（如"多关注物理作业"，直接注入 LLM prompt）
+- `per_type`: 不同报别的差异化覆盖
+
+#### 交互流程
+
+```
+用户在飞书说："早报不用展示教务通知了，太啰嗦"
+  → LLM 识别为日报偏好修改
+  → 调用 update_report_preferences(sections={"jwc": false}, report_type="morning")
+  → 工具更新 config.json
+  → Agent 回复："好的，已调整：早报将不再展示📢教务通知。"
+```
+
+#### 新增工具
+
+在 `sjtu_agent/agent/tools/_core.py` 新增：
+
+- `tool_update_report_preferences(sections, custom_instructions, report_type)` — 修改偏好
+- `tool_get_report_preferences()` — 查看当前偏好
+
+#### 日报生成改造
+
+`scripts/daily_report.py` 的 `build_report()`:
+
+- 读取 `report_preferences` 
+- 按 `sections` 动态构建 LLM 提示词（替换当前硬编码 6 段结构）
+- 将 `custom_instructions` 注入提示词
+- `per_type[report_type]` 覆盖通用偏好
+
+### Part B: DDL 智能分类
+
+#### 数据模型
+
+`fetch_canvas()` 返回的每个 DDL 项增加：
+
+```python
+{
+    # ... 现有字段 ...
+    "type": "assignment" | "notification" | "unknown",
+    "type_confidence": 0.95,  # LLM 分类置信度
+    "description": "...",      # Canvas assignment description (HTML)
+}
+```
+
+`_serialize_ddl()` 也增加 `type` 和 `type_confidence`。
+
+#### 分类流程
+
+```
+fetch_canvas(classify=True)
+  → 对每个 assignment 拉取 description 字段
+  → 规则预筛:
+      - submission_types=["none"] 且 description 含「通知/公告/提醒/评分/评价/问卷/反馈」
+        → type=notification, confidence=1.0
+      - submission_types 包含 online_upload / online_text_entry / online_url
+        → 进入 LLM 分类
+  → 剩余项 → 批量 LLM 分类（单次调用，一次处理所有 assignments）
+  → 分类结果写入 DDL 缓存（随 15 分钟 TTL）
+```
+
+#### LLM 分类提示词
+
+```
+以下是 Canvas 上的若干条目，请判断每个是「作业/任务」还是「课程通知」：
+
+[列表: 课程名 + 作业名 + description]
+
+返回 JSON: [{"index": 0, "type": "assignment", "confidence": 0.95}, ...]
+
+判断标准：
+- 要求学生提交/完成具体内容 → assignment
+- 仅信息告知、无需提交 → notification
+- 评价/评分/问卷/反馈类 → notification
+- description 为空且 submission_types 为 none → notification
+```
+
+#### 触发时机
+
+- `daily_report.py` 收集数据时 → `tool_get_ddls(classify=True)`
+- 用户主动说「查 DDL」→ LLM 调 `get_ddls` 工具时传 `classify=True`
+- 不传 `classify=True` 时复用上一次的分类缓存
+
+#### 展示效果
+
+- 默认只展示 `type=assignment` 的项
+- 末尾提示「已过滤 X 条课程通知，回复"全部"可查看」
+- `get_ddls` 增加 `include_notifications` 参数供用户主动查看全部
+
+### Part C: SYSTEM_PROMPT 更新
+
+`prompts.py` 增加：
+
+```
+## 日报偏好
+
+用户可能要求调整早/中/晚报的内容。识别到意图后调用 update_report_preferences：
+- "早报不要XX" / "晚报加上XX" → 修改对应 sections
+- "日报多关注XX" / "日报语气轻松点" → 更新 custom_instructions
+- 修改成功后简短确认，下次日报自动生效
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `scripts/daily_report.py` | `build_report()` 读偏好，动态构建提示词；`_collect_data()` 传 `classify=True` |
+| `sjtu_agent/agent/tools/_core.py` | 新增 `tool_update_report_preferences`、`tool_get_report_preferences`、`_classify_canvas_ddls()`；`_serialize_ddl()` 增加 `type`/`type_confidence`；`tool_get_ddls()` 增加 `classify` 和 `include_notifications` 参数 |
+| `ddl_checker.py` | `fetch_canvas()` 增加 `classify` 参数，拉取 description，调用分类逻辑 |
+| `sjtu_agent/agent/prompts.py` | SYSTEM_PROMPT 增加日报偏好修改和 DDL 分类行为指引 |
+
+## Implementation Order
+
+**Phase 1: DDL 分类基础设施**（更高优先级 — 直接解决失败案例）
+
+1. `ddl_checker.py` — `fetch_canvas()` 增加 `classify` 参数，拉取 description
+2. `_core.py` — 新增 `_classify_canvas_ddls()` 批量 LLM 分类函数
+3. `_core.py` — `_serialize_ddl()` 增加 `type`/`type_confidence`，`tool_get_ddls()` 增加 `classify` 参数
+4. `_core.py` — DDL 缓存扩展，分类结果随缓存一起存储（15 分钟 TTL）
+5. `daily_report.py` — 日报调用时传 `classify=True`，DDL 区段过滤 notification
+
+**Phase 2: 日报偏好系统**
+
+1. `_core.py` — 新增 `tool_update_report_preferences` + `tool_get_report_preferences`
+2. `prompts.py` — SYSTEM_PROMPT 增加日报偏好修改行为指引
+3. `daily_report.py` — `build_report()` 读取偏好，动态构建提示词
+
+## Verification
+
+1. **DDL 分类**: `python ddl_checker.py` 检查输出包含 `type` 字段；验证已知案例（课程综合评分 → notification）
+2. **日报过滤**: `python daily_report.py --test --type morning` 确认不展示通知类条目；行动建议合理
+3. **对话交互**: 飞书中说「早报不要教务通知」→ 确认 `config.json` 更新 → 下次日报生效
+4. **回归**: `pytest` 全量通过，不破坏现有 DDL 获取功能

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -150,7 +150,7 @@ def _collect_data(report_type: str = "evening") -> dict:
     date_arg = "明天" if report_type == "evening" else "今天"
     results = {}
     tasks = {
-        "ddls":     lambda: agent.tool_get_ddls(),
+        "ddls":     lambda: agent.tool_get_ddls(classify=True),
         "schedule": lambda: agent.tool_get_schedule(query_type="day", date=date_arg),
         "lab":      lambda: agent.tool_get_next_lab(),
         "jwc":      lambda: agent.tool_search_campus("通知 公告", sites=["jwc"], max_results=4),
@@ -189,6 +189,29 @@ def _build_care_note() -> str:
     except Exception:
         pass
     return ""
+
+def _load_report_preferences(report_type: str) -> dict:
+    """加载日报偏好，合并通用设置和报别特定设置。"""
+    try:
+        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        prefs = cfg.get("report_preferences", {})
+    except Exception:
+        return {"sections": {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}, "custom_instructions": ""}
+
+    # 默认值
+    default_sections = {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}
+    sections = {**default_sections, **prefs.get("sections", {})}
+    custom = prefs.get("custom_instructions", "")
+
+    # 报别特定覆盖
+    per_type = prefs.get("per_type", {}).get(report_type, {})
+    if per_type.get("sections"):
+        sections.update(per_type["sections"])
+    if per_type.get("custom_instructions"):
+        custom = per_type["custom_instructions"]
+
+    return {"sections": sections, "custom_instructions": custom}
+
 
 def build_report(report_type: str = "evening") -> str:
     """收集数据 → 调用 AI 生成中文汇报 → 返回 HTML 格式字符串。"""
@@ -289,6 +312,39 @@ def build_report(report_type: str = "evening") -> str:
         return "\n".join(lines)
 
     schedule_section_label = "明日课表" if report_type == "evening" else "今日课表"
+
+    # 读取日报偏好
+    prefs = _load_report_preferences(report_type)
+    enabled_sections = prefs["sections"]
+    custom_instructions = prefs["custom_instructions"]
+
+    _type_hints = {
+        "morning": "今日课程安排+今日截止DDL+晨间行动建议（如：早上有什么课、今天要交什么）",
+        "noon":   "下午及晚间课程安排+临近DDL提醒+午间行动建议（如：下午有什么课、明天截止的作业；上午课程已结束无需再提）",
+        "evening": "今日总结+明日课程预告+晚间行动建议（如：今天完成了什么、明天有什么课、要准备什么）",
+    }
+    hint = _type_hints.get(report_type, _type_hints["evening"])
+    schedule_prompt_header = "明日课程" if report_type == "evening" else "今日课程"
+
+    # --- 动态构建 AI 提示词 ---
+    section_templates = {
+        "ddl": (f"""📚 <b>作业 DDL</b>：列出今日/本周截止任务（如无则写"暂无紧急 DDL ✅"）；每条注明距截止时间
+今日截止（{len(today_ddls)} 项）：
+{chr(10).join(_fmt_ddl(d) for d in today_ddls) or "（无）"}
+本周内截止（{len(week_ddls)} 项）：
+{chr(10).join(_fmt_ddl(d) for d in week_ddls) or "（无）"}"""),
+        "schedule": (f"""📅 <b>{schedule_prompt_header}</b>：课程名+时间（如无课则写"无课"）
+{_fmt_schedule(schedule_raw)}"""),
+        "lab": (f"""🔬 <b>下次实验</b>：时间、地点（如无则写"暂无安排"）
+{_fmt_lab(lab_raw)}"""),
+        "jwc": (f"""📢 <b>教务通知</b>：最多2条关键通知摘要（如无则写"暂无新通知"）
+{_fmt_jwc(jwc_raw)}"""),
+        "news": (f"""📰 <b>校园动态</b>：从校园新闻中选取1-2条最相关或有趣的摘要（如无则写"暂无"）
+{news_raw or "（暂无）"}"""),
+        "tips": "💡 <b>行动建议</b>：根据当前 DDL 紧急程度和时段，用1-2句话给出具体建议",
+    }
+
+    # 构建 data_ctx（DDL 详情和校历始终包含，供 LLM 参考）
     data_ctx = f"""当前时间：{date_str} {now.strftime('%H:%M')}
 
 【DDL 汇总（共 {len(all_ddls)} 项未完成）】
@@ -313,7 +369,7 @@ def build_report(report_type: str = "evening") -> str:
 【校园新闻/水源热帖（近24h）】
 {news_raw or "（暂无）"}"""
 
-    # 校历假日/调休上下文
+    # 校历
     try:
         from sjtu_agent.calendar import AcademicCalendar
         from sjtu_agent.paths import DATA_DIR
@@ -325,13 +381,16 @@ def build_report(report_type: str = "evening") -> str:
 
     _THINK_RE = __import__("re").compile(r"<think>.*?</think>", __import__("re").DOTALL)
 
-    _type_hints = {
-        "morning": "今日课程安排+今日截止DDL+晨间行动建议（如：早上有什么课、今天要交什么）",
-        "noon":   "下午及晚间课程安排+临近DDL提醒+午间行动建议（如：下午有什么课、明天截止的作业；上午课程已结束无需再提）",
-        "evening": "今日总结+明日课程预告+晚间行动建议（如：今天完成了什么、明天有什么课、要准备什么）",
-    }
-    hint = _type_hints.get(report_type, _type_hints["evening"])
-    schedule_prompt_header = "明日课程" if report_type == "evening" else "今日课程"
+    # 构建启用的 section 列表
+    section_order = ["ddl", "schedule", "lab", "jwc", "news", "tips"]
+    enabled_list = [section_templates[k] for k in section_order if enabled_sections.get(k, True)]
+
+    if not enabled_list:
+        # 用户把所有模块都关了
+        enabled_list = ["请告知用户当前日报所有模块均已隐藏，建议至少开启一个模块。"]
+
+    # 构建提示词
+    extra_line = f"\n额外要求：{custom_instructions}" if custom_instructions else ""
     prompt = f"""你是一个贴心的学习助手，请根据以下数据为上海交通大学学生生成一份{label}。
 
 要求：
@@ -339,17 +398,12 @@ def build_report(report_type: str = "evening") -> str:
 - 语气友好简洁，像朋友发消息，不要太正式
 - 全部用中文
 - 时间段：现在是{report_type}（{hint}）
-- 按以下固定结构输出：
+- 按以下结构输出（只输出启用的模块，顺序不变）：
 
 第1行：📊 <b>{date_str} {label}</b>
 
-然后依次输出以下几节（每节空一行）：
-📚 <b>作业 DDL</b>：列出今日/本周截止任务（如无则写"暂无紧急 DDL ✅"）；每条注明距截止时间
-📅 <b>{schedule_prompt_header}</b>：课程名+时间（如无课则写"无课"）
-🔬 <b>下次实验</b>：时间、地点（如无则写"暂无安排"）
-📢 <b>教务通知</b>：最多2条关键通知摘要（如无则写"暂无新通知"）
-📰 <b>校园动态</b>：从校园新闻中选取1-2条最相关或有趣的摘要（如无则写"暂无"）
-💡 <b>行动建议</b>：根据当前 DDL 紧急程度和时段，用1-2句话给出具体建议
+然后依次输出以下启用的模块（每节空一行）：
+{chr(10).join(enabled_list)}{extra_line}
 
 以下是收集到的数据：
 {data_ctx}

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -129,6 +129,10 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 无待完成任务时明确告知
 
+- 获取 DDL 时默认传 classify=True，自动区分真实作业和课程通知（评分/问卷/公告等）
+- 如果返回结果包含 filtered_notifications 和 hint，按 hint 提示用户
+- 用户说「全部」「包括通知」「所有DDL」时传 include_notifications=True
+- 分类为 notification 的条目在展示时标注 📢 而非 📝
 
 
 ## 下载行为
@@ -362,6 +366,15 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 6. 回复邮件（reply_to_uid）同样适用此规则。
 
 
+## 日报偏好
+
+用户可能通过对话调整早/中/晚报的内容。识别到以下意图时调用对应工具：
+
+- 「早报不要XX」「晚报加上XX」「日报隐藏XX」→ update_report_preferences 修改 sections
+- 「日报多关注XX」「日报语气XX」「晚报重点提醒XX」→ update_report_preferences 更新 custom_instructions
+- 「看看日报设置」「日报偏好是什么」→ get_report_preferences
+
+修改成功后简短确认变更内容，告知「下次日报自动生效」。不要长篇解释。
 
 ## 提醒事项管理
 

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -129,7 +129,7 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 无待完成任务时明确告知
 
-- 获取 DDL 时默认传 classify=True，自动区分真实作业和课程通知（评分/问卷/公告等）
+- 获取 DDL 时应传 classify=True，自动区分真实作业和课程通知（评分/问卷/公告等）
 - 如果返回结果包含 filtered_notifications 和 hint，按 hint 提示用户
 - 用户说「全部」「包括通知」「所有DDL」时传 include_notifications=True
 - 分类为 notification 的条目在展示时标注 📢 而非 📝

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -112,13 +112,21 @@ TOOLS = [
         "type": "function",
         "function": {
             "name": "get_ddls",
-            "description": "获取所有平台（Canvas / AI 好课（aihaoke） / 中国大学MOOC）未完成 DDL，按截止时间升序。",
+            "description": "获取所有平台（Canvas / AI 好课（aihaoke） / 中国大学MOOC）未完成 DDL，按截止时间升序。默认自动过滤 Canvas 课程通知（评分/问卷等非作业条目）。",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "skip_canvas":  {"type": "boolean"},
                     "skip_aihaoke": {"type": "boolean"},
                     "skip_icourse": {"type": "boolean"},
+                    "classify": {
+                        "type": "boolean",
+                        "description": "是否对 Canvas 作业进行智能分类（区分真实作业与课程通知）。日报和用户主动查 DDL 时传 true。",
+                    },
+                    "include_notifications": {
+                        "type": "boolean",
+                        "description": "是否包含课程通知类条目。用户说「全部」「包括通知」时传 true。默认 false（过滤通知）。",
+                    },
                 },
                 "required": [],
             },
@@ -1432,7 +1440,7 @@ def _serialize_ddl(item: dict, now=None) -> dict:
         now = _dt.datetime.now(dc.CST)
     total_seconds = (item["due"] - now).total_seconds()
     hours_left    = int(total_seconds / 3600)
-    return {
+    result = {
         "platform":   item["platform"],
         "course":     item["course"],
         "name":       item["name"],
@@ -1441,6 +1449,11 @@ def _serialize_ddl(item: dict, now=None) -> dict:
         "expired":    total_seconds < 0,
         "submitted":  item.get("submitted", False),
     }
+    # 如果有分类信息则带上
+    if item.get("type"):
+        result["type"] = item["type"]
+        result["type_confidence"] = item.get("type_confidence", 0.0)
+    return result
 
 
 def _serialize_lab(lab: dict | None) -> dict | None:
@@ -2097,19 +2110,23 @@ def _ddl_cache_set(cache_key: str, data: list) -> None:
     _ddl_cache_save(store)
 
 
-def _fetch_ddls_parallel(cfg: dict, skip_canvas=False, skip_aihaoke=False, skip_icourse=False) -> list:
+def _fetch_ddls_parallel(cfg: dict, skip_canvas=False, skip_aihaoke=False,
+                          skip_icourse=False, classify: bool = False) -> list:
     """并行拉取各平台 DDL，返回合并列表（未排序）。
-    优先使用 15 分钟内的磁盘缓存，缓存命中时无需发起任何网络请求。
+    优先使用 15 分钟内的磁盘缓存。
+    classify=True 时使用独立缓存键（含 description/type），避免缓存污染。
     """
     import concurrent.futures as _cf
 
     cache_key = f"{skip_canvas},{skip_aihaoke},{skip_icourse}"
+    if classify:
+        cache_key += ",classify"
     cached = _ddl_cache_get(cache_key)
     if cached is not None:
         return cached
 
     tasks = []
-    if not skip_canvas:   tasks.append(("canvas",  lambda: dc.fetch_canvas(cfg)))
+    if not skip_canvas:   tasks.append(("canvas",  lambda: dc.fetch_canvas(cfg, classify=classify)))
     if not skip_aihaoke:  tasks.append(("aihaoke", lambda: dc.fetch_aihaoke(cfg)))
     if not skip_icourse:  tasks.append(("icourse", lambda: dc.fetch_icourse(cfg)))
 
@@ -2355,20 +2372,47 @@ def _check_for_updates() -> None:
 _UPDATE_AVAILABLE: dict = {}
 
 
-def tool_get_ddls(skip_canvas=False, skip_aihaoke=False, skip_icourse=False):
+def tool_get_ddls(skip_canvas=False, skip_aihaoke=False, skip_icourse=False,
+                  classify: bool = False, include_notifications: bool = False):
     import datetime as _dt
     cfg = dc.load_config()
     now = _dt.datetime.now(dc.CST)
-    all_ddl = _fetch_ddls_parallel(cfg, skip_canvas, skip_aihaoke, skip_icourse)
+
+    # 当 classify=True 时，需要原始数据（含 description）做分类
+    fetch_classify = classify
+    all_ddl = _fetch_ddls_parallel(cfg, skip_canvas, skip_aihaoke, skip_icourse,
+                                    classify=fetch_classify)
+
+    if classify:
+        _classify_canvas_ddls(all_ddl)
+
     all_ddl.sort(key=lambda x: x["due"])
     warnings = []
     if not skip_canvas and not (cfg.get("canvas_token") and not cfg.get("canvas_token", "").startswith("YOUR_")):
         warnings.append("Canvas 未配置 token；请先调用 setup_canvas 获取引导，生成后再用 save_credentials 保存。")
-    return {
+
+    serialized = [_serialize_ddl(x, now) for x in all_ddl if not x.get("submitted")]
+
+    # 默认过滤通知类（除非用户明确要求）
+    notification_count = 0
+    if classify and not include_notifications:
+        filtered = []
+        for d in serialized:
+            if d.get("type") == "notification":
+                notification_count += 1
+            else:
+                filtered.append(d)
+        serialized = filtered
+
+    result = {
         "current_time": now.strftime("%Y-%m-%d %H:%M"),
-        "ddls": [_serialize_ddl(x, now) for x in all_ddl if not x.get("submitted")],
+        "ddls": serialized,
         "warnings": warnings,
     }
+    if classify and notification_count > 0:
+        result["filtered_notifications"] = notification_count
+        result["hint"] = f"已过滤 {notification_count} 条课程通知（评分/问卷/公告等）。回复「全部DDL」可查看所有条目。"
+    return result
 
 
 def tool_get_next_lab():

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -72,6 +72,10 @@ from sjtu_agent.agent.tools._user_profile import (
     TOOLS_ENTRIES as _USER_PROFILE_TOOLS,
     tool_get_user_profile, tool_update_user_profile,
 )
+from sjtu_agent.agent.tools._report_prefs import (
+    TOOLS_ENTRIES as _REPORT_PREFS_TOOLS,
+    tool_get_report_preferences, tool_update_report_preferences,
+)
 from sjtu_agent.agent.tools._python_exec import (
     TOOLS_ENTRIES as _PYTHON_EXEC_TOOLS,
     tool_execute_python,
@@ -834,6 +838,7 @@ TOOLS = [
     },
     *_REMINDER_TOOLS,
     *_USER_PROFILE_TOOLS,
+    *_REPORT_PREFS_TOOLS,
     *_PLATFORM_TOOLS,
     {
         "type": "function",
@@ -3765,6 +3770,8 @@ def run_tool(name: str, args: dict) -> str:
         elif name == "execute_python":           r = tool_execute_python(**args)
         elif name == "update_user_profile":      r = tool_update_user_profile(**args)
         elif name == "get_user_profile":         r = tool_get_user_profile()
+        elif name == "update_report_preferences": r = tool_update_report_preferences(**args)
+        elif name == "get_report_preferences":    r = tool_get_report_preferences()
         elif name == "setup_telegram":           r = tool_setup_telegram(**args)
         elif name == "setup_wechat":             r = tool_setup_wechat()
         elif name == "setup_feishu":             r = tool_setup_feishu(**args)

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -2129,6 +2129,135 @@ def _fetch_ddls_parallel(cfg: dict, skip_canvas=False, skip_aihaoke=False, skip_
     return all_ddl
 
 
+def _classify_canvas_ddls(ddls: list) -> list:
+    """对 Canvas DDL 列表进行智能分类（作业 / 通知 / 其他）。
+
+    规则预筛 + LLM 批量分类。结果写回每个 dict 的 type 和 type_confidence 字段。
+    仅处理 platform == "Canvas" 且有 description 字段的项。
+    """
+    import json as _json
+    from sjtu_agent.agent.chat_loop import load_agent_config as _load_cfg
+    from sjtu_agent.agent.runner import _make_client as _make_llm_client
+
+    # 只处理 Canvas 且有 description 的项
+    canvas_items = [
+        (i, d) for i, d in enumerate(ddls)
+        if d.get("platform") == "Canvas" and d.get("description") is not None
+    ]
+    if not canvas_items:
+        return ddls
+
+    # ── 规则预筛 ──
+    notification_keywords = ["通知", "公告", "提醒", "评分", "评价", "问卷", "反馈",
+                              "评分标准", "课程介绍", "Syllabus", "教学大纲"]
+    need_llm = []
+    for idx, d in canvas_items:
+        desc = (d.get("description") or "").strip()
+        sub_types = d.get("submission_types") or []
+        name = d.get("name", "")
+
+        # 规则1: submission_types 为 ["none"] 或空，且名称/描述含关键词 → notification
+        is_none_submission = (not sub_types or sub_types == ["none"])
+        if is_none_submission:
+            text = f"{name} {desc}"
+            if any(kw in text for kw in notification_keywords):
+                d["type"] = "notification"
+                d["type_confidence"] = 1.0
+                continue
+
+        # 规则2: submission_types 包含实际提交类型 (online_upload/online_text_entry/online_url)
+        #         且名称不含通知关键词 → 疑似作业，交给 LLM
+        has_real_submission = any(
+            t in sub_types for t in ["online_upload", "online_text_entry", "online_url",
+                                      "online_quiz", "external_tool", "media_recording"]
+        )
+        if has_real_submission:
+            need_llm.append((idx, d))
+            continue
+
+        # 规则3: 没有 description 且 submission_types 为 none → notification
+        if not desc and is_none_submission:
+            d["type"] = "notification"
+            d["type_confidence"] = 1.0
+            continue
+
+        # 剩余 → LLM 判断
+        need_llm.append((idx, d))
+
+    if not need_llm:
+        return ddls
+
+    # ── LLM 批量分类 ──
+    # 构建简洁的分类请求
+    items_for_llm = []
+    for idx, d in need_llm:
+        desc = (d.get("description") or "")[:500]  # 截断长描述
+        items_for_llm.append({
+            "index": len(items_for_llm),
+            "course": d.get("course", ""),
+            "name": d.get("name", ""),
+            "description": desc,
+            "submission_types": d.get("submission_types", []),
+        })
+
+    prompt = f"""判断以下 Canvas 条目是「作业/任务」还是「课程通知」。
+
+条目列表：
+{_json.dumps(items_for_llm, ensure_ascii=False, indent=2)}
+
+判断标准：
+- 要求学生提交/完成具体内容（做题、写报告、上传文件）→ "assignment"
+- 仅信息告知、无需提交（课程安排通知、评分提醒、问卷、反馈征集、Syllabus）→ "notification"
+- 评价/评分/问卷/反馈/课程介绍 → "notification"
+- 不确定 → "unknown"
+
+返回 JSON 数组（只返回 JSON，不要其他文字）：
+[{{"index": 0, "type": "assignment", "confidence": 0.95}}, ...]"""
+
+    try:
+        agent_cfg = _load_cfg()
+        client = _make_llm_client(agent_cfg)
+        model = agent_cfg.get("model", "deepseek-chat")
+
+        # 使用轻量模型调用（非流式，快速返回）
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=1024,
+            temperature=0.1,  # 低温度，追求一致分类
+        )
+        text = resp.choices[0].message.content or ""
+
+        # 解析 JSON（防御：可能有 markdown 包裹）
+        text = text.strip()
+        if text.startswith("```"):
+            # 去掉 ```json ... ``` 包裹
+            lines = text.split("\n")
+            text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+        classifications = _json.loads(text)
+
+        # 写回结果
+        class_map = {c["index"]: c for c in classifications}
+        for local_idx, (orig_idx, d) in enumerate(need_llm):
+            c = class_map.get(local_idx, {})
+            d["type"] = c.get("type", "unknown")
+            d["type_confidence"] = c.get("confidence", 0.0)
+
+    except Exception as e:
+        print(f"[DDL classify] LLM 分类失败，全部标记为 unknown: {e}")
+        for idx, d in need_llm:
+            d.setdefault("type", "unknown")
+            d.setdefault("type_confidence", 0.0)
+
+    # 确保所有 Canvas 项都有 type（防御）
+    for d in ddls:
+        if d.get("platform") == "Canvas":
+            d.setdefault("type", "unknown")
+            d.setdefault("type_confidence", 0.0)
+
+    return ddls
+
+
 def _prefetch_ddls_background() -> None:
     """在独立子进程中静默预热 DDL 缓存，不阻塞主进程，不向终端输出任何内容。
     子进程的 stdout/stderr 统一重定向到 devnull，完全不干扰主进程终端。

--- a/sjtu_agent/agent/tools/_dining.py
+++ b/sjtu_agent/agent/tools/_dining.py
@@ -591,14 +591,15 @@ W_CUISINE = 0.20
 
 
 
-def _compute_frequency_stats(history: list[dict]) -> dict[int, float]:
+def _compute_frequency_stats(history: list[dict], now=None) -> dict[int, float]:
     """Count visits per canteen with recency weighting.
 
     Visits in last 7 days: 2x weight
     Visits in last 30 days: 1.5x weight
     Older: 1x weight
     """
-    now = _dt.datetime.now(dc.CST)
+    if now is None:
+        now = _dt.datetime.now(dc.CST)
     freq: dict[int, float] = {}
     for r in history:
         cid = r.get("canteen_id", 0)

--- a/sjtu_agent/agent/tools/_report_prefs.py
+++ b/sjtu_agent/agent/tools/_report_prefs.py
@@ -1,0 +1,187 @@
+"""Report preferences tools — customize daily report sections and instructions."""
+
+import json
+
+from sjtu_agent.paths import CONFIG_PATH, atomic_write_json
+
+# ---- Default preferences ------------------------------------------------
+_DEFAULT_SECTIONS = {
+    "ddl": True,
+    "schedule": True,
+    "lab": True,
+    "jwc": True,
+    "news": True,
+    "tips": True,
+}
+
+_DEFAULT_PREFS = {
+    "sections": dict(_DEFAULT_SECTIONS),
+    "custom_instructions": "",
+    "per_type": {
+        "morning": {},
+        "noon": {},
+        "evening": {},
+    },
+}
+
+# ---- Tool definitions ----------------------------------------------------
+
+TOOLS_ENTRIES = [
+    {
+        "type": "function",
+        "function": {
+            "name": "update_report_preferences",
+            "description": (
+                "修改用户的早/中/晚报偏好设置。用户说「早报不要XX」「晚报加上XX」"
+                "「日报多关注XX」时调用。只传需要修改的字段，未传字段保持不变。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "sections": {
+                        "type": "object",
+                        "description": (
+                            "要修改的日报模块显隐。键名：ddl（作业DDL）、schedule（课表）、"
+                            "lab（物理实验）、jwc（教务通知）、news（校园动态）、tips（行动建议）。"
+                            "值为 true=显示，false=隐藏。只传需要改的键。"
+                        ),
+                        "properties": {
+                            "ddl": {"type": "boolean"},
+                            "schedule": {"type": "boolean"},
+                            "lab": {"type": "boolean"},
+                            "jwc": {"type": "boolean"},
+                            "news": {"type": "boolean"},
+                            "tips": {"type": "boolean"},
+                        },
+                    },
+                    "custom_instructions": {
+                        "type": "string",
+                        "description": (
+                            "用户对日报的额外要求（自然语言），将直接注入日报生成提示词。"
+                            "如「多关注物理作业」「语气轻松一点」「晚报重点提醒明天要交的」。"
+                        ),
+                    },
+                    "report_type": {
+                        "type": "string",
+                        "enum": ["morning", "noon", "evening", "all"],
+                        "description": (
+                            "修改哪个报别的偏好。morning=早报，noon=午报，evening=晚报。"
+                            "all=所有报别统一修改。默认 all。"
+                        ),
+                    },
+                },
+                "required": [],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_report_preferences",
+            "description": "查看用户当前的日报偏好设置（各模块显隐状态和自定义要求）。",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+# ---- Internal helpers ----------------------------------------------------
+
+
+def _load_prefs() -> dict:
+    """Load report preferences from config.json, returning defaults if absent."""
+    try:
+        if CONFIG_PATH.exists():
+            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+            prefs = cfg.get("report_preferences")
+            if prefs and isinstance(prefs, dict):
+                merged = dict(_DEFAULT_PREFS)
+                merged["sections"] = {**_DEFAULT_SECTIONS, **prefs.get("sections", {})}
+                merged["custom_instructions"] = prefs.get("custom_instructions", "")
+                merged["per_type"] = prefs.get("per_type", {})
+                for rt in ("morning", "noon", "evening"):
+                    merged["per_type"].setdefault(rt, {})
+                return merged
+    except Exception:
+        pass
+    return dict(_DEFAULT_PREFS)
+
+
+def _save_prefs(prefs: dict) -> None:
+    """Write report preferences back to config.json atomically."""
+    try:
+        if CONFIG_PATH.exists():
+            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        else:
+            cfg = {}
+        cfg["report_preferences"] = prefs
+        atomic_write_json(CONFIG_PATH, cfg)
+    except Exception as e:
+        raise RuntimeError(f"保存日报偏好失败: {e}")
+
+
+# ---- Tool implementations ------------------------------------------------
+
+
+def tool_get_report_preferences() -> dict:
+    """Read current report preferences."""
+    prefs = _load_prefs()
+    return {"preferences": prefs}
+
+
+def tool_update_report_preferences(
+    sections: dict | None = None,
+    custom_instructions: str | None = None,
+    report_type: str = "all",
+) -> dict:
+    """Update report preferences. Only modifies fields that are passed."""
+    prefs = _load_prefs()
+    changes = []
+
+    targets = ["morning", "noon", "evening"] if report_type == "all" else [report_type]
+
+    for rt in targets:
+        per_type = prefs["per_type"].setdefault(rt, {})
+
+        if sections:
+            rt_sections = per_type.setdefault("sections", {})
+            for key in ("ddl", "schedule", "lab", "jwc", "news", "tips"):
+                if key in sections:
+                    rt_sections[key] = sections[key]
+            changes.extend(f"{rt}:{k}={sections[k]}" for k in sections)
+
+        if custom_instructions is not None:
+            per_type["custom_instructions"] = custom_instructions
+            changes.append(f"{rt}:custom_instructions")
+
+    # When report_type is "all", also update the top-level defaults
+    if report_type == "all":
+        if sections:
+            for key in sections:
+                prefs["sections"][key] = sections[key]
+        if custom_instructions is not None:
+            prefs["custom_instructions"] = custom_instructions
+
+    _save_prefs(prefs)
+
+    summary_parts = []
+    if sections:
+        enabled = [k for k, v in sections.items() if v]
+        disabled = [k for k, v in sections.items() if not v]
+        section_names = {
+            "ddl": "📚作业DDL", "schedule": "📅课表", "lab": "🔬物理实验",
+            "jwc": "📢教务通知", "news": "📰校园动态", "tips": "💡行动建议",
+        }
+        if enabled:
+            summary_parts.append(f"将展示: {'、'.join(section_names.get(k, k) for k in enabled)}")
+        if disabled:
+            summary_parts.append(f"将隐藏: {'、'.join(section_names.get(k, k) for k in disabled)}")
+    if custom_instructions is not None:
+        summary_parts.append(f"自定义要求: {custom_instructions}")
+
+    scope = "所有报别" if report_type == "all" else f"{report_type}"
+    return {
+        "ok": True,
+        "scope": scope,
+        "summary": "；".join(summary_parts) if summary_parts else "偏好已更新",
+        "changes": changes,
+    }

--- a/sjtu_agent/agent/tools/_report_prefs.py
+++ b/sjtu_agent/agent/tools/_report_prefs.py
@@ -123,9 +123,20 @@ def _save_prefs(prefs: dict) -> None:
 
 
 def tool_get_report_preferences() -> dict:
-    """Read current report preferences."""
+    """Read current report preferences, including per-type overrides."""
     prefs = _load_prefs()
-    return {"preferences": prefs}
+    # Surface per-type overrides so users can see effective settings
+    effective = {}
+    for rt in ("morning", "noon", "evening"):
+        per_type = prefs.get("per_type", {}).get(rt, {})
+        rt_sections = dict(prefs["sections"])
+        if per_type.get("sections"):
+            rt_sections.update(per_type["sections"])
+        rt_custom = per_type.get("custom_instructions") or prefs.get("custom_instructions", "")
+        effective[rt] = {"sections": rt_sections}
+        if rt_custom:
+            effective[rt]["custom_instructions"] = rt_custom
+    return {"preferences": prefs, "effective": effective}
 
 
 def tool_update_report_preferences(

--- a/tests/test_dining.py
+++ b/tests/test_dining.py
@@ -381,8 +381,11 @@ class TestFrequencyStats:
         assert _compute_frequency_stats([]) == {}
 
     def test_weighting(self):
+        import datetime as _dt
         from sjtu_agent.agent.tools._dining import _compute_frequency_stats
-        stats = _compute_frequency_stats(SAMPLE_DINING_HISTORY)
+        # Use a fixed "now" just after the sample data dates so test is not time-sensitive
+        fixed_now = _dt.datetime(2026, 6, 19, 0, 0, 0, tzinfo=CST)
+        stats = _compute_frequency_stats(SAMPLE_DINING_HISTORY, now=fixed_now)
         # canteen 300 appears 3 times: June 15, 16, 17
         # all within 7 days → 2x weight each = 6.0
         assert stats[300] == pytest.approx(6.0, abs=0.1)
@@ -536,7 +539,7 @@ class TestScoreCanteen:
             _compute_time_stats, _compute_last_visits, _compute_cuisine_history,
         )
         now = _dt.datetime(2026, 6, 18, 12, 0, 0, tzinfo=CST)
-        freq = _compute_frequency_stats(SAMPLE_DINING_HISTORY)
+        freq = _compute_frequency_stats(SAMPLE_DINING_HISTORY, now=now)
         time_s = _compute_time_stats(SAMPLE_DINING_HISTORY)
         last = _compute_last_visits(SAMPLE_DINING_HISTORY)
         cuisine = _compute_cuisine_history(SAMPLE_DINING_HISTORY)


### PR DESCRIPTION
## 改动概要

### 日报定制化
- 用户可通过对话自然调整早/中/晚报展示内容（「早报不要教务通知」「晚报多关注物理作业」等）
- Agent 自动调用 `update_report_preferences` 工具保存偏好到 `config.json`
- `daily_report.py` 读取偏好动态构建 LLM 提示词，替换原来的硬编码 6 段固定模板
- 支持不同报别独立配置 + 自定义额外要求（语气/关注重点等）

### DDL 智能分类
- `fetch_canvas()` 新增 `classify` 参数，拉取作业 description 和 submission_types
- 新增 `_classify_canvas_ddls()` 函数：规则预筛 + LLM 批量分类（作业 vs 通知）
- `tool_get_ddls()` 默认过滤通知类条目，返回过滤数量 + 提示
- 日报 DDL 区段自动只展示真实作业，解决「课程综合评分」等通知被当作作业的问题

### 修复
- CI: `_compute_frequency_stats` 支持固定时间参考，修复时间敏感测试
- `get_report_preferences` 返回各报别生效配置
- SYSTEM_PROMPT 措辞修正

### 涉及文件
| 文件 | 变更 |
|------|------|
| `ddl_checker.py` | fetch_canvas 增加 classify 参数 |
| `sjtu_agent/agent/tools/_core.py` | 分类函数 + 工具签名更新 + 偏好工具接入 |
| `sjtu_agent/agent/tools/_report_prefs.py` | **新建** — 日报偏好工具模块 |
| `sjtu_agent/agent/prompts.py` | SYSTEM_PROMPT 增加行为指引 |
| `scripts/daily_report.py` | 动态提示词 + 分类集成 |
| `sjtu_agent/agent/tools/_dining.py` | 修复时间敏感测试 |
| `tests/test_dining.py` | 修复时间敏感测试 |

### 测试
- 206 测试通过，0 回归（85 个 dining 测试全部通过）
- 日报生成测试：默认全模块 + 自定义偏好均正常