### PR TITLE
refactor: tech debt P0+P2 — config write protection, silent exceptions, dead code

### DIFF
--- a/ddl_checker.py
+++ b/ddl_checker.py
@@ -871,13 +871,6 @@ def _parse_phycai_dt(date_str: str, time_str: str) -> datetime | None:
 
 # ── Platform 4: icourse163.org ────────────────────────────────────────────────
 
-def _icourse_fill_form(page_or_frame, username: str, password: str) -> None:
-    """在登录表单（页面或 iframe）中填写账号密码并提交。"""
-    page_or_frame.locator("input[type='text'], input[type='tel'], input[placeholder*='手机'], input[placeholder*='邮箱']").first.fill(username)
-    page_or_frame.locator("input[type='password']").first.fill(password)
-    page_or_frame.locator("button.btn-login, .btn-submit, button[type='submit'], .f-btn-login").first.click()
-
-
 def _icourse_login_with_creds(cfg: dict) -> dict | None:
     """
     用 .env 中的 MOOC_USERNAME / MOOC_PASSWORD 登录 icourse163。

--- a/login.py
+++ b/login.py
@@ -418,8 +418,9 @@ def _collect_and_save(ctx: BrowserContext) -> None:
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        except json.JSONDecodeError:
-            pass
+        except json.JSONDecodeError as e:
+            print(f"[login] config.json 解析失败，已中止保存 cookies 以保护现有配置: {e}")
+            return
 
     # 按域名归集 cookies
     platform_cookies: dict[str, dict[str, str]] = {}

--- a/scripts/care_check.py
+++ b/scripts/care_check.py
@@ -116,12 +116,12 @@ def _get_urgent_ddls() -> list[dict]:
         all_ddl = []
         try:
             all_ddl.extend(dc2.fetch_canvas(cfg))
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[care] fetch_canvas 拉取失败: {e}")
         try:
             all_ddl.extend(dc2.fetch_aihaoke(cfg))
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[care] fetch_aihaoke 拉取失败: {e}")
         urgent = []
         for item in all_ddl:
             due = item.get("due")

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -1245,11 +1245,15 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         if sender_open_id:
             try:
                 cfg_data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-                if cfg_data.get("feishu_open_id") != sender_open_id:
+            except Exception as e:
+                print(f"[feishu] 跳过 open_id 持久化：config.json 读取失败: {e}")
+                cfg_data = None
+            if cfg_data is not None and cfg_data.get("feishu_open_id") != sender_open_id:
+                try:
                     cfg_data["feishu_open_id"] = sender_open_id
                     CONFIG_PATH.write_text(json.dumps(cfg_data, ensure_ascii=False, indent=2), encoding="utf-8")
-            except Exception:
-                pass
+                except Exception as e:
+                    print(f"[feishu] open_id 写入失败: {e}")
 
         # ── 提交到后台线程，立即返回 ──
         if msg_type == "text":

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -301,8 +301,8 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
                     "role": "assistant",
                     "content": [{"type": "text", "text": fallback_text}],
                 })
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[telegram] 最终回复合成失败: {e}")
         return full_text
 
     # ── OpenAI 兼容路径 ──────────────────────────────────────────────────────
@@ -398,8 +398,8 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
                 _emit_first_token()
         if fb_text:
             sess["messages"].append({"role": "assistant", "content": fb_text})
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"[telegram] 最终回复合成失败: {e}")
 
     # 记录对话到 conversation_log（供用户画像更新使用）
     try:

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -1266,24 +1266,6 @@ def handle_text(msg):
 
 # ── 公共函数（供 remind_check.py 调用） ──────────────────────────────────────
 
-def send_reminder_via_telegram(title: str, subtitle: str, body: str) -> None:
-    """
-    向 telegram_allowed_ids 中所有用户推送提醒通知。
-    由 remind_check.py 在找到匹配提醒时调用。
-    """
-    allowed = set(int(x) for x in _load_cfg().get("telegram_allowed_ids", []))
-    if not allowed:
-        return
-    text = f"🔔 <b>{title}</b>\n<i>{subtitle}</i>"
-    if body:
-        text += f"\n{body}"
-    _bot = telebot.TeleBot(BOT_TOKEN)
-    for uid in allowed:
-        try:
-            _bot.send_message(uid, text, parse_mode="HTML")
-        except Exception as e:
-            print(f"[WARN] Telegram 推送失败 uid={uid}: {e}")
-
 
 # ── 入口 ──────────────────────────────────────────────────────────────────────
 

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -14,7 +14,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import urllib.parse
@@ -1620,23 +1619,6 @@ def tool_setup_shuiyuan() -> dict:
     return _setup_shuiyuan_session(cfg, username, password)
 
 
-def _normalize_config_list(value) -> list:
-    if isinstance(value, str):
-        return [value] if value.strip() else []
-    if isinstance(value, list):
-        return [str(x) for x in value if str(x).strip()]
-    return []
-
-
-def _valid_config_id(value: str, label: str) -> str:
-    cleaned = (value or "").strip()
-    if not cleaned:
-        raise ValueError(f"{label} is required")
-    if not re.fullmatch(r"[A-Za-z0-9_.-]+", cleaned):
-        raise ValueError(f"{label} may only contain letters, numbers, dot, underscore, and hyphen")
-    return cleaned
-
-
 
 def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
     """降级方案：Playwright 登录水源，保存 session cookie。"""
@@ -2288,103 +2270,6 @@ def _classify_canvas_ddls(ddls: list) -> list:
             d.setdefault("type_confidence", 0.0)
 
     return ddls
-
-
-def _prefetch_ddls_background() -> None:
-    """在独立子进程中静默预热 DDL 缓存，不阻塞主进程，不向终端输出任何内容。
-    子进程的 stdout/stderr 统一重定向到 devnull，完全不干扰主进程终端。
-    """
-    import subprocess as _sp
-    import sys as _sys
-    import os as _os
-
-    cached = _ddl_cache_get("False,False,False")
-    if cached is not None:
-        return  # 缓存仍有效，无需预热
-
-    # 用 -c 片段在子进程里静默执行拉取
-    _script = (
-        "import sys, os; sys.path.insert(0, os.path.dirname(sys.argv[0]) or '.'); "
-        "import agent as _a, ddl_checker as _dc; "
-        "_a._fetch_ddls_parallel(_dc.load_config())"
-    )
-    try:
-        _sp.Popen(
-            [_sys.executable, "-c", _script],
-            stdout=_sp.DEVNULL,
-            stderr=_sp.DEVNULL,
-            cwd=str(Path(__file__).resolve().parent),
-        )
-    except Exception:
-        pass  # 预热失败不影响主进程
-
-
-def _check_for_updates() -> None:
-    """
-    在后台线程中检查 git 远程是否有新提交。
-    若检测到更新，启动完成后打印一行提示，引导用户运行 sjtu-agent update。
-    非 git 仓库 / 无网络时静默失败，不影响任何功能。
-    """
-    import shutil as _shutil
-    import subprocess as _sub
-
-    git = _shutil.which("git")
-    if not git:
-        return
-
-    project_root = str(Path(__file__).resolve().parent)
-    try:
-        # 检查是否在 git 仓库内
-        r = _sub.run(
-            [git, "rev-parse", "--is-inside-work-tree"],
-            cwd=project_root, capture_output=True, timeout=5,
-        )
-        if r.returncode != 0:
-            return
-
-        # 静默 fetch（只更新远端引用，不改变本地分支）
-        _sub.run(
-            [git, "fetch", "--quiet", "--no-tags", "origin"],
-            cwd=project_root, capture_output=True, timeout=15,
-        )
-
-        # 比较本地 HEAD 与 origin/HEAD（或 origin/main）
-        local_hash = _sub.run(
-            [git, "rev-parse", "HEAD"],
-            cwd=project_root, capture_output=True, timeout=5,
-        ).stdout.decode().strip()
-
-        # 尝试 @{u}（跟踪分支），失败则 origin/main
-        r2 = _sub.run(
-            [git, "rev-parse", "@{u}"],
-            cwd=project_root, capture_output=True, timeout=5,
-        )
-        if r2.returncode == 0:
-            remote_hash = r2.stdout.decode().strip()
-        else:
-            r3 = _sub.run(
-                [git, "rev-parse", "origin/main"],
-                cwd=project_root, capture_output=True, timeout=5,
-            )
-            if r3.returncode != 0:
-                return
-            remote_hash = r3.stdout.decode().strip()
-
-        if local_hash and remote_hash and local_hash != remote_hash:
-            # 统计落后几个提交
-            r4 = _sub.run(
-                [git, "rev-list", "--count", f"{local_hash}..{remote_hash}"],
-                cwd=project_root, capture_output=True, timeout=5,
-            )
-            behind = r4.stdout.decode().strip() if r4.returncode == 0 else "?"
-            # 存入模块级变量，启动完成后打印
-            _UPDATE_AVAILABLE["behind"] = behind
-    except Exception:
-        pass  # 网络不通或其他异常，静默忽略
-
-
-# 用于在主线程启动完成后读取后台更新检查结果
-_UPDATE_AVAILABLE: dict = {}
 
 
 def tool_get_ddls(skip_canvas=False, skip_aihaoke=False, skip_icourse=False,

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -1812,8 +1812,10 @@ def tool_setup_course_community(username: str = "", password: str = "") -> dict:
 
     cfg = {}
     if _CFG.exists():
-        try: cfg = _json.loads(_CFG.read_text(encoding="utf-8"))
-        except Exception: pass
+        try:
+            cfg = _json.loads(_CFG.read_text(encoding="utf-8"))
+        except Exception as e:
+            return {"error": f"config.json 读取失败，已中止保存以保护现有配置: {e}"}
     cfg["course_sjtu_cookies"] = course_cookies
     _CFG.write_text(_json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
     return {
@@ -1980,8 +1982,8 @@ def tool_save_credentials(
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text())
-        except Exception:
-            pass
+        except Exception as e:
+            return {"error": f"config.json 读取失败，已中止保存以保护现有配置: {e}"}
 
     cfg.setdefault("canvas_base_url", "https://oc.sjtu.edu.cn")
     cfg.setdefault("aihaoke_cookies", {})

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -1807,8 +1807,8 @@ def tool_setup_course_community(username: str = "", password: str = "") -> dict:
                 "error": "cookie 验证失败，请手动登录选课社区",
                 "next_action": "访问 https://course.sjtu.plus 登录后告诉我「已登录」。"
             }
-    except Exception:
-        pass
+    except Exception as e:
+        return {"error": f"cookie 验证请求失败: {e}", "next_action": "请重试或手动登录"}
 
     cfg = {}
     if _CFG.exists():

--- a/sjtu_agent/agent/tools/_platforms.py
+++ b/sjtu_agent/agent/tools/_platforms.py
@@ -306,8 +306,8 @@ def tool_setup_telegram(telegram_token: str, allowed_ids: list | None = None) ->
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            return {"error": f"config.json 读取失败，已中止保存以保护现有配置: {e}"}
 
     cfg["telegram_token"] = telegram_token.strip()
     if allowed_ids is not None:
@@ -358,8 +358,8 @@ def tool_setup_feishu(feishu_app_id: str = "", feishu_app_secret: str = "", allo
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            return {"error": f"config.json 读取失败，已中止保存以保护现有配置: {e}"}
 
     if feishu_app_id:
         cfg["feishu_app_id"] = feishu_app_id.strip()
@@ -430,8 +430,8 @@ def tool_setup_qq(
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+        except Exception as e:
+            return {"error": f"config.json 读取失败，已中止保存以保护现有配置: {e}"}
 
     if qq_app_id:
         cfg["qq_app_id"] = str(qq_app_id).strip()

--- a/tests/test_config_write_protection.py
+++ b/tests/test_config_write_protection.py
@@ -1,0 +1,68 @@
+"""Tests for config write protection.
+
+Guards against the "read config fails → pass → rewrite whole config as {}
+→ silently wipes all other credentials" pattern (P0-1 technical debt).
+Rule: never write config back unless the read succeeded.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def corrupt_config(monkeypatch, tmp_path):
+    """Point module-level CONFIG_PATH at an unreadable config.json.
+
+    Returns (module, config_path) so the test can compare bytes before/after.
+    """
+    def _patch(module):
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text("{corrupt json!!!", encoding="utf-8")  # 非法 JSON
+        monkeypatch.setattr(module, "CONFIG_PATH", cfg_path)
+        return cfg_path
+    return _patch
+
+
+def test_tool_save_credentials_aborts_on_corrupt_config(corrupt_config):
+    from sjtu_agent.agent.tools import _core
+    cfg_path = corrupt_config(_core)
+    before = cfg_path.read_bytes()
+
+    result = _core.tool_save_credentials(canvas_token="abc123")
+
+    assert "error" in result, f"expected error, got {result}"
+    assert cfg_path.read_bytes() == before, "config.json 被覆盖写回，凭据可能被清空"
+
+
+def test_tool_setup_feishu_aborts_on_corrupt_config(corrupt_config):
+    from sjtu_agent.agent.tools import _platforms
+    cfg_path = corrupt_config(_platforms)
+    before = cfg_path.read_bytes()
+
+    result = _platforms.tool_setup_feishu(
+        feishu_app_id="cli_x", feishu_app_secret="secret",
+    )
+
+    assert "error" in result, f"expected error, got {result}"
+    assert cfg_path.read_bytes() == before, "config.json 被覆盖写回，凭据可能被清空"
+
+
+def test_tool_setup_telegram_aborts_on_corrupt_config(corrupt_config):
+    from sjtu_agent.agent.tools import _platforms
+    cfg_path = corrupt_config(_platforms)
+    before = cfg_path.read_bytes()
+
+    result = _platforms.tool_setup_telegram(telegram_token="123:ABC")
+
+    assert "error" in result, f"expected error, got {result}"
+    assert cfg_path.read_bytes() == before, "config.json 被覆盖写回，凭据可能被清空"
+
+
+def test_tool_setup_qq_aborts_on_corrupt_config(corrupt_config):
+    from sjtu_agent.agent.tools import _platforms
+    cfg_path = corrupt_config(_platforms)
+    before = cfg_path.read_bytes()
+
+    result = _platforms.tool_setup_qq(qq_app_id="111", qq_app_secret="secret")
+
+    assert "error" in result, f"expected error, got {result}"
+    assert cfg_path.read_bytes() == before, "config.json 被覆盖写回，凭据可能被清空"


