### PR TITLE
refactor: ConfigStore adoption (20 read sites) + run_tool registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ sjtu_agent/
   agent/              # LLM chat engine (refactored from root-level agent.py in 2026-05)
     __init__.py       # re-exports all public symbols
     prompts.py        # SYSTEM_PROMPT, date context builder, tool labels (~22KB)
-    tools.py          # TOOLS definitions + all tool_xxx implementations (~172KB — largest file)
+    tools/            # TOOLS definitions + tool_xxx implementations (split by domain, _core.py kernel)
     runner.py         # LLM client creation, single-turn execution, streaming
     chat_loop.py      # config loading, chat main loop, startup logic
 
@@ -106,7 +106,7 @@ sjtu_agent/
 
 **Runtime layout**: Data lives in a platform-specific user data directory (`~/.local/share/sjtu-agent` on Linux, `~/Library/Application Support/sjtu-agent` on macOS, `%APPDATA%/sjtu-agent` on Windows). On first run, `ensure_runtime_layout()` migrates legacy files (`.env`, `config.json`, etc.) from the project root.
 
-**Agent tool system** (`agent/tools/`): Each tool is a `tool_xxx` function + a `TOOLS` dict entry. The `run_tool(name, args)` function dispatches by name. Tools are split by domain across submodules (`_reminders.py`, `_email.py`, `_mcp_skills.py`, `_platforms.py`, etc.), with the tightly-coupled kernel remaining in `_core.py` (~135KB).
+**Agent tool system** (`agent/tools/`): Each tool is a `tool_xxx` function + a `TOOLS` dict entry. The `run_tool(name, args)` function dispatches by name. Tools are split by domain across submodules (`_reminders.py`, `_email.py`, `_mcp_skills.py`, `_platforms.py`, etc.), with the tightly-coupled kernel remaining in `_core.py` (~3700 lines).
 
 **Bot architecture**: All three bots (Telegram, Feishu, WeChat) share the same `agent/chat_loop.py` engine. Each bot adds its own platform-specific message handling layer. A `BaseBotRunner` abstraction is planned (`docs/REFACTOR_PLAN.md` §2.2) but not yet implemented.
 
@@ -130,6 +130,7 @@ New code should go into `sjtu_agent/`, not these root or script files.
 ### Refactoring status
 
 Per `docs/REFACTOR_PLAN.md`:
-- **Done**: Phase 1 (ConfigStore singleton), Phase 2.1 (agent.py split into `sjtu_agent/agent/`), tools.py split into `agent/tools/` subpackage (7 domain-specific submodules, `_core.py` ~135KB)
+- **Done**: Phase 2.1 (agent.py split into `sjtu_agent/agent/`), tools.py split into `agent/tools/` subpackage (7 domain-specific submodules + `_report_prefs.py`, `_core.py` ~3700 lines)
+- **Partial**: Phase 1 (ConfigStore) — 类已实现 + 测试，纯读取点已迁移（20 处）；受保护的读写路径（setup/save + P0 凭据保护）保留直接文件操作。`run_tool` 已注册表化（`_TOOL_REGISTRY`）
 - **Not done**: Phase 2.2 (BotRunner base class to deduplicate telegram/wechat ~65% shared code), Phase 3 (Notifier abstraction, BasePlatform for DDL scrapers), Phase 4 (unified logging)
-- CI workflow exists (`.github/workflows/test.yml`, 45 tests) but coverage is thin
+- CI workflow exists (`.github/workflows/test.yml`, 299 tests) but coverage is thin

--- a/scripts/aihot_push.py
+++ b/scripts/aihot_push.py
@@ -161,12 +161,9 @@ def main() -> None:
     from sjtu_agent.feishu_client import send_post_message
 
     # open_id 从 config.json 读取
