### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.0"
+version = "0.7.1"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
## v0.7.1

### 🐛 Fix
- DDL 分类 Rule 0：名称含「评分/评价/问卷/反馈」的 Canvas 条目直接判为 notification，不再依赖 LLM 判断。修复「课程综合评分」等条目随机出现在日报中的问题。