### PR DESCRIPTION
## 技术债务修复 — P0（数据安全）+ P2（死代码）

基于三线程代码审查（静默异常 / 未完成重构 / 大文件结构）的实际证据，非 5 月 REFACTOR_PLAN（已过时）。

### P0-1 配置写回保护（7 处）— 防静默清空凭据
`config.json` 读取失败时原代码 `pass` 留下 `cfg={}`，随后**把整个配置写回** — 静默清空所有凭据（telegram token、飞书 app id、全部 cookies）。现在读失败一律**中止写回**：
- `_core.py` tool_save_credentials + course.sjtu cookie 保存 → 返回 error
- `_platforms.py` setup_telegram/feishu/qq → 返回 error
- `feishu_bot.py` 每条消息 open_id 持久化 → 跳过写回，仅日志
- `login.py` _collect_and_save → 中止 cookie 保存

新增 `tests/test_config_write_protection.py`（4 测试）：证明读失败时 config 文件保持不变。

### P0-2 关键静默异常可见化（4 处）
- `telegram_bot.py` 最终回复合成异常被吞 → 空回复零日志（#93 同款）→ 打印
- `_core.py` course.sjtu 验证异常被吞 → 假成功 → 返回 error
- `care_check.py` Canvas/aihaoke 拉取失败静默 → 残缺数据 → 打印

### P2 死代码删除（7 处，-140 行）
全部确认零调用者：`_icourse_fill_form`、`_core.py` 4 个死副本（`_prefetch_ddls_background`/`_check_for_updates`/`_normalize_config_list`/`_valid_config_id` + `_UPDATE_AVAILABLE`）、未使用 `import tempfile`、`send_reminder_via_telegram`。

### 验证
- 全量 295 tests 通过（210 + 85 dining）
- import 冒烟测试通过
- 新增 4 个配置写回保护测试

### 本轮不做（P1）
ConfigStore 迁移 / BotRunner 去重 / Notifier 统一 / 日志改造 / execute_python 暴露（保持隐藏，安全决策）