-    try:
-        from sjtu_agent.paths import CONFIG_PATH
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        open_id = cfg.get("feishu_open_id", "")
-    except Exception:
-        open_id = ""
+    from sjtu_agent.config import cfg as _cfg
+    _cfg.reload_if_changed()
+    open_id = _cfg.get("feishu_open_id", "")
 
     if not open_id:
         print("[aihot] 未配置 feishu_open_id，跳过推送。请先在飞书 Bot 中发一条消息以记录 open_id。")

--- a/scripts/care_check.py
+++ b/scripts/care_check.py
@@ -85,13 +85,15 @@ def _mark_sent(state: dict, care_type: str) -> None:
 
 def _send_care(message: str) -> bool:
     """通过 Telegram 推送关怀消息，返回是否发送成功。"""
+    from sjtu_agent.config import cfg as _cfg
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
+    token = cfg.get("telegram_token", "")
+    allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
+    if not token or not allowed_ids:
+        print("[care_check] Telegram 未配置，跳过发送", flush=True)
+        return False
     try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        token = cfg.get("telegram_token", "")
-        allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
-        if not token or not allowed_ids:
-            print("[care_check] Telegram 未配置，跳过发送", flush=True)
-            return False
         import telebot
         bot = telebot.TeleBot(token)
         for uid in allowed_ids:

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -25,6 +25,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH, DAILY_REPORT_LOG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 import agent
 import ddl_checker as dc
@@ -33,7 +34,8 @@ import ddl_checker as dc
 
 def _send_telegram(text: str) -> None:
     """向所有 allowed_ids 分块推送 Telegram 消息。"""
-    cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
     if not cfg.get("telegram_enabled", True):
         print("[daily_report] Telegram 推送已关闭，跳过")
         return
@@ -107,10 +109,8 @@ def _html_to_post(text: str) -> list:
 
 def _send_feishu(text: str) -> None:
     """通过飞书 API 向用户私聊推送日报（post 格式，支持 Markdown 渲染）。"""
-    try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
     if not cfg.get("feishu_enabled", True):
         print("[daily_report] 飞书推送已关闭，跳过")
         return
@@ -177,11 +177,12 @@ _WEEKDAY_ZH = ["一", "二", "三", "四", "五", "六", "日"]
 
 def _build_care_note() -> str:
     """Build a care note from recent memories for personalisation."""
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
+    open_id = cfg.get("feishu_open_id", "")
+    if not open_id:
+        return ""
     try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        open_id = cfg.get("feishu_open_id", "")
-        if not open_id:
-            return ""
         from sjtu_agent.memory import get_care_suggestions
         suggestion = get_care_suggestions(open_id)
         if suggestion:
@@ -192,11 +193,8 @@ def _build_care_note() -> str:
 
 def _load_report_preferences(report_type: str) -> dict:
     """加载日报偏好，合并通用设置和报别特定设置。"""
-    try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        prefs = cfg.get("report_preferences", {})
-    except Exception:
-        return {"sections": {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}, "custom_instructions": ""}
+    _cfg.reload_if_changed()
+    prefs = _cfg.get("report_preferences", {})
 
     # 默认值
     default_sections = {"ddl": True, "schedule": True, "lab": True, "jwc": True, "news": True, "tips": True}

--- a/scripts/email_watcher.py
+++ b/scripts/email_watcher.py
@@ -130,10 +130,9 @@ def _save_state(last_uid: int, sent_uids: set) -> None:
 
 def _push_feishu(text: str) -> bool:
     """通过飞书 API 向用户发送私聊消息。返回是否成功。"""
-    try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return False
+    from sjtu_agent.config import cfg as _cfg
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
     open_id = cfg.get("feishu_open_id", "")
     if not open_id:
         return False

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -34,6 +34,7 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 import lark_oapi as lark
 from lark_oapi.api.im.v1 import (
@@ -54,10 +55,8 @@ from sjtu_agent.feishu.conversations import FeishuConversationManager
 
 
 def _load_cfg() -> dict:
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError):
-        return {}
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 
 cfg = _load_cfg()

--- a/scripts/qq_bot.py
+++ b/scripts/qq_bot.py
@@ -40,6 +40,7 @@ if hasattr(sys.stderr, "reconfigure"):
     sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 import agent
 import botpy
