### PR TITLE
refactor: P1 tech debt — notifier consolidation, bot core, unified logging

### DIFF
--- a/scripts/canvas_watcher.py
+++ b/scripts/canvas_watcher.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from sjtu_agent.canvas_client import CanvasError, make_client_from_config
 from sjtu_agent.canvas_monitor import merged_canvas_monitor_config
 from sjtu_agent.notifications import send_notification
+from sjtu_agent.logging import get_logger
 from sjtu_agent.paths import (
     CANVAS_MONITOR_STATE_PATH,
     CONFIG_PATH,
@@ -21,15 +22,11 @@ from sjtu_agent.paths import (
 CST = timezone(timedelta(hours=8))
 
 
+_logger = get_logger("canvas_watcher")
+
+
 def _log(message: str) -> None:
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    line = f"[{datetime.now(CST).strftime('%Y-%m-%d %H:%M:%S')}] {message}"
-    print(line)
-    try:
-        with (LOG_DIR / "canvas_watcher.log").open("a", encoding="utf-8") as f:
-            f.write(line + "\n")
-    except Exception:
-        pass
+    _logger.info(message)
 
 
 def _load_cfg() -> dict:

--- a/scripts/care_check.py
+++ b/scripts/care_check.py
@@ -86,25 +86,10 @@ def _mark_sent(state: dict, care_type: str) -> None:
 def _send_care(message: str) -> bool:
     """通过 Telegram 推送关怀消息，返回是否发送成功。"""
     from sjtu_agent.config import cfg as _cfg
+    from sjtu_agent.notifications import send_notification
     _cfg.reload_if_changed()
-    cfg = _cfg.raw()
-    token = cfg.get("telegram_token", "")
-    allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
-    if not token or not allowed_ids:
-        print("[care_check] Telegram 未配置，跳过发送", flush=True)
-        return False
-    try:
-        import telebot
-        bot = telebot.TeleBot(token)
-        for uid in allowed_ids:
-            try:
-                bot.send_message(uid, message, parse_mode="HTML")
-            except Exception as e:
-                print(f"[care_check] 推送失败 uid={uid}: {e}", flush=True)
-        return True
-    except Exception as e:
-        print(f"[care_check] 发送关怀消息出错: {e}", flush=True)
-        return False
+    result = send_notification(_cfg.raw(), "", "", message, channels=["telegram"])
+    return bool(result["ok"])
 
 
 def _get_urgent_ddls() -> list[dict]:

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -26,6 +26,7 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH, DAILY_REPORT_LOG_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.logging import get_logger
 
 import agent
 import ddl_checker as dc
@@ -470,22 +471,11 @@ def _fallback_report(date_str, today_ddls, week_ddls, far_ddls,
 
 # ── 日志 ──────────────────────────────────────────────────────────────────────
 
-LOG_PATH = DAILY_REPORT_LOG_PATH
-MAX_LOG_BYTES = 200 * 1024  # 200 KB
+_logger = get_logger("daily_report")
 
 
 def _log(msg: str) -> None:
-    ts = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    line = f"[{ts}] {msg}\n"
-    print(line, end="")
-    try:
-        if LOG_PATH.exists() and LOG_PATH.stat().st_size > MAX_LOG_BYTES:
-            content = LOG_PATH.read_text(encoding="utf-8")
-            LOG_PATH.write_text(content[-MAX_LOG_BYTES//2:], encoding="utf-8")
-        with LOG_PATH.open("a", encoding="utf-8") as f:
-            f.write(line)
-    except Exception:
-        pass
+    _logger.info(msg)
 
 
 # ── 入口 ──────────────────────────────────────────────────────────────────────

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -35,6 +35,10 @@ sys.path.insert(0, str(ROOT))
 
 from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.bots._core import (
+    build_date_ctx,
+    model_supports_vision as _model_supports_vision,
+)
 
 import lark_oapi as lark
 from lark_oapi.api.im.v1 import (
@@ -159,39 +163,19 @@ _RECENT_UPDATES_TEXT = (
 
 
 def _build_date_ctx() -> str:
-    now = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
-    year = now.year
-    month = now.month
-    if month >= 9:
-        cur_xnm, cur_xqm = year, "1"
-        prev_xnm, prev_xqm = year - 1, "2"
-    elif month <= 6:
-        cur_xnm, cur_xqm = year - 1, "2"
-        prev_xnm, prev_xqm = year - 1, "1"
-    else:
-        cur_xnm, cur_xqm = year - 1, "3"
-        prev_xnm, prev_xqm = year - 1, "2"
-
-    base = (
-        f"\n\n## 当前时间（每轮自动刷新）\n"
-        f"现在：{now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[now.weekday()]}。\n"
-        f"当前学期：{cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期。\n"
-        f"「上学期」={prev_xnm}-{prev_xnm+1}学年第{prev_xqm}学期"
-        f"（query_grades: year='{prev_xnm}', semester='{prev_xqm}'）。\n"
-        f"「本学期」={cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期"
-        f"（query_grades: year='{cur_xnm}', semester='{cur_xqm}'）。"
-    )
-
+    """日期上下文（共享 base + 校历假日/调休）。"""
+    import datetime as _dt
+    base = build_date_ctx()
     # 校历假日/调休上下文
     try:
         from sjtu_agent.calendar import AcademicCalendar
         from sjtu_agent.paths import DATA_DIR
+        now = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
         cal_ctx = AcademicCalendar(DATA_DIR).get_context(now.date())
         if cal_ctx:
             base += f"\n{cal_ctx}"
     except Exception:
         pass
-
     return base
 
 
@@ -287,13 +271,6 @@ def _is_duplicate_content(sender_id: str, text: str) -> bool:
     return False
 
 
-def _model_supports_vision(model: str) -> bool:
-    m = (model or "").lower()
-    return any(kw in m for kw in [
-        "vision", "gpt-4o", "gpt-4-turbo", "claude-3", "claude-4",
-        "gemini", "qwen-vl", "qwen3vl", "glm-4v", "internvl",
-        "sonnet-4", "opus-4", "haiku-4",
-    ])
 
 
 def _capture_turn_multimodal(sess: dict, content: list, open_id: str = "") -> str:

--- a/scripts/qq_bot.py
+++ b/scripts/qq_bot.py
@@ -43,7 +43,10 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    make_session,
     model_supports_vision as _model_supports_vision,
+    run_one_turn,
+    run_one_turn_multimodal,
 )
 
 import agent
@@ -133,50 +136,13 @@ def _next_msg_seq(_: str = "", baseline: int | None = None) -> int:
 
 def _get_session(user_id: str) -> dict:
     if user_id not in _sessions:
-        agent_cfg = agent.load_agent_config()
-        _sessions[user_id] = {
-            "messages": [],
-            "model_box": [agent_cfg["model"]],
-            "client_box": [agent._make_client(agent_cfg)],
-        }
+        _sessions[user_id] = make_session()
         _locks[user_id] = threading.Lock()
     return _sessions[user_id]
 
 
 def _capture_turn(sess: dict, user_text: str) -> str:
-    if not sess["messages"]:
-        sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _QQ_CTX})
-    else:
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _QQ_CTX
-
-    sess["messages"].append({"role": "user", "content": user_text})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    clean = _ANSI_RE.sub("", buf.getvalue())
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                content = m.get("content", "")
-                if isinstance(content, str):
-                    return content.strip() or "(已完成)"
-                if isinstance(content, list):
-                    texts = [b.get("text", "") for b in content if b.get("type") == "text"]
-                    return "\n".join(texts).strip() or "(已完成)"
-        return "(已完成)"
-    return clean[idx + len(marker):].strip()
+    return run_one_turn(sess, user_text, _QQ_CTX)
 
 
 def _normalize_text(raw: str) -> str:
@@ -197,38 +163,7 @@ def _split_text(text: str, max_len: int = 1500) -> list[str]:
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:
-    if not sess["messages"]:
-        sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _QQ_CTX})
-    else:
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _QQ_CTX
-    sess["messages"].append({"role": "user", "content": content})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    clean = _ANSI_RE.sub("", buf.getvalue())
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                c = m.get("content", "")
-                if isinstance(c, str):
-                    return c.strip() or "(已完成)"
-                if isinstance(c, list):
-                    texts = [b.get("text", "") for b in c if b.get("type") == "text"]
-                    return "\n".join(texts).strip() or "(已完成)"
-        return "(已完成)"
-    return clean[idx + len(marker):].strip()
+    return run_one_turn_multimodal(sess, content, _QQ_CTX)
 
 
 def _guess_suffix_from_url(url: str, default: str = ".bin") -> str:

--- a/scripts/qq_bot.py
+++ b/scripts/qq_bot.py
@@ -41,6 +41,10 @@ if hasattr(sys.stderr, "reconfigure"):
 
 from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.bots._core import (
+    build_date_ctx as _build_date_ctx,
+    model_supports_vision as _model_supports_vision,
+)
 
 import agent
 import botpy
@@ -91,28 +95,6 @@ def _verify_credentials(app_id: str, app_secret: str) -> tuple[bool | None, dict
         return None, {"error": str(e)}
 
 
-def _build_date_ctx() -> str:
-    now = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
-    year = now.year
-    month = now.month
-    if month >= 9:
-        cur_xnm, cur_xqm = year, "1"
-        prev_xnm, prev_xqm = year - 1, "2"
-    elif month <= 6:
-        cur_xnm, cur_xqm = year - 1, "2"
-        prev_xnm, prev_xqm = year - 1, "1"
-    else:
-        cur_xnm, cur_xqm = year - 1, "3"
-        prev_xnm, prev_xqm = year - 1, "2"
-    return (
-        f"\n\n## 当前时间（每轮自动刷新）\n"
-        f"现在：{now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[now.weekday()]}。\n"
-        f"当前学期：{cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期。\n"
-        f"「上学期」={prev_xnm}-{prev_xnm+1}学年第{prev_xqm}学期"
-        f"（query_grades: year='{prev_xnm}', semester='{prev_xqm}'）。\n"
-        f"「本学期」={cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期"
-        f"（query_grades: year='{cur_xnm}', semester='{cur_xqm}'）。"
-    )
 
 
 _QQ_CTX = (
@@ -212,13 +194,6 @@ def _split_text(text: str, max_len: int = 1500) -> list[str]:
     return chunks
 
 
-def _model_supports_vision(model: str) -> bool:
-    m = (model or "").lower()
-    return any(kw in m for kw in [
-        "vision", "gpt-4o", "gpt-4-turbo", "claude-3", "claude-4",
-        "gemini", "qwen-vl", "qwen3vl", "glm-4v", "internvl",
-        "sonnet-4", "opus-4", "haiku-4",
-    ])
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:

--- a/scripts/remind_check.py
+++ b/scripts/remind_check.py
@@ -194,111 +194,14 @@ def _check_deadline_guard(state: dict, test_mode: bool = False) -> bool:
 
 
 def _send_notification(title: str, subtitle: str, body: str) -> None:
-    """同时推送系统通知 + Telegram 消息（若已配置）。支持 macOS / Windows / Linux。"""
-    # ── 跨平台系统通知 ────────────────────────────────────────────────────
-    message = f"{subtitle}\n{body}" if body else subtitle
-    try:
-        from plyer import notification as _plyer_notif  # type: ignore
-        _plyer_notif.notify(
-            title=title,
-            message=message,
-            app_name="SJTU Agent",
-            timeout=10,
-        )
-    except Exception:
-        # plyer 不可用时，降级到各平台原生方式
-        try:
-            if sys.platform == "darwin":
-                def esc(s: str) -> str:
-                    return s.replace("\\", "\\\\").replace('"', '\\"')
-                script = (
-                    f'display notification "{esc(body)}" '
-                    f'with title "{esc(title)}" '
-                    f'subtitle "{esc(subtitle)}"'
-                )
-                subprocess.run(["osascript", "-e", script],
-                               check=True, capture_output=True, timeout=5)
-            elif sys.platform == "win32":
-                # Windows 10+ 内置 PowerShell 通知 — 用环境变量传参，防注入
-                ps_script = (
-                    "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, "
-                    "ContentType = WindowsRuntime] | Out-Null; "
-                    "$t = $env:SJTU_TITLE; $m = $env:SJTU_MESSAGE; "
-                    "$template = [Windows.UI.Notifications.ToastNotificationManager]"
-                    "::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
-                    '$template.GetElementsByTagName("text")[0].AppendChild($template.CreateTextNode($t)) | Out-Null; '
-                    '$template.GetElementsByTagName("text")[1].AppendChild($template.CreateTextNode($m)) | Out-Null; '
-                    "$toast = [Windows.UI.Notifications.ToastNotification]::new($template); "
-                    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('SJTU Agent').Show($toast)"
-                )
-                env = {**os.environ, "SJTU_TITLE": title, "SJTU_MESSAGE": message}
-                subprocess.run(["powershell", "-Command", ps_script],
-                               capture_output=True, timeout=10, env=env)
-            else:
-                subprocess.run(["notify-send", title, message],
-                               check=True, capture_output=True, timeout=5)
-        except Exception as e:
-            _log(f"系统通知发送失败: {e}")
-
-    # ── Telegram 推送 ─────────────────────────────────────────────────────
-    try:
-        cfg = _load_cfg()
-        if not cfg.get("telegram_enabled", True):
-            return
-        token       = cfg.get("telegram_token", "")
-        allowed_ids = [int(x) for x in cfg.get("telegram_allowed_ids", [])]
-        if not token or not allowed_ids:
-            return
-        import urllib.request
-        text = f"🔔 <b>{title}</b>\n<i>{subtitle}</i>"
-        if body:
-            text += f"\n{body}"
-        for uid in allowed_ids:
-            url  = f"https://api.telegram.org/bot{token}/sendMessage"
-            data = json.dumps({"chat_id": uid, "text": text, "parse_mode": "HTML"}).encode()
-            req  = urllib.request.Request(url, data=data,
-                                          headers={"Content-Type": "application/json"})
-            urllib.request.urlopen(req, timeout=10)
-        _log(f"Telegram 推送成功 → {allowed_ids}")
-    except Exception as e:
-        _log(f"Telegram 推送失败: {e}")
-
-    # ── 飞书推送 ──────────────────────────────────────────────────────────
-    try:
-        cfg = _load_cfg()
-        if not cfg.get("feishu_enabled", True):
-            return
-        app_id = cfg.get("feishu_app_id", "")
-        app_secret = cfg.get("feishu_app_secret", "")
-        open_id = cfg.get("feishu_open_id", "")
-        if not app_id or not app_secret or not open_id:
-            return
-        import requests
-        r = requests.post(
-            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-            json={"app_id": app_id, "app_secret": app_secret}, timeout=10,
-        )
-        if r.status_code != 200 or r.json().get("code") != 0:
-            _log(f"飞书推送 token 获取失败")
-            return
-        token = r.json()["tenant_access_token"]
-        text = f"🔔 {title}\n{subtitle}"
-        if body:
-            text += f"\n{body}"
-        resp = requests.post(
-            "https://open.feishu.cn/open-apis/im/v1/messages",
-            params={"receive_id_type": "open_id"},
-            headers={"Authorization": f"Bearer {token}"},
-            json={"receive_id": open_id, "msg_type": "text",
-                  "content": json.dumps({"text": text}, ensure_ascii=False)},
-            timeout=15,
-        )
-        if resp.status_code == 200 and resp.json().get("code") == 0:
-            _log("飞书推送完成")
-        else:
-            _log(f"飞书推送失败: {resp.text[:100]}")
-    except Exception as e:
-        _log(f"飞书推送异常: {e}")
+    """同时推送系统通知 + Telegram + 飞书（若已配置）。"""
+    from sjtu_agent.notifications import send_notification
+    cfg = _load_cfg()
+    result = send_notification(cfg, title, subtitle, body)
+    if result["sent"]:
+        _log(f"通知已发送: {[s['channel'] for s in result['sent']]}")
+    if result["failed"]:
+        _log(f"通知推送失败: {result['failed']}")
 
 
 # ── 核心逻辑 ─────────────────────────────────────────────────────────────────

--- a/scripts/remind_check.py
+++ b/scripts/remind_check.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from sjtu_agent.paths import CONFIG_PATH, REMINDERS_PATH, REMIND_CHECK_LOG_PATH, REMIND_STATE_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.logging import get_logger
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
@@ -46,19 +47,11 @@ CST = timezone(timedelta(hours=8))
 
 # ── 工具函数 ─────────────────────────────────────────────────────────────────
 
+_logger = get_logger("remind_check")
+
+
 def _log(msg: str) -> None:
-    ts = datetime.now(CST).strftime("%Y-%m-%d %H:%M:%S")
-    line = f"[{ts}] {msg}"
-    print(line)
-    try:
-        with open(LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
-        # 限制日志大小：超过 200KB 截断到最后 100KB
-        if LOG_PATH.stat().st_size > 200 * 1024:
-            content = LOG_PATH.read_bytes()
-            LOG_PATH.write_bytes(content[-100 * 1024:])
-    except Exception:
-        pass
+    _logger.info(msg)
 
 
 def _load_reminders() -> list[dict]:

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -35,6 +35,10 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.bots._core import (
+    build_date_ctx as _build_date_ctx,
+    model_supports_vision as _model_supports_vision,
+)
 
 import telebot
 import agent
@@ -84,29 +88,6 @@ _TG_CTX = (
 )
 
 
-def _build_date_ctx() -> str:
-    """生成包含当前精确时间的日期上下文（每次调用都是最新时间）。"""
-    now   = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
-    year  = now.year
-    month = now.month
-    if month >= 9:
-        cur_xnm, cur_xqm   = year,     "1"
-        prev_xnm, prev_xqm = year - 1, "2"
-    elif month <= 6:
-        cur_xnm, cur_xqm   = year - 1, "2"
-        prev_xnm, prev_xqm = year - 1, "1"
-    else:
-        cur_xnm, cur_xqm   = year - 1, "3"
-        prev_xnm, prev_xqm = year - 1, "2"
-    return (
-        f"\n\n## 当前时间（每轮自动刷新）\n"
-        f"现在：{now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[now.weekday()]}。\n"
-        f"当前学期：{cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期。\n"
-        f"「上学期」={prev_xnm}-{prev_xnm+1}学年第{prev_xqm}学期"
-        f"（query_grades: year='{prev_xnm}', semester='{prev_xqm}'）。\n"
-        f"「本学期」={cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期"
-        f"（query_grades: year='{cur_xnm}', semester='{cur_xqm}'）。"
-    )
 
 
 def _init_messages(sess: dict) -> None:
@@ -915,14 +896,6 @@ def _download_tg_file(file_id: str, filename: str) -> Path:
     return save_path
 
 
-def _model_supports_vision(model: str) -> bool:
-    """简单判断当前模型是否支持图片输入。"""
-    m = model.lower()
-    return any(kw in m for kw in [
-        "vision", "gpt-4o", "gpt-4-turbo", "claude-3", "claude-4",
-        "gemini", "qwen-vl", "qwen3vl", "glm-4v", "internvl",
-        "sonnet-4", "opus-4", "haiku-4",  # Claude 4 系列（支持下划线和连字符）
-    ])
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -37,7 +37,10 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    make_session,
     model_supports_vision as _model_supports_vision,
+    run_one_turn,
+    run_one_turn_multimodal,
 )
 
 import telebot
@@ -68,12 +71,7 @@ _locks:    dict[int, threading.Lock] = {}
 
 def _get_session(chat_id: int) -> dict:
     if chat_id not in _sessions:
-        agent_cfg = agent.load_agent_config()
-        _sessions[chat_id] = {
-            "messages":   [],
-            "model_box":  [agent_cfg["model"]],
-            "client_box": [agent._make_client(agent_cfg)],
-        }
+        _sessions[chat_id] = make_session()
         _locks[chat_id] = threading.Lock()
     return _sessions[chat_id]
 
@@ -103,49 +101,11 @@ _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[mKABCDEFGHJKST]')
 
 
 def _capture_turn(sess: dict, user_text: str, on_tool_result=None) -> str:
+    """运行一轮对话，返回 Agent 回复文本（共享 message-based 提取）。
+
+    on_tool_result 参数保留以兼容旧签名，但共享路径无需 stdout 捕获。
     """
-    运行一轮对话，捕获 stdout，提取并返回 Agent 回复文本。
-    Spinner 的 \r 控制序列和 ANSI 颜色代码会被过滤掉。
-    on_tool_result: 可选回调 (tool_name, fn_args, result_str) -> None
-    """
-    _init_messages(sess)
-    # 每轮刷新 system prompt 中的时间，避免长会话里时间过期
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
-    sess["messages"].append({"role": "user", "content": user_text})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    raw = buf.getvalue()
-    # 去除 ANSI 转义码
-    clean = _ANSI_RE.sub("", raw)
-    # 找到最后一个 "Agent: " 标记（spinner 输出在它之前）
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        # 没有找到，可能全是工具调用后无文本回复
-        # 尝试从消息历史里取最后一条 assistant 消息
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                content = m.get("content", "")
-                if isinstance(content, str):
-                    return content.strip() or "(已完成)"
-                elif isinstance(content, list):
-                    texts = [b.get("text", "") for b in content if b.get("type") == "text"]
-                    return "\n".join(texts).strip() or "(已完成)"
-        return "(已完成)"
-
-    return clean[idx + len(marker):].strip()
+    return run_one_turn(sess, user_text, _TG_CTX)
 
 
 # ── 流式推进（带工具进度回调） ──────────────────────────────────────────────
@@ -904,37 +864,7 @@ def _capture_turn_multimodal(sess: dict, content: list) -> str:
     content 格式：OpenAI 多模态消息 content 数组，如
       [{"type": "text", "text": "..."}, {"type": "image_url", "image_url": {"url": "data:..."}}]
     """
-    _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
-    sess["messages"].append({"role": "user", "content": content})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    raw   = buf.getvalue()
-    clean = _ANSI_RE.sub("", raw)
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                c = m.get("content", "")
-                if isinstance(c, str):
-                    return c.strip() or "(已完成)"
-                elif isinstance(c, list):
-                    return "\n".join(b.get("text", "") for b in c if b.get("type") == "text").strip() or "(已完成)"
-        return "(已完成)"
-    return clean[idx + len(marker):].strip()
+    return run_one_turn_multimodal(sess, content, _TG_CTX)
 
 
 def _run_with_typing(chat_id: int, lock, fn):

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -57,7 +57,10 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    make_session,
     model_supports_vision as _model_supports_vision,
+    run_one_turn,
+    run_one_turn_multimodal,
 )
 
 import agent
@@ -253,12 +256,7 @@ _sess_lock = threading.Lock()
 def _get_or_create_session() -> dict:
     with _sess_lock:
         if not _sess:
-            agent_cfg = agent.load_agent_config()
-            _sess.update({
-                "messages":   [],
-                "model_box":  [agent_cfg["model"]],
-                "client_box": [agent._make_client(agent_cfg)],
-            })
+            _sess.update(make_session())
     return _sess
 
 
@@ -275,73 +273,11 @@ def _init_messages(sess: dict) -> None:
 
 def _capture_turn(sess: dict, user_text: str) -> str:
     """运行一轮对话，返回 Agent 回复文本。"""
-    _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx()
-    sess["messages"].append({"role": "user", "content": user_text})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    raw   = buf.getvalue()
-    clean = _ANSI_RE.sub("", raw)
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                content = m.get("content", "")
-                if isinstance(content, str):
-                    return content.strip() or "(已完成)"
-                elif isinstance(content, list):
-                    return "\n".join(b.get("text", "") for b in content if b.get("type") == "text").strip() or "(已完成)"
-        return "(已完成)"
-    return clean[idx + len(marker):].strip()
-
-
+    return run_one_turn(sess, user_text)
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:
-    _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx()
-    sess["messages"].append({"role": "user", "content": content})
-
-    buf = io.StringIO()
-    old_stdout = sys.stdout
-    sys.stdout = buf
-    try:
-        agent._run_one_turn(
-            sess["client_box"][0],
-            sess["model_box"][0],
-            sess["messages"],
-        )
-    finally:
-        sys.stdout = old_stdout
-
-    clean = _ANSI_RE.sub("", buf.getvalue())
-    marker = "Agent: "
-    idx = clean.rfind(marker)
-    if idx == -1:
-        for m in reversed(sess["messages"]):
-            if m.get("role") == "assistant":
-                c = m.get("content", "")
-                if isinstance(c, str):
-                    return c.strip() or "(已完成)"
-                if isinstance(c, list):
-                    texts = [b.get("text", "") for b in c if b.get("type") == "text"]
-                    return "\n".join(texts).strip() or "(已完成)"
-        return "(已完成)"
-    return clean[idx + len(marker):].strip()
+    return run_one_turn_multimodal(sess, content)
 
 
 def _guess_suffix_from_url(url: str, default: str = ".bin") -> str:

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -55,6 +55,10 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.bots._core import (
+    build_date_ctx as _build_date_ctx,
+    model_supports_vision as _model_supports_vision,
+)
 
 import agent
 
@@ -258,28 +262,6 @@ def _get_or_create_session() -> dict:
     return _sess
 
 
-def _build_date_ctx() -> str:
-    now   = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
-    year  = now.year
-    month = now.month
-    if month >= 9:
-        cur_xnm, cur_xqm   = year,     "1"
-        prev_xnm, prev_xqm = year - 1, "2"
-    elif month <= 6:
-        cur_xnm, cur_xqm   = year - 1, "2"
-        prev_xnm, prev_xqm = year - 1, "1"
-    else:
-        cur_xnm, cur_xqm   = year - 1, "3"
-        prev_xnm, prev_xqm = year - 1, "2"
-    return (
-        f"\n\n## 当前时间（每轮自动刷新）\n"
-        f"现在：{now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[now.weekday()]}。\n"
-        f"当前学期：{cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期。\n"
-        f"「上学期」={prev_xnm}-{prev_xnm+1}学年第{prev_xqm}学期"
-        f"（query_grades: year='{prev_xnm}', semester='{prev_xqm}'）。\n"
-        f"「本学期」={cur_xnm}-{cur_xnm+1}学年第{cur_xqm}学期"
-        f"（query_grades: year='{cur_xnm}', semester='{cur_xqm}'）。"
-    )
 
 
 def _init_messages(sess: dict) -> None:
@@ -326,13 +308,6 @@ def _capture_turn(sess: dict, user_text: str) -> str:
     return clean[idx + len(marker):].strip()
 
 
-def _model_supports_vision(model: str) -> bool:
-    m = (model or "").lower()
-    return any(kw in m for kw in [
-        "vision", "gpt-4o", "gpt-4-turbo", "claude-3", "claude-4",
-        "gemini", "qwen-vl", "qwen3vl", "glm-4v", "internvl",
-        "sonnet-4", "opus-4", "haiku-4",
-    ])
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:

--- a/sjtu_agent/bots/__init__.py
+++ b/sjtu_agent/bots/__init__.py
@@ -1,0 +1,5 @@
+"""Shared conversation-core for the SJTU platform bots.
+
+Each platform script (telegram/wechat/qq/feishu) keeps only its transport,
+media, and command plumbing; the stateless turn logic lives in `_core`.
+"""

--- a/sjtu_agent/bots/_core.py
+++ b/sjtu_agent/bots/_core.py
@@ -1,0 +1,124 @@
+"""Shared conversation-core for the SJTU platform bots.
+
+Everything here is stateless (takes the session dict explicitly), so each
+platform script keeps only its transport/media/command plumbing.
+
+The session dict shape is: {messages, model_box: [str], client_box: [client]}
+— compatible with both the plain in-memory dicts of telegram/wechat/qq and
+FeishuConversationManager's conversations.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+
+from sjtu_agent.agent import SYSTEM_PROMPT, _run_one_turn
+
+# Each bot previously defined this regex locally; kept here once. feishu never
+# needed it because it doesn't capture stdout — the shared path also doesn't.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mKABCDEFGHJKST]")
+
+
+def build_date_ctx() -> str:
+    """当前时间 + SJTU 学期上下文（每次调用刷新，避免长会话里时间过期）。"""
+    now = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
+    year, month = now.year, now.month
+    if month >= 9:
+        cur_xnm, cur_xqm = year, "1"
+        prev_xnm, prev_xqm = year - 1, "2"
+    elif month <= 6:
+        cur_xnm, cur_xqm = year - 1, "2"
+        prev_xnm, prev_xqm = year - 1, "1"
+    else:
+        cur_xnm, cur_xqm = year - 1, "3"
+        prev_xnm, prev_xqm = year - 1, "2"
+    return (
+        f"\n\n## 当前时间（每轮自动刷新）\n"
+        f"现在：{now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[now.weekday()]}。\n"
+        f"当前学期：{cur_xnm}-{cur_xnm + 1}学年第{cur_xqm}学期。\n"
+        f"「上学期」={prev_xnm}-{prev_xnm + 1}学年第{prev_xqm}学期"
+        f"（query_grades: year='{prev_xnm}', semester='{prev_xqm}'）。\n"
+        f"「本学期」={cur_xnm}-{cur_xnm + 1}学年第{cur_xqm}学期"
+        f"（query_grades: year='{cur_xnm}', semester='{cur_xqm}'）。"
+    )
+
+
+def model_supports_vision(model: str) -> bool:
+    """关键词判断模型是否支持图片输入。对 None 安全（统一各 bot 的防御写法）。"""
+    m = (model or "").lower()
+    return any(kw in m for kw in [
+        "vision", "gpt-4o", "gpt-4-turbo", "claude-3", "claude-4",
+        "gemini", "qwen-vl", "qwen3vl", "glm-4v", "internvl",
+        "sonnet-4", "opus-4", "haiku-4",
+    ])
+
+
+def make_session(agent_cfg: dict | None = None) -> dict:
+    """标准 session dict: {messages, model_box, client_box}。"""
+    from sjtu_agent.agent import _make_client, load_agent_config
+    cfg = agent_cfg or load_agent_config()
+    return {
+        "messages": [],
+        "model_box": [cfg.get("model", "deepseek-chat")],
+        "client_box": [_make_client(cfg) if cfg.get("api_key") else None],
+    }
+
+
+def init_messages(sess: dict, platform_ctx: str = "") -> None:
+    """首次对话注入 system prompt；后续由 refresh_system_prompt 刷新时间。"""
+    if sess["messages"]:
+        return
+    sess["messages"].append({
+        "role": "system",
+        "content": SYSTEM_PROMPT + build_date_ctx() + platform_ctx,
+    })
+
+
+def refresh_system_prompt(sess: dict, platform_ctx: str = "",
+                          extra_suffix_fn=None, user_text: str = "") -> None:
+    """每轮刷新 [0] system 内容（时间过期）+ 可选额外上下文。
+
+    extra_suffix_fn(user_text) -> str 是飞书记忆注入的钩子。
+    """
+    if sess["messages"] and sess["messages"][0]["role"] == "system":
+        base = SYSTEM_PROMPT + build_date_ctx() + platform_ctx
+        if extra_suffix_fn:
+            base += extra_suffix_fn(user_text)
+        sess["messages"][0]["content"] = base
+
+
+def extract_assistant_reply(sess: dict) -> str:
+    """从消息历史取最后一条 assistant 文本（飞书已验证的可靠方式）。
+
+    _run_one_turn 会把 assistant 消息追加到 sess['messages']，所以无需
+    捕获 stdout + 解析 "Agent: " marker。
+    """
+    for m in reversed(sess["messages"]):
+        if m.get("role") == "assistant":
+            content = m.get("content", "")
+            if isinstance(content, str):
+                return content.strip() or "(已完成)"
+            if isinstance(content, list):
+                texts = [b.get("text", "") for b in content if b.get("type") == "text"]
+                return "\n".join(texts).strip() or "(已完成)"
+    return "(已完成)"
+
+
+def run_one_turn(sess: dict, user_text: str, platform_ctx: str = "",
+                 extra_suffix_fn=None) -> str:
+    """追加文本用户轮次 → 跑 LLM → 返回 assistant 回复。"""
+    init_messages(sess, platform_ctx)
+    refresh_system_prompt(sess, platform_ctx, extra_suffix_fn, user_text)
+    sess["messages"].append({"role": "user", "content": user_text})
+    _run_one_turn(sess["client_box"][0], sess["model_box"][0], sess["messages"])
+    return extract_assistant_reply(sess)
+
+
+def run_one_turn_multimodal(sess: dict, content: list, platform_ctx: str = "",
+                            extra_suffix_fn=None) -> str:
+    """同 run_one_turn，但用户消息是 OpenAI multimodal content list。"""
+    init_messages(sess, platform_ctx)
+    refresh_system_prompt(sess, platform_ctx, extra_suffix_fn, "")
+    sess["messages"].append({"role": "user", "content": content})
+    _run_one_turn(sess["client_box"][0], sess["model_box"][0], sess["messages"])
+    return extract_assistant_reply(sess)

--- a/sjtu_agent/logging.py
+++ b/sjtu_agent/logging.py
@@ -1,0 +1,55 @@
+"""Unified logging for SJTU Agent.
+
+Replaces the ad-hoc "print + append to file + manual rotation" _log() helpers
+that were duplicated across remind_check/daily_report/canvas_watcher. Uses
+stdlib `logging` with a RotatingFileHandler writing to DATA_DIR/logs/, and
+mirrors to stdout so interactive/daemon output stays visible where a terminal
+exists.
+"""
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+from sjtu_agent.paths import DATA_DIR
+
+#: 单个日志文件大小上限（与原 _log 的 200KB 手动轮转一致）
+_LOG_MAX_BYTES = 200 * 1024
+_LOG_BACKUP_COUNT = 2
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger writing to DATA_DIR/logs/<name>.log with rotation.
+
+    Each name gets its own file handler + a stdout mirror. Repeated calls with
+    the same name reuse the configured logger (no duplicate handlers).
+    """
+    logger = logging.getLogger(f"sjtu_agent.{name}")
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    logger.propagate = False  # 避免传播到 root 造成重复输出
+
+    log_dir = DATA_DIR / "logs"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+    file_handler = RotatingFileHandler(
+        log_dir / f"{name}.log",
+        maxBytes=_LOG_MAX_BYTES,
+        backupCount=_LOG_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    file_handler.setFormatter(
+        logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+    )
+    logger.addHandler(file_handler)
+
+    # stdout 镜像（有终端时可见；pythonw 无控制台时此 handler 静默丢弃）
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(stream_handler)
+
+    return logger

--- a/sjtu_agent/notifications.py
+++ b/sjtu_agent/notifications.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import urllib.request
@@ -31,11 +32,21 @@ def _send_system_notification(title: str, subtitle: str, body: str) -> None:
         )
         subprocess.run(["osascript", "-e", script], check=True, capture_output=True, timeout=5)
     elif sys.platform == "win32":
-        subprocess.run(
-            ["powershell", "-Command", f"Write-Host {json.dumps(message)}"],
-            capture_output=True,
-            timeout=10,
+        # Windows 10+ 内置 PowerShell ToastNotification — 用环境变量传参，防注入
+        ps_script = (
+            "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, "
+            "ContentType = WindowsRuntime] | Out-Null; "
+            "$t = $env:SJTU_TITLE; $m = $env:SJTU_MESSAGE; "
+            "$template = [Windows.UI.Notifications.ToastNotificationManager]"
+            "::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
+            '$template.GetElementsByTagName("text")[0].AppendChild($template.CreateTextNode($t)) | Out-Null; '
+            '$template.GetElementsByTagName("text")[1].AppendChild($template.CreateTextNode($m)) | Out-Null; '
+            "$toast = [Windows.UI.Notifications.ToastNotification]::new($template); "
+            "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('SJTU Agent').Show($toast)"
         )
+        env = {**os.environ, "SJTU_TITLE": title, "SJTU_MESSAGE": message}
+        subprocess.run(["powershell", "-Command", ps_script],
+                       capture_output=True, timeout=10, env=env)
     else:
         subprocess.run(["notify-send", title, message], check=True, capture_output=True, timeout=5)
 
@@ -46,47 +57,25 @@ def _send_telegram_notification(cfg: dict, title: str, subtitle: str, body: str)
     text = f"🔔 <b>{title}</b>\n<i>{subtitle}</i>"
     if body:
         text += f"\n{body}"
+    # Telegram 单条消息最大 4096 字符，超长按 4000 分块
+    chunks = [text[i:i + 4000] for i in range(0, len(text), 4000)] or [""]
     for uid in allowed_ids:
         url = f"https://api.telegram.org/bot{token}/sendMessage"
-        data = json.dumps({"chat_id": uid, "text": text, "parse_mode": "HTML"}).encode()
-        req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
-        urllib.request.urlopen(req, timeout=10)
+        for chunk in chunks:
+            data = json.dumps({"chat_id": uid, "text": chunk, "parse_mode": "HTML"}).encode()
+            req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+            urllib.request.urlopen(req, timeout=10)
 
 
 def _send_feishu_notification(cfg: dict, title: str, subtitle: str, body: str) -> None:
-    import requests
-
-    app_id = cfg.get("feishu_app_id", "")
-    app_secret = cfg.get("feishu_app_secret", "")
+    # 复用 feishu_client 的缓存 tenant_access_token，避免每次手动获取
+    from sjtu_agent.feishu_client import send_text_message
     open_id = cfg.get("feishu_open_id", "")
-    token_resp = requests.post(
-        "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
-        json={"app_id": app_id, "app_secret": app_secret},
-        timeout=10,
-    )
-    token_resp.raise_for_status()
-    token_payload = token_resp.json()
-    if token_payload.get("code") != 0:
-        raise RuntimeError("飞书 tenant_access_token 获取失败")
-    tenant_token = token_payload["tenant_access_token"]
     text = f"🔔 {title}\n{subtitle}"
     if body:
         text += f"\n{body}"
-    resp = requests.post(
-        "https://open.feishu.cn/open-apis/im/v1/messages",
-        params={"receive_id_type": "open_id"},
-        headers={"Authorization": f"Bearer {tenant_token}"},
-        json={
-            "receive_id": open_id,
-            "msg_type": "text",
-            "content": json.dumps({"text": text}, ensure_ascii=False),
-        },
-        timeout=15,
-    )
-    resp.raise_for_status()
-    payload = resp.json()
-    if payload.get("code") != 0:
-        raise RuntimeError(payload.get("msg") or "飞书推送失败")
+    if not send_text_message(open_id, text):
+        raise RuntimeError("飞书推送失败")
 
 
 def _channel_configured(cfg: dict, channel: str) -> bool:

--- a/tests/test_bots_core.py
+++ b/tests/test_bots_core.py
@@ -1,0 +1,69 @@
+"""Tests for sjtu_agent/bots/_core.py — shared conversation-core.
+
+The critical invariant: run_one_turn relies on agent._run_one_turn APPENDING
+the assistant message to sess['messages'] (runner.py does this), so reply
+extraction from message history is equivalent to the old stdout "Agent: "
+marker parse that telegram/wechat/qq used.
+"""
+
+import pytest
+
+
+def test_model_supports_vision():
+    from sjtu_agent.bots._core import model_supports_vision
+    assert model_supports_vision("gpt-4o") is True
+    assert model_supports_vision("claude-3-5-sonnet") is True
+    assert model_supports_vision("deepseek-chat") is False
+    assert model_supports_vision(None) is False  # 防御 None
+
+
+def test_build_date_ctx_contains_semester():
+    from sjtu_agent.bots._core import build_date_ctx
+    ctx = build_date_ctx()
+    assert "当前时间" in ctx
+    assert "当前学期" in ctx
+
+
+def test_extract_assistant_reply_text_and_list():
+    from sjtu_agent.bots._core import extract_assistant_reply
+    assert extract_assistant_reply(
+        {"messages": [{"role": "assistant", "content": "  你好  "}]}
+    ) == "你好"
+    assert extract_assistant_reply(
+        {"messages": [{"role": "assistant", "content": [{"type": "text", "text": "A"}, {"type": "text", "text": "B"}]}]}
+    ) == "A\nB"
+    assert extract_assistant_reply({"messages": []}) == "(已完成)"
+
+
+def test_run_one_turn_appends_and_returns(monkeypatch):
+    """模拟 _run_one_turn 把 assistant 回复追加到 messages，验证提取等价。"""
+    import sjtu_agent.bots._core as core
+
+    def fake_run_one_turn(client, model, messages):
+        messages.append({"role": "assistant", "content": "模拟回复"})
+
+    monkeypatch.setattr(core, "_run_one_turn", fake_run_one_turn)
+
+    sess = {"messages": [], "model_box": ["deepseek-chat"], "client_box": [object()]}
+    reply = core.run_one_turn(sess, "你好", "【平台上下文】")
+
+    assert reply == "模拟回复"
+    assert sess["messages"][0]["role"] == "system"
+    assert "你好" in sess["messages"][1]["content"] or sess["messages"][1]["content"] == "你好"
+    assert sess["messages"][2]["role"] == "assistant"
+
+
+def test_run_one_turn_multimodal(monkeypatch):
+    import sjtu_agent.bots._core as core
+
+    def fake_run_one_turn(client, model, messages):
+        messages.append({"role": "assistant", "content": "多模态回复"})
+
+    monkeypatch.setattr(core, "_run_one_turn", fake_run_one_turn)
+
+    sess = {"messages": [], "model_box": ["deepseek-chat"], "client_box": [object()]}
+    content = [{"type": "text", "text": "看图"}]
+    reply = core.run_one_turn_multimodal(sess, content, "【平台】")
+
+    assert reply == "多模态回复"
+    assert sess["messages"][1]["content"] == content


### PR DESCRIPTION
## P1 技术债务（A/B/C1）

三个 P1 问题经代码验证：Notifier 被夸大（共享层已存在）、BotRunner 重复（~350 行）和日志（523 print）真实存在。先修小的再修大的。

### Phase A: Notifier 收尾（-159 行）
- notifications._send_telegram_notification 加 4000-char 分块（原缺，超长 400）
- notifications._send_feishu_notification 改用 feishu_client 缓存 token（原每次手动获取）
- notifications._send_system_notification win32 升级为真实 ToastNotification
- remind_check._send_notification → send_notification()（删 ~106 行重复）
- care_check._send_care → send_notification()

### Phase B: BotRunner 去重（-220 行）
新建 `sjtu_agent/bots/_core.py` 共享会话核心：
- build_date_ctx + model_supports_vision（纯函数，4 bot 共用，修 telegram None 崩溃隐患）
- run_one_turn / run_one_turn_multimodal（message-based extraction，替代 stdout 'Agent: ' 解析）
- make_session（session 工厂）
- 新增 tests/test_bots_core.py（5 测试，验证提取等价性）

### Phase C1: 统一日志
新建 `sjtu_agent/logging.py`（stdlib logging + RotatingFileHandler，零新依赖），合并 3 个重复的 _log()（remind_check/daily_report/canvas_watcher），canvas_watcher 获得轮转，Windows pythonw 下日志不再丢失。

### 验证
- 304 测试全过（含新增 5 bots core + 既有）
- send_notification 三通道 test_mode 验证
- get_logger 写文件 + stdout 镜像验证

### 本轮不做
- 日志 C2（~200 处 daemon print→logging）+ C3（ddl_checker 84 处）— 单独推进