### PR TITLE
chore: bump version to 0.7.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.3"
+version = "0.7.4"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
## v0.7.4

### 重构（#108）
- **ConfigStore 采用**：20 个纯读点迁移到统一配置层（单例 + 热重载），消除重复 json.loads；13 个受保护读写点保留直接文件操作
- **run_tool 注册表化**：70 分支 if/elif → _TOOL_REGISTRY dict，新增 registry 测试
- **CLAUDE.md 纠正**：Phase 1 (ConfigStore) Done → Partial（纠正错误声明）