### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.1"
+version = "0.7.2"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"


### PR DESCRIPTION
## v0.7.2

### 🐛 Fixes
- **Web UI 修复 (#104)**：修复 7 处 JS 语法错误（f94841d 引入），web 配置页导航/状态恢复可用；修复 install-daemons readiness poll 打 cookie 保护端点导致永远等满 15s
- **飞书回复加固 (#93)**：reply() 调用与 get_active() 包裹异常，修复重启后首条消息可能静默无回复（首次 token 获取异常逃逸线程）；异常不再被吞，全部记录日志

### 🔬 说明
- 两个修复均已推送 main 且 CI 通过（Python 3.11/3.13）