@@ -54,10 +55,8 @@ _AUDIO_SUFFIXES = {".mp3", ".wav", ".m4a", ".flac", ".ogg", ".amr", ".silk", ".a
 
 
 def _load_cfg() -> dict:
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 
 cfg = _load_cfg()

--- a/scripts/remind_check.py
+++ b/scripts/remind_check.py
@@ -27,6 +27,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from sjtu_agent.paths import CONFIG_PATH, REMINDERS_PATH, REMIND_CHECK_LOG_PATH, REMIND_STATE_PATH
+from sjtu_agent.config import cfg as _cfg
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
@@ -101,13 +102,8 @@ def _parse_dt(s: str) -> datetime | None:
 
 
 def _load_cfg() -> dict:
-    if not CONFIG_PATH.exists():
-        return {}
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception as e:
-        _log(f"读取 config.json 失败: {e}")
-        return {}
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 
 def _open_url(url: str) -> None:

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -34,6 +34,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 import telebot
 import agent
@@ -42,7 +43,8 @@ import ddl_checker as dc
 # ── 配置加载 ──────────────────────────────────────────────────────────────────
 
 def _load_cfg() -> dict:
-    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 cfg         = _load_cfg()
 BOT_TOKEN   = cfg.get("telegram_token", "")

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -54,6 +54,7 @@ import qrcode  # pip install qrcode[pil]
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 import agent
 
@@ -224,7 +225,8 @@ def do_login() -> tuple[str, str, str]:
 # ── 配置读写 ──────────────────────────────────────────────────────────────────
 
 def _load_cfg() -> dict:
-    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 
 def _save_cfg(cfg: dict) -> None:

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -37,6 +37,7 @@ from sjtu_agent.paths import (
     read_json_safe,
 )
 from sjtu_agent.parsing import parse_file as parse_router_file
+from sjtu_agent.config import cfg as _cfg
 
 ROOT = PROJECT_ROOT
 _INTERACTIVE_CHAT_ENV = "SJTU_AGENT_INTERACTIVE_CHAT"
@@ -1482,12 +1483,8 @@ def tool_check_setup() -> dict:
     agent_cfg = load_agent_config()
     canvas_auto_ready, canvas_auto_reason = _canvas_auto_setup_state()
 
-    cfg = {}
-    if CONFIG_PATH.exists():
-        try:
-            cfg = json.loads(CONFIG_PATH.read_text())
-        except Exception:
-            pass
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
 
     def has_cookies(key: str) -> bool:
         return bool(cfg.get(key))
@@ -1811,18 +1808,11 @@ _COURSE_PLUS_BASE = "https://course.sjtu.plus"
 
 def _course_plus_request(path: str, params: dict | None = None, max_retry: int = 2):
     """Call course.sjtu.plus API (v2). Uses stored cookies."""
-    import json as _json
     import time as _time
     import requests as _rq
-    from sjtu_agent.paths import CONFIG_PATH as _CFG
 
-    cookies = {}
-    try:
-        cfg = _json.loads(_CFG.read_text(encoding="utf-8"))
-        if cfg.get("course_sjtu_cookies"):
-            cookies = cfg["course_sjtu_cookies"]
-    except Exception:
-        pass
+    _cfg.reload_if_changed()
+    cookies = _cfg.get("course_sjtu_cookies") or {}
 
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -3594,82 +3594,97 @@ def tool_submit_canvas_assignment(
     }
 
 
+def _no_args(fn):
+    """包装不接受参数的 tool_xxx：忽略传入的 kwargs，调用 fn()。
+
+    保持 run_tool 原行为（无参工具在 if/elif 里被直接调用，忽略多余 args）。
+    """
+    return lambda **kw: fn()
+
+
+# 工具名 → callable(args_dict)。无参工具用 _no_args 包裹；有特殊参数
+# 处理的特例用 lambda。普通工具直接存函数引用（run_tool 用 fn(**args) 调用）。
+_TOOL_REGISTRY = {
+    "check_setup": _no_args(tool_check_setup),
+    "save_credentials": tool_save_credentials,
+    "setup_canvas": tool_setup_canvas,
+    "login_platform": lambda **kw: tool_login_platform(kw["platform"]),
+    "get_ddls": tool_get_ddls,
+    "get_next_lab": _no_args(tool_get_next_lab),
+    "get_all": tool_get_all,
+    "download_assignments": tool_download_assignments,
+    "list_assignment_files": tool_list_assignment_files,
+    "read_assignment_file": tool_read_assignment_file,
+    "parse_local_file": tool_parse_local_file,
+    "parse_local_files": tool_parse_local_files,
+    "install_parse_backend": tool_install_parse_backend,
+    "search_campus": tool_search_campus,
+    "read_shuiyuan_topic": tool_read_shuiyuan_topic,
+    "get_schedule": tool_get_schedule,
+    "setup_shuiyuan": _no_args(tool_setup_shuiyuan),
+    "add_mcp_server": tool_add_mcp_server,
+    "add_skill": tool_add_skill,
+    "create_skill": tool_create_skill,
+    "list_skills": tool_list_skills,
+    "manage_skill": tool_manage_skill,
+    "setup_course_community": tool_setup_course_community,
+    "search_courses": tool_search_courses,
+    "get_course_detail": tool_get_course_detail,
+    "browse_mysjtu": tool_browse_mysjtu,
+    "refresh_mysjtu_catalog": _no_args(tool_refresh_mysjtu_catalog),
+    "query_grades": tool_query_grades,
+    "add_reminder": tool_add_reminder,
+    "list_reminders": _no_args(tool_list_reminders),
+    "remove_reminder": tool_remove_reminder,
+    "list_canvas_courses": tool_list_canvas_courses,
+    "get_canvas_course_announcements": tool_get_canvas_course_announcements,
+    "get_canvas_course_quizzes": tool_get_canvas_course_quizzes,
+    "get_canvas_course_updates": tool_get_canvas_course_updates,
+    "get_canvas_todo": tool_get_canvas_todo,
+    "configure_canvas_monitor": tool_configure_canvas_monitor,
+    "list_canvas_assignments": tool_list_canvas_assignments,
+    "submit_canvas_assignment": tool_submit_canvas_assignment,
+    "list_canvas_folders": tool_list_canvas_folders,
+    "list_canvas_files": tool_list_canvas_files,
+    "canvas_file_tree": tool_canvas_file_tree,
+    "download_canvas_file": tool_download_canvas_file,
+    "canvas_track_mark": tool_canvas_track_mark,
+    "canvas_track_unmark": tool_canvas_track_unmark,
+    "canvas_track_list": _no_args(tool_canvas_track_list),
+    "canvas_track_status": tool_canvas_track_status,
+    "canvas_track_diff": tool_canvas_track_diff,
+    "canvas_track_mark_course": tool_canvas_track_mark_course,
+    "read_emails": tool_read_emails,
+    "search_emails": tool_search_emails,
+    "send_email": tool_send_email,
+    "fetch_url": tool_fetch_url,
+    "execute_python": tool_execute_python,
+    "update_user_profile": tool_update_user_profile,
+    "get_user_profile": _no_args(tool_get_user_profile),
+    "update_report_preferences": tool_update_report_preferences,
+    "get_report_preferences": _no_args(tool_get_report_preferences),
+    "setup_telegram": tool_setup_telegram,
+    "setup_wechat": _no_args(tool_setup_wechat),
+    "setup_feishu": tool_setup_feishu,
+    "setup_qq": tool_setup_qq,
+    "qq_add_user": tool_qq_add_user,
+    "qq_list_users": _no_args(tool_qq_list_users),
+    "qq_remove_user": tool_qq_remove_user,
+    "get_canteen_crowd": tool_get_canteen_crowd,
+    "get_canteen_info": tool_get_canteen_info,
+    "recommend_canteen": tool_recommend_canteen,
+    "record_dining_choice": tool_record_dining_choice,
+    "get_dining_history": tool_get_dining_history,
+}
+
+
 def run_tool(name: str, args: dict) -> str:
     try:
         if name.startswith("mcp__"):
             from sjtu_agent.extensions.mcp_client import call_tool
             return call_tool(name, args or {})
-        if   name == "check_setup":         r = tool_check_setup()
-        elif name == "save_credentials":    r = tool_save_credentials(**args)
-        elif name == "setup_canvas":        r = tool_setup_canvas(**args)
-        elif name == "login_platform":      r = tool_login_platform(args["platform"])
-        elif name == "get_ddls":            r = tool_get_ddls(**args)
-        elif name == "get_next_lab":        r = tool_get_next_lab()
-        elif name == "get_all":             r = tool_get_all(**args)
-        elif name == "download_assignments":r = tool_download_assignments(**args)
-        elif name == "list_assignment_files": r = tool_list_assignment_files(**args)
-        elif name == "read_assignment_file":  r = tool_read_assignment_file(**args)
-        elif name == "parse_local_file":      r = tool_parse_local_file(**args)
-        elif name == "parse_local_files":     r = tool_parse_local_files(**args)
-        elif name == "install_parse_backend": r = tool_install_parse_backend(**args)
-        elif name == "search_campus":         r = tool_search_campus(**args)
-        elif name == "read_shuiyuan_topic":   r = tool_read_shuiyuan_topic(**args)
-        elif name == "get_schedule":          r = tool_get_schedule(**args)
-        elif name == "setup_shuiyuan":        r = tool_setup_shuiyuan()
-        elif name == "add_mcp_server":        r = tool_add_mcp_server(**args)
-        elif name == "add_skill":             r = tool_add_skill(**args)
-        elif name == "create_skill":          r = tool_create_skill(**args)
-        elif name == "list_skills":           r = tool_list_skills(**args)
-        elif name == "manage_skill":          r = tool_manage_skill(**args)
-        elif name == "setup_course_community": r = tool_setup_course_community(**args)
-        elif name == "search_courses":        r = tool_search_courses(**args)
-        elif name == "get_course_detail":     r = tool_get_course_detail(**args)
-        elif name == "browse_mysjtu":         r = tool_browse_mysjtu(**args)
-        elif name == "refresh_mysjtu_catalog": r = tool_refresh_mysjtu_catalog()
-        elif name == "query_grades":            r = tool_query_grades(**args)
-        elif name == "add_reminder":            r = tool_add_reminder(**args)
-        elif name == "list_reminders":          r = tool_list_reminders()
-        elif name == "remove_reminder":         r = tool_remove_reminder(**args)
-        elif name == "list_canvas_courses":      r = tool_list_canvas_courses(**args)
-        elif name == "get_canvas_course_announcements": r = tool_get_canvas_course_announcements(**args)
-        elif name == "get_canvas_course_quizzes": r = tool_get_canvas_course_quizzes(**args)
-        elif name == "get_canvas_course_updates": r = tool_get_canvas_course_updates(**args)
-        elif name == "get_canvas_todo":          r = tool_get_canvas_todo(**args)
-        elif name == "configure_canvas_monitor": r = tool_configure_canvas_monitor(**args)
-        elif name == "list_canvas_assignments":  r = tool_list_canvas_assignments(**args)
-        elif name == "submit_canvas_assignment": r = tool_submit_canvas_assignment(**args)
-        elif name == "list_canvas_folders":      r = tool_list_canvas_folders(**args)
-        elif name == "list_canvas_files":        r = tool_list_canvas_files(**args)
-        elif name == "canvas_file_tree":         r = tool_canvas_file_tree(**args)
-        elif name == "download_canvas_file":     r = tool_download_canvas_file(**args)
-        elif name == "canvas_track_mark":        r = tool_canvas_track_mark(**args)
-        elif name == "canvas_track_unmark":      r = tool_canvas_track_unmark(**args)
-        elif name == "canvas_track_list":        r = tool_canvas_track_list()
-        elif name == "canvas_track_status":      r = tool_canvas_track_status(**args)
-        elif name == "canvas_track_diff":        r = tool_canvas_track_diff(**args)
-        elif name == "canvas_track_mark_course": r = tool_canvas_track_mark_course(**args)
-        elif name == "read_emails":              r = tool_read_emails(**args)
-        elif name == "search_emails":            r = tool_search_emails(**args)
-        elif name == "send_email":               r = tool_send_email(**args)
-        elif name == "fetch_url":                r = tool_fetch_url(**args)
-        elif name == "execute_python":           r = tool_execute_python(**args)
-        elif name == "update_user_profile":      r = tool_update_user_profile(**args)
-        elif name == "get_user_profile":         r = tool_get_user_profile()
-        elif name == "update_report_preferences": r = tool_update_report_preferences(**args)
-        elif name == "get_report_preferences":    r = tool_get_report_preferences()
-        elif name == "setup_telegram":           r = tool_setup_telegram(**args)
-        elif name == "setup_wechat":             r = tool_setup_wechat()
-        elif name == "setup_feishu":             r = tool_setup_feishu(**args)
-        elif name == "setup_qq":                 r = tool_setup_qq(**args)
-        elif name == "qq_add_user":              r = tool_qq_add_user(**args)
-        elif name == "qq_list_users":            r = tool_qq_list_users()
-        elif name == "qq_remove_user":           r = tool_qq_remove_user(**args)
-        elif name == "get_canteen_crowd":    r = tool_get_canteen_crowd(**args)
-        elif name == "get_canteen_info":     r = tool_get_canteen_info(**args)
-        elif name == "recommend_canteen":    r = tool_recommend_canteen(**args)
-        elif name == "record_dining_choice": r = tool_record_dining_choice(**args)
-        elif name == "get_dining_history":   r = tool_get_dining_history(**args)
-        else:                               r = {"error": f"未知工具: {name}"}
+        fn = _TOOL_REGISTRY.get(name)
+        r = fn(**(args or {})) if fn else {"error": f"未知工具: {name}"}
     except Exception as e:
         r = {"error": str(e)}
     return json.dumps(r, ensure_ascii=False)

--- a/sjtu_agent/agent/tools/_platforms.py
+++ b/sjtu_agent/agent/tools/_platforms.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -508,12 +509,8 @@ def tool_setup_qq(
 
 
 def _load_cfg_for_qq_users() -> dict:
-    if not CONFIG_PATH.exists():
-        return {}
-    try:
-        return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
+    _cfg.reload_if_changed()
+    return _cfg.raw()
 
 
 def _save_cfg_for_qq_users(cfg: dict) -> None:

--- a/sjtu_agent/agent/tools/_report_prefs.py
+++ b/sjtu_agent/agent/tools/_report_prefs.py
@@ -3,6 +3,7 @@
 import json
 
 from sjtu_agent.paths import CONFIG_PATH, atomic_write_json
+from sjtu_agent.config import cfg as _cfg
 
 # ---- Default preferences ------------------------------------------------
 _DEFAULT_SECTIONS = {
@@ -89,20 +90,16 @@ TOOLS_ENTRIES = [
 
 def _load_prefs() -> dict:
     """Load report preferences from config.json, returning defaults if absent."""
-    try:
-        if CONFIG_PATH.exists():
-            cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-            prefs = cfg.get("report_preferences")
-            if prefs and isinstance(prefs, dict):
-                merged = dict(_DEFAULT_PREFS)
-                merged["sections"] = {**_DEFAULT_SECTIONS, **prefs.get("sections", {})}
-                merged["custom_instructions"] = prefs.get("custom_instructions", "")
-                merged["per_type"] = prefs.get("per_type", {})
-                for rt in ("morning", "noon", "evening"):
-                    merged["per_type"].setdefault(rt, {})
-                return merged
-    except Exception:
-        pass
+    _cfg.reload_if_changed()
+    prefs = _cfg.get("report_preferences")
+    if prefs and isinstance(prefs, dict):
+        merged = dict(_DEFAULT_PREFS)
+        merged["sections"] = {**_DEFAULT_SECTIONS, **prefs.get("sections", {})}
+        merged["custom_instructions"] = prefs.get("custom_instructions", "")
+        merged["per_type"] = prefs.get("per_type", {})
+        for rt in ("morning", "noon", "evening"):
+            merged["per_type"].setdefault(rt, {})
+        return merged
     return dict(_DEFAULT_PREFS)
 
 

--- a/sjtu_agent/feishu_client.py
+++ b/sjtu_agent/feishu_client.py
@@ -11,6 +11,7 @@ import time
 import requests
 
 from sjtu_agent.paths import CONFIG_PATH
+from sjtu_agent.config import cfg as _cfg
 
 _TENANT_TOKEN: str = ""
 _TENANT_TOKEN_EXPIRES_AT: float = 0.0
@@ -44,10 +45,8 @@ def get_tenant_access_token(app_id: str, app_secret: str) -> str:
 
 
 def _load_feishu_config() -> dict | None:
-    try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-    except Exception:
-        return None
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
     if not cfg.get("feishu_app_id") or not cfg.get("feishu_app_secret"):
         return None
     return cfg

--- a/sjtu_agent/homework_agent.py
+++ b/sjtu_agent/homework_agent.py
@@ -16,21 +16,17 @@ import re
 from pathlib import Path
 
 from sjtu_agent.paths import ASSIGNMENTS_DIR
+from sjtu_agent.config import cfg as _cfg
 
 import agent
 
 
 def _get_feishu_config() -> dict | None:
     """读取飞书配置用于推送。"""
-    from sjtu_agent.paths import CONFIG_PATH
-    if not CONFIG_PATH.exists():
-        return None
-    try:
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        if cfg.get("feishu_app_id") and cfg.get("feishu_open_id"):
-            return cfg
-    except Exception:
-        pass
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
+    if cfg.get("feishu_app_id") and cfg.get("feishu_open_id"):
+        return cfg
     return None
 
 
@@ -265,16 +261,11 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
 
     # 读取用户信息作为上下文
     user_ctx = ""
-    try:
-        from sjtu_agent.paths import CONFIG_PATH, ENV_PATH
-        cfg_data = {}
-        if CONFIG_PATH.exists():
-            cfg_data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
-        jaccount = cfg_data.get("jaccount_username", "") or ""
-        if jaccount:
-            user_ctx = f"\n用户信息：jAccount 用户名 {jaccount}"
-    except Exception:
-        pass
+    _cfg.reload_if_changed()
+    cfg_data = _cfg.raw()
+    jaccount = cfg_data.get("jaccount_username", "") or ""
+    if jaccount:
+        user_ctx = f"\n用户信息：jAccount 用户名 {jaccount}"
 
     prompt = f"""在当前目录完成{aname}（{course}）。{user_ctx}
 

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -20,12 +20,9 @@ from pathlib import Path
 
 def _default_service_names() -> tuple[str, ...]:
     """根据 config.json 中的推送渠道开关返回默认服务列表。"""
-    try:
-        from sjtu_agent.paths import CONFIG_PATH
-        import json
-        cfg = json.loads(CONFIG_PATH.read_text(encoding="utf-8")) if CONFIG_PATH.exists() else {}
-    except Exception:
-        cfg = {}
+    from sjtu_agent.config import cfg as _cfg
+    _cfg.reload_if_changed()
+    cfg = _cfg.raw()
     names = list(available_service_names()) + ["web", "news-digest"]
     if not cfg.get("telegram_enabled", True) and "telegram-bot" in names:
         names.remove("telegram-bot")

--- a/tests/test_run_tool_registry.py
+++ b/tests/test_run_tool_registry.py
@@ -1,0 +1,45 @@
+"""Tests for the run_tool dispatch registry.
+
+run_tool was a 70-branch if/elif chain; it's now a _TOOL_REGISTRY dict.
+These tests guard against tools being exposed to the LLM (in TOOLS) but
+missing from the registry (which would make the model call fail), and
+against dispatch regressions.
+"""
+
+
+def test_all_exposed_tools_are_registered():
+    """TOOLS 列表暴露的每个工具名都能被 run_tool 分发（mcp__ 和隐藏的 execute_python 除外）。"""
+    from sjtu_agent.agent.tools._core import TOOLS, _TOOL_REGISTRY
+    missing = []
+    for entry in TOOLS:
+        name = entry["function"]["name"]
+        if name.startswith("mcp__") or name == "execute_python":
+            continue
+        if name not in _TOOL_REGISTRY:
+            missing.append(name)
+    assert missing == [], f"以下工具暴露给 LLM 但未注册: {missing}"
+
+
+def test_unknown_tool_returns_error():
+    from sjtu_agent.agent.tools._core import run_tool
+    import json
+    result = json.loads(run_tool("no_such_tool", {}))
+    assert "error" in result
+
+
+def test_no_args_tool_ignores_extra_args():
+    """无参工具（如 get_user_profile）传多余参数不应报错。"""
+    from sjtu_agent.agent.tools._core import run_tool
+    import json
+    # 无参工具被 LLM 误传 args 时，原 if/elif 会忽略 args；注册表 _no_args 也应忽略
+    result = json.loads(run_tool("get_user_profile", {"unexpected": 1}))
+    assert "error" not in result
+
+
+def test_arity_tool_passes_kwargs():
+    """带参工具应正确展开 kwargs 调用。get_ddls 传 skip_icourse=True 不应因参数处理报错。"""
+    from sjtu_agent.agent.tools._core import run_tool
+    import json
+    result = json.loads(run_tool("get_ddls", {"skip_icourse": True}))
+    # get_ddls 会尝试拉取（可能因未配置返回空/警告），但不应因 dispatch 本身报错
+    assert "error" not in result


### PR DESCRIPTION
## ConfigStore 采用 + run_tool 注册表化

基于技术债务审查：ConfigStore 类已实现但有测试但 0% 采用；run_tool 是 70 分支 if/elif。

### Task 1: ConfigStore 迁移（20 个纯读点）
`config.py` 的 ConfigStore（单例 + mtime 热重载 + 类型化）已完整实现，但 33 处 `json.loads(CONFIG_PATH.read_text())` 绕过它。迁移了所有**纯读取**点：
- 5 个 bot/daemon 的 `_load_cfg()`（telegram/wechat/qq/feishu/remind_check）
- `tool_check_setup`、`_course_plus_request`、`_load_cfg_for_qq_users`、`_load_prefs`
- homework_agent、scheduler、feishu_client、aihot_push、care_check、daily_report（4处）、email_watcher

**保留 13 个读写点**（setup/save + P0 凭据保护 + web 实时）— ConfigStore 的宽松 `_read_raw`（解析失败返回 {}）会绕过 P0 的读失败中止写回保护。

关键设计：`cfg.reload_if_changed()`（O(1) mtime 检查）保持读取实时，即使保留的直接写文件点修改了 config.json。import 用 `_cfg` 别名避免与 bot 模块级 `cfg`（配置 dict）冲突。

### Task 2: run_tool 注册表化
70 分支 if/elif → `_TOOL_REGISTRY` dict。无参工具用 `_no_args` 包裹（保持忽略多余 args 行为），login_platform 保留特殊参数处理。

新增测试：所有暴露工具必须注册；未知工具报错；无参工具忽略多余参数。

### Task 3: 纠正 CLAUDE.md
`Phase 1 (ConfigStore) Done` → **Partial**（类已实现 + 只读点迁移；受保护读写路径保留直接文件操作）。

### 验证
- 299 测试全过（含 4 个新 registry 测试）
- 迁移后 `json.loads(CONFIG_PATH.read_text)` 剩 13 处（全部为保留的读写点）
- 15 个文件语法检查通过