### PR TITLE
feat: migrate 187 print→logging across daemons and ddl_checker (Phase C C2+C3)

### DIFF
--- a/ddl_checker.py
+++ b/ddl_checker.py
@@ -29,12 +29,15 @@ from pathlib import Path
 import requests
 from bs4 import BeautifulSoup
 from sjtu_agent.paths import CONFIG_PATH, ENV_PATH, SCHEDULE_CACHE_PATH as _SCHEDULE_CACHE_PATH
+from sjtu_agent.logging import get_logger
 
 try:
     from playwright.sync_api import sync_playwright
     HAS_PLAYWRIGHT = True
 except ImportError:
     HAS_PLAYWRIGHT = False
+
+_logger = get_logger("ddl_checker")
 
 # ── 全局常量 ──────────────────────────────────────────────────────────────────
 
@@ -120,7 +123,7 @@ def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) 
     token = cfg.get("canvas_token", "").strip()
     base = cfg.get("canvas_base_url", "https://oc.sjtu.edu.cn").rstrip("/")
     if not token or token.startswith("YOUR_"):
-        print("[Canvas] ⚠ 未配置 canvas_token，跳过")
+        _logger.warning("[Canvas] ⚠ 未配置 canvas_token，跳过")
         return []
 
     session = requests.Session()
@@ -135,7 +138,7 @@ def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) 
             r = session.get(url, params=params, timeout=15)
             r.raise_for_status()
         except requests.RequestException as e:
-            print(f"[Canvas] 获取课程列表失败：{e}")
+            _logger.error(f"[Canvas] 获取课程列表失败：{e}")
             raise  # 让上层调用者感知错误，而非静默返回空列表
         courses.extend(r.json())
         url = r.links.get("next", {}).get("url")
@@ -158,7 +161,7 @@ def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) 
                 r = session.get(asgn_url, params=asgn_params, timeout=15)
                 r.raise_for_status()
             except requests.RequestException as e:
-                print(f"[Canvas] 获取 {cname} 作业失败：{e}")
+                _logger.error(f"[Canvas] 获取 {cname} 作业失败：{e}")
                 raise
             for a in r.json():
                 if a.get("workflow_state") == "deleted":
@@ -191,7 +194,7 @@ def fetch_canvas(cfg: dict, include_past: bool = False, classify: bool = False) 
                 if sub.get("workflow_state") in ("submitted", "graded") and sub.get("submitted_at"):
                     submitted_ids.add(sub["assignment_id"])
         except requests.RequestException as e:
-            print(f"[Canvas] 查询 {cname} 提交状态失败：{e}")
+            _logger.warning(f"[Canvas] 查询 {cname} 提交状态失败：{e}")
 
         for a in pending:
             entry = {
@@ -237,7 +240,7 @@ def _fetch_aihaoke_enrolled_courses(cfg: dict) -> list[dict] | None:
 
     ok, error = refresh_aihaoke_cookies(cfg)
     if not ok:
-        print(f"[aihaoke] cookies 刷新失败：{error}")
+        _logger.warning(f"[aihaoke] cookies 刷新失败：{error}")
         return None
 
     raw_cookies = cfg.get("aihaoke_cookies", {})
@@ -286,11 +289,11 @@ def _fetch_aihaoke_enrolled_courses(cfg: dict) -> list[dict] | None:
             finally:
                 browser.close()
     except Exception as e:
-        print(f"[aihaoke] 调用 listMyClass 失败：{e}")
+        _logger.warning(f"[aihaoke] 调用 listMyClass 失败：{e}")
         return None
 
     if data.get("code") == 401:
-        print("[aihaoke] listMyClass 返回 401，token 可能失效")
+        _logger.warning("[aihaoke] listMyClass 返回 401，token 可能失效")
         return None
 
     payload = data.get("data")
@@ -326,7 +329,7 @@ def _fetch_aihaoke_enrolled_courses(cfg: dict) -> list[dict] | None:
         })
 
     if not courses:
-        print(f"[aihaoke] listMyClass 返回空列表，响应：{json.dumps(data, ensure_ascii=False)[:300]}")
+        _logger.warning(f"[aihaoke] listMyClass 返回空列表，响应：{json.dumps(data, ensure_ascii=False)[:300]}")
         return None
 
     cfg["aihaoke_courses"] = courses
@@ -334,7 +337,7 @@ def _fetch_aihaoke_enrolled_courses(cfg: dict) -> list[dict] | None:
     CONFIG_PATH.write_text(
         json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8"
     )
-    print(f"[aihaoke] ✓ 自动识别到 {len(courses)} 门课程：{[c['name'] for c in courses]}")
+    _logger.info(f"[aihaoke] ✓ 自动识别到 {len(courses)} 门课程：{[c['name'] for c in courses]}")
     return courses
 
 
@@ -387,15 +390,15 @@ def fetch_aihaoke(cfg: dict, *, force_refresh_courses: bool = False) -> list[dic
         and os.environ.get("JACCOUNT_PASSWORD", "").strip()
     )
     if not token and not has_creds:
-        print("[aihaoke] ⚠ 未配置 aihaoke_cookies[haoke-token] 且缺少 jAccount 凭据，跳过")
+        _logger.warning("[aihaoke] ⚠ 未配置 aihaoke_cookies[haoke-token] 且缺少 jAccount 凭据，跳过")
         return []
 
     # 快速验证 token（纯 requests，< 1s）；token 为空或失效都触发刷新
     if not token or not _aihaoke_token_works(token):
-        print("[aihaoke] Token 缺失或已过期，正在登录…")
+        _logger.info("[aihaoke] Token 缺失或已过期，正在登录…")
         ok, error = refresh_aihaoke_cookies(cfg)
         if not ok:
-            print(f"[aihaoke] ⚠ 登录失败：{error}")
+            _logger.warning(f"[aihaoke] ⚠ 登录失败：{error}")
             return []
         raw_cookies = cfg.get("aihaoke_cookies", {})
         token = raw_cookies.get("haoke-token", "").strip()
@@ -410,22 +413,22 @@ def fetch_aihaoke(cfg: dict, *, force_refresh_courses: bool = False) -> list[dic
     cache_fresh = _aihaoke_courses_cache_fresh(cfg)
     if force_refresh_courses or not courses or not cache_fresh:
         if force_refresh_courses:
-            print("[aihaoke] 强制刷新选修课程列表…")
+            _logger.info("[aihaoke] 强制刷新选修课程列表…")
         elif not courses:
-            print("[aihaoke] 正在自动识别选修课程列表…")
+            _logger.info("[aihaoke] 正在自动识别选修课程列表…")
         else:
-            print("[aihaoke] 课程缓存已过期，重新识别…")
+            _logger.info("[aihaoke] 课程缓存已过期，重新识别…")
         discovered = _fetch_aihaoke_enrolled_courses(cfg)
         if discovered:
             courses = discovered
         elif courses:
-            print("[aihaoke] ⚠ 自动识别失败，沿用历史缓存继续运行")
+            _logger.warning("[aihaoke] ⚠ 自动识别失败，沿用历史缓存继续运行")
         else:
-            print("[aihaoke] ⚠ 未能识别到任何已选修课程，跳过")
+            _logger.warning("[aihaoke] ⚠ 未能识别到任何已选修课程，跳过")
             return []
 
     if not courses:
-        print("[aihaoke] ⚠ 课程列表为空，跳过")
+        _logger.warning("[aihaoke] ⚠ 课程列表为空，跳过")
         return []
 
     def _fetch_one(course: dict) -> tuple[list[dict], bool]:
@@ -452,7 +455,7 @@ def fetch_aihaoke(cfg: dict, *, force_refresh_courses: bool = False) -> list[dic
                 )
                 data = resp.json()
             except Exception as e:
-                print(f"  [aihaoke] {cname} 第{page_no}页请求失败：{e}")
+                _logger.warning(f"  [aihaoke] {cname} 第{page_no}页请求失败：{e}")
                 return tasks, False
 
             if data.get("code") == 401:
@@ -491,7 +494,7 @@ def fetch_aihaoke(cfg: dict, *, force_refresh_courses: bool = False) -> list[dic
             if expired:
                 token_expired = True
     if token_expired:
-        print("[aihaoke] ⚠ Token 已过期，请运行 python login.py --aihaoke 刷新")
+        _logger.warning("[aihaoke] ⚠ Token 已过期，请运行 python login.py --aihaoke 刷新")
 
     return results
 
@@ -622,7 +625,7 @@ def _solve_captcha_phycai(img_bytes: bytes) -> str:
         if r.ok:
             code = r.json().get("result", "").strip()
             if code:
-                print(f"  [CAPTCHA] 极客协会识别：{code}")
+                _logger.info(f"  [CAPTCHA] 极客协会识别：{code}")
                 return code
     except Exception:
         pass
@@ -646,7 +649,7 @@ def _solve_captcha_phycai(img_bytes: bytes) -> str:
             )
             code = msg.content[0].text.strip()
             if code:
-                print(f"  [CAPTCHA] Claude 识别：{code}")
+                _logger.info(f"  [CAPTCHA] Claude 识别：{code}")
                 return code
     except Exception:
         pass
@@ -685,7 +688,7 @@ def _phycai_fetch_with_login(cfg: dict) -> str | None:
     if not username or not password:
         return None
 
-    print("[phycai] 正在通过 jAccount 登录…")
+    _logger.info("[phycai] 正在通过 jAccount 登录…")
     target_url = "http://www.phycai.sjtu.edu.cn/pe/student/select.aspx"
     try:
         with sync_playwright() as pw:
@@ -732,7 +735,7 @@ def _phycai_fetch_with_login(cfg: dict) -> str | None:
                     page.wait_for_timeout(700)
 
                 if not logged_in:
-                    print("[phycai] jAccount 登录失败")
+                    _logger.error("[phycai] jAccount 登录失败")
                     browser.close()
                     return None
 
@@ -757,12 +760,12 @@ def _phycai_fetch_with_login(cfg: dict) -> str | None:
                 CONFIG_PATH.write_text(
                     json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8"
                 )
-                print("[phycai] ✓ 已登录并更新 cookies")
+                _logger.info("[phycai] ✓ 已登录并更新 cookies")
 
             browser.close()
             return html
     except Exception as e:
-        print(f"[phycai] jAccount 登录出错：{e}")
+        _logger.error(f"[phycai] jAccount 登录出错：{e}")
         return None
 
 
@@ -789,7 +792,7 @@ def fetch_phycai(cfg: dict) -> dict | None:
     # 回退：用 .env 账号密码通过 jAccount 登录
     html = _phycai_fetch_with_login(cfg)
     if html is None:
-        print("[phycai] ⚠ 登录失败，跳过")
+        _logger.warning("[phycai] ⚠ 登录失败，跳过")
         return None
 
     return _parse_phycai_table(html)
@@ -801,7 +804,7 @@ def _parse_phycai_table(html: str) -> dict | None:
     # 找到包含实验数据的主表（通常是内容最多的那个）
     tables = soup.find_all("table")
     if not tables:
-        print("[phycai] ⚠ 未找到任何表格，可能 cookie 已过期")
+        _logger.warning("[phycai] ⚠ 未找到任何表格，可能 cookie 已过期")
         return None
     table = max(tables, key=lambda t: len(t.find_all("tr")))
 
@@ -889,7 +892,7 @@ def _icourse_login_with_creds(cfg: dict) -> dict | None:
     if not username or not password:
         return None
 
-    print("[icourse163] 正在用账号密码登录…")
+    _logger.info("[icourse163] 正在用账号密码登录…")
     try:
         with sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True)
@@ -925,7 +928,7 @@ def _icourse_login_with_creds(cfg: dict) -> dict | None:
                         break
 
             if login_frame is None:
-                print("[icourse163] 未找到登录 iframe")
+                _logger.warning("[icourse163] 未找到登录 iframe")
                 browser.close()
                 return None
 
@@ -935,7 +938,7 @@ def _icourse_login_with_creds(cfg: dict) -> dict | None:
             ).all()
             txt_field = next((i for i in txt_inputs if i.is_visible()), None)
             if txt_field is None:
-                print("[icourse163] 未找到手机号输入框")
+                _logger.warning("[icourse163] 未找到手机号输入框")
                 browser.close()
                 return None
             txt_field.fill(username)
@@ -943,7 +946,7 @@ def _icourse_login_with_creds(cfg: dict) -> dict | None:
             pwd_inputs = login_frame.locator("input[type='password']").all()
             pwd_field = next((i for i in pwd_inputs if i.is_visible()), None)
             if pwd_field is None:
-                print("[icourse163] 未找到密码输入框")
+                _logger.warning("[icourse163] 未找到密码输入框")
                 browser.close()
                 return None
             pwd_field.fill(password)
@@ -970,18 +973,18 @@ def _icourse_login_with_creds(cfg: dict) -> dict | None:
             browser.close()
 
             if not new_cookies.get("NTESSTUDYSI"):
-                print("[icourse163] 登录失败，请确认 MOOC_USERNAME / MOOC_PASSWORD 正确")
+                _logger.error("[icourse163] 登录失败，请确认 MOOC_USERNAME / MOOC_PASSWORD 正确")
                 return None
 
             cfg["icourse_cookies"] = new_cookies
             CONFIG_PATH.write_text(
                 json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8"
             )
-            print("[icourse163] ✓ 登录成功，已更新 cookies")
+            _logger.info("[icourse163] ✓ 登录成功，已更新 cookies")
             return new_cookies
 
     except Exception as e:
-        print(f"[icourse163] 登录出错：{e}")
+        _logger.error(f"[icourse163] 登录出错：{e}")
         return None
 
 
@@ -1023,7 +1026,7 @@ def _icourse_get_my_courses(session: requests.Session) -> list[dict] | None:
                     timeout=15,
                 )
             except requests.RequestException as e:
-                print(f"[icourse163] 拉取课程列表网络错误：{e}")
+                _logger.warning(f"[icourse163] 拉取课程列表网络错误：{e}")
                 return None
             if r.status_code != 200:
                 return None
@@ -1103,26 +1106,26 @@ def fetch_icourse(cfg: dict) -> list[dict]:
             session = None  # cookies 已失效
 
     if session is None:
-        print("[icourse163] cookies 失效或未配置，正在登录…")
+        _logger.info("[icourse163] cookies 失效或未配置，正在登录…")
         new_cookies = _icourse_login_with_creds(cfg)
         if not new_cookies:
-            print("[icourse163] ⚠ 登录失败，跳过")
+            _logger.warning("[icourse163] ⚠ 登录失败，跳过")
             return []
         cookies = new_cookies
         session = make_session(cookies)
         if not _icourse_warm_up(session):
-            print("[icourse163] ⚠ 登录成功但 warm-up 仍失败，跳过")
+            _logger.warning("[icourse163] ⚠ 登录成功但 warm-up 仍失败，跳过")
             return []
 
     courses = _icourse_get_my_courses(session)
     if courses is None:
-        print("[icourse163] ⚠ 无法拉取课程列表，跳过")
+        _logger.warning("[icourse163] ⚠ 无法拉取课程列表，跳过")
         return []
     if not courses:
-        print("[icourse163] 用户未注册任何 MOOC/SPOC 课程")
+        _logger.info("[icourse163] 用户未注册任何 MOOC/SPOC 课程")
         return []
 
-    print(f"[icourse163] 已发现 {len(courses)} 门课程：{', '.join(c['name'] for c in courses)}")
+    _logger.info(f"[icourse163] 已发现 {len(courses)} 门课程：{', '.join(c['name'] for c in courses)}")
     results: list[dict] = []
     for course in courses:
         rpc_result = _icourse_rpc(
@@ -1131,7 +1134,7 @@ def fetch_icourse(cfg: dict) -> list[dict]:
             school=course["school_short_name"],
         )
         if rpc_result is None:
-            print(f"[icourse163] ⚠ {course['name']} 拉取章节失败 (term={course['term_id']})")
+            _logger.warning(f"[icourse163] ⚠ {course['name']} 拉取章节失败 (term={course['term_id']})")
             continue
         results.extend(_parse_icourse_rpc(rpc_result, course["name"]))
     return results
@@ -1406,7 +1409,7 @@ def download_canvas_assignments(
                 r = session.get(asgn_url, params=asgn_params, timeout=15)
                 r.raise_for_status()
             except Exception as e:
-                print(f"[Canvas] {cname} 获取作业列表失败：{e}")
+                _logger.warning(f"[Canvas] {cname} 获取作业列表失败：{e}")
                 break
             for a in r.json():
                 if a.get("workflow_state") == "deleted":
@@ -1546,7 +1549,7 @@ def download_aihaoke_assignments(
                 )
                 tasks = page.evaluate(_AIHAOKE_TASK_FULL_JS) or []
             except Exception as e:
-                print(f"  [aihaoke] {cname} 加载失败：{e}")
+                _logger.warning(f"  [aihaoke] {cname} 加载失败：{e}")
                 continue
 
             for t in tasks:
@@ -1696,7 +1699,7 @@ def _search_jwc(query: str, max_results: int = 8) -> list[dict]:
                 date  = (item.findtext("pubDate") or "").strip()
                 items.append({"title": title, "summary": desc[:300], "url": link, "date": date})
         except Exception as e:
-            print(f"[jwc] RSS 获取失败：{e}")
+            _logger.warning(f"[jwc] RSS 获取失败：{e}")
 
     if not items:
         return [{"error": "无法获取教务处 RSS，网络不通或地址变更"}]
@@ -1872,14 +1875,14 @@ def _dyweb_refresh_token(cfg: dict) -> str:
                         token = c["value"]
                         break
         except Exception as e:
-            print(f"[dyweb] OAuth 失败：{e}")
+            _logger.warning(f"[dyweb] OAuth 失败：{e}")
         finally:
             browser.close()
 
     if token:
         cfg["dyweb_token"] = token
         CONFIG_PATH.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
-        print("[dyweb] ✓ token 已更新")
+        _logger.info("[dyweb] ✓ token 已更新")
     return token
 
 
@@ -1914,7 +1917,7 @@ def _dyweb_request(cfg: dict, method: str, path: str, **kwargs) -> dict | None:
         return None
     data = r.json()
     if isinstance(data, dict) and not data.get("success", True):
-        print(f"[dyweb] API error: {data.get('message', '')}")
+        _logger.warning(f"[dyweb] API error: {data.get('message', '')}")
         return None
     return data.get("data")
 
@@ -2019,13 +2022,13 @@ def search_campus(
         sites = ["jwc", "shuiyuan", "dyweb"]
     out: dict = {}
     if "jwc" in sites:
-        print(f"[搜索] 教务处通知：{query}…")
+        _logger.info(f"[搜索] 教务处通知：{query}…")
         out["jwc"] = _search_jwc(query, max_results)
     if "shuiyuan" in sites:
-        print(f"[搜索] 水源社区：{query}…")
+        _logger.info(f"[搜索] 水源社区：{query}…")
         out["shuiyuan"] = _search_shuiyuan(cfg, query, max_results)
     if "dyweb" in sites:
-        print(f"[搜索] 传承·交大：{query}…")
+        _logger.info(f"[搜索] 传承·交大：{query}…")
         out["dyweb"] = _search_dyweb(cfg, query, max_results)
     return out
 
@@ -2103,7 +2106,7 @@ def _get_jwxt_cookies(cfg: dict) -> dict | None:
                 return saved
         except Exception:
             pass
-        print("[jwxt] session 已过期，重新登录…")
+        _logger.info("[jwxt] session 已过期，重新登录…")
 
     if not HAS_PLAYWRIGHT:
         return None
@@ -2125,7 +2128,7 @@ def _get_jwxt_cookies(cfg: dict) -> dict | None:
                       wait_until="networkidle", timeout=20_000)
             time.sleep(2)
         except Exception as e:
-            print(f"[jwxt] 登录失败: {e}")
+            _logger.error(f"[jwxt] 登录失败: {e}")
             browser.close()
             return None
         cookies = {c["name"]: c["value"] for c in ctx.cookies()
@@ -2135,7 +2138,7 @@ def _get_jwxt_cookies(cfg: dict) -> dict | None:
     if cookies:
         cfg["jwxt_cookies"] = cookies
         CONFIG_PATH.write_text(json.dumps(cfg, ensure_ascii=False, indent=2), encoding="utf-8")
-        print("[jwxt] ✓ cookies 已更新")
+        _logger.info("[jwxt] ✓ cookies 已更新")
         return cookies
     return None
 
@@ -2233,9 +2236,9 @@ def fetch_schedule(cfg: dict, year: str = "", term: str = "", refresh: bool = Fa
     try:
         _SCHEDULE_CACHE_PATH.write_text(json.dumps(result, ensure_ascii=False, indent=2),
                                         encoding="utf-8")
-        print(f"[jwxt] ✓ 课表已缓存（{len(courses)} 门）")
+        _logger.info(f"[jwxt] ✓ 课表已缓存（{len(courses)} 门）")
     except Exception as e:
-        print(f"[jwxt] 缓存写入失败: {e}")
+        _logger.warning(f"[jwxt] 缓存写入失败: {e}")
 
     return result
 

--- a/scripts/aihot_push.py
+++ b/scripts/aihot_push.py
@@ -17,6 +17,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
+from sjtu_agent.logging import get_logger
+
+_logger = get_logger("aihot_push")
+
 CST = timezone(timedelta(hours=8))
 _API_BASE = "https://aihot.virxact.com/api/public"
 _UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 sjtu-agent/0.2"
@@ -43,10 +47,10 @@ def _fetch_items(mode: str = "selected", hours: int = 24) -> list[dict]:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read().decode())
     except urllib.error.HTTPError as e:
-        print(f"[aihot] API HTTP {e.code}: {e.reason}")
+        _logger.warning(f"[aihot] API HTTP {e.code}: {e.reason}")
         return []
     except Exception as e:
-        print(f"[aihot] API 请求失败: {e}")
+        _logger.warning(f"[aihot] API 请求失败: {e}")
         return []
 
     return data.get("items", []) if isinstance(data, dict) else []
@@ -145,16 +149,16 @@ def _html_to_post(text: str) -> list:
 def main() -> None:
     test_mode = "--test" in sys.argv
 
-    print("[aihot] 正在获取 AI 资讯…")
+    _logger.info("[aihot] 正在获取 AI 资讯…")
     items = _fetch_items()
     if not items:
-        print("[aihot] 未获取到 AI 资讯")
+        _logger.warning("[aihot] 未获取到 AI 资讯")
         return
 
     md = _build_markdown(items)
     if test_mode:
         _safe_print(md)
-        print(f"\n[aihot] 测试模式，未推送。共 {len(items)} 条。")
+        _logger.info(f"[aihot] 测试模式，未推送。共 {len(items)} 条。")
         return
 
     post_paras = _html_to_post(md)
@@ -166,13 +170,13 @@ def main() -> None:
     open_id = _cfg.get("feishu_open_id", "")
 
     if not open_id:
-        print("[aihot] 未配置 feishu_open_id，跳过推送。请先在飞书 Bot 中发一条消息以记录 open_id。")
+        _logger.warning("[aihot] 未配置 feishu_open_id，跳过推送。请先在飞书 Bot 中发一条消息以记录 open_id。")
         return
 
     if send_post_message(open_id, post_paras):
-        print(f"[aihot] 推送完成，共 {len(items)} 条")
+        _logger.info(f"[aihot] 推送完成，共 {len(items)} 条")
     else:
-        print("[aihot] 推送失败")
+        _logger.warning("[aihot] 推送失败")
 
 
 if __name__ == "__main__":

--- a/scripts/care_check.py
+++ b/scripts/care_check.py
@@ -28,6 +28,10 @@ from sjtu_agent.paths import (
 from dotenv import load_dotenv
 load_dotenv(ENV_PATH)
 
+from sjtu_agent.logging import get_logger
+
+_logger = get_logger("care_check")
+
 import ddl_checker as dc
 
 # CST 时区，避免 datetime.now() 受系统时区/DST 影响导致冷却期错乱
@@ -60,7 +64,7 @@ def _save_care_state(state: dict) -> None:
         atomic_write_json(CARE_STATE_PATH, state)
     except Exception as e:
         # 写入失败保留旧状态，下次冷却期判断仍用旧时间戳；好过把状态丢空
-        print(f"[care_check] 状态写入失败（保留旧状态）: {e}", flush=True)
+        _logger.warning(f"[care_check] 状态写入失败（保留旧状态）: {e}")
 
 
 def _can_send(state: dict, care_type: str) -> bool:
@@ -104,11 +108,11 @@ def _get_urgent_ddls() -> list[dict]:
         try:
             all_ddl.extend(dc2.fetch_canvas(cfg))
         except Exception as e:
-            print(f"[care] fetch_canvas 拉取失败: {e}")
+            _logger.warning(f"[care] fetch_canvas 拉取失败: {e}")
         try:
             all_ddl.extend(dc2.fetch_aihaoke(cfg))
         except Exception as e:
-            print(f"[care] fetch_aihaoke 拉取失败: {e}")
+            _logger.warning(f"[care] fetch_aihaoke 拉取失败: {e}")
         urgent = []
         for item in all_ddl:
             due = item.get("due")
@@ -122,7 +126,7 @@ def _get_urgent_ddls() -> list[dict]:
                 })
         return sorted(urgent, key=lambda x: x["hours_left"])
     except Exception as e:
-        print(f"[care_check] 获取 DDL 出错: {e}", flush=True)
+        _logger.warning(f"[care_check] 获取 DDL 出错: {e}")
         return []
 
 
@@ -212,12 +216,12 @@ def run_care_check() -> None:
         for msg in messages_to_send:
             sent = _send_care(msg)
             if sent:
-                print(f"[care_check] 已发送关怀消息: {msg[:30]}…", flush=True)
+                _logger.info(f"[care_check] 已发送关怀消息: {msg[:30]}…")
         for ct in care_types_sent:
             _mark_sent(state, ct)
         _save_care_state(state)
     else:
-        print(f"[care_check] {now.strftime('%H:%M')} 暂无需要发送的关怀消息", flush=True)
+        _logger.info(f"[care_check] {now.strftime('%H:%M')} 暂无需要发送的关怀消息")
 
 
 if __name__ == "__main__":

--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -38,12 +38,12 @@ def _send_telegram(text: str) -> None:
     _cfg.reload_if_changed()
     cfg = _cfg.raw()
     if not cfg.get("telegram_enabled", True):
-        print("[daily_report] Telegram 推送已关闭，跳过")
+        _logger.info("[daily_report] Telegram 推送已关闭，跳过")
         return
     token = cfg.get("telegram_token", "")
     allowed_ids = cfg.get("telegram_allowed_ids", [])
     if not token or not allowed_ids:
-        print("[daily_report] Telegram 未配置，跳过推送")
+        _logger.warning("[daily_report] Telegram 未配置，跳过推送")
         return
 
     import urllib.request
@@ -64,7 +64,7 @@ def _send_telegram(text: str) -> None:
             try:
                 urllib.request.urlopen(req, timeout=15)
             except Exception as e:
-                print(f"[daily_report] Telegram 推送失败 uid={uid}: {e}")
+                _logger.warning(f"[daily_report] Telegram 推送失败 uid={uid}: {e}")
 
 
 def _html_to_post(text: str) -> list:
@@ -113,11 +113,11 @@ def _send_feishu(text: str) -> None:
     _cfg.reload_if_changed()
     cfg = _cfg.raw()
     if not cfg.get("feishu_enabled", True):
-        print("[daily_report] 飞书推送已关闭，跳过")
+        _logger.info("[daily_report] 飞书推送已关闭，跳过")
         return
     open_id = cfg.get("feishu_open_id", "")
     if not open_id:
-        print("[daily_report] 飞书未配置（feishu_open_id 缺失），跳过推送")
+        _logger.warning("[daily_report] 飞书未配置（feishu_open_id 缺失），跳过推送")
         return
 
     # 把 HTML 转为飞书 post 段落格式
@@ -125,9 +125,9 @@ def _send_feishu(text: str) -> None:
 
     from sjtu_agent.feishu_client import send_post_message
     if send_post_message(open_id, post_paras):
-        print("[daily_report] 飞书推送完成")
+        _logger.info("[daily_report] 飞书推送完成")
     else:
-        print("[daily_report] 飞书推送失败")
+        _logger.warning("[daily_report] 飞书推送失败")
 
 
 # ── 数据收集 ──────────────────────────────────────────────────────────────────
@@ -140,7 +140,7 @@ def _get_news() -> str:
         md_digest, _ = agg.run(hours=24, top_k=4)
         return md_digest or ""
     except Exception as e:
-        print(f"[daily_report] 新闻获取失败: {e}")
+        _logger.warning(f"[daily_report] 新闻获取失败: {e}")
         return ""
 
 
@@ -165,7 +165,7 @@ def _collect_data(report_type: str = "evening") -> dict:
             try:
                 results[key] = fut.result()
             except Exception as e:
-                print(f"[daily_report] {key} 获取失败: {e}")
+                _logger.warning(f"[daily_report] {key} 获取失败: {e}")
                 results[key] = None
 
     return results
@@ -224,7 +224,7 @@ def build_report(report_type: str = "evening") -> str:
     else:
         label = "晚间学习日报"
 
-    print("[daily_report] 正在收集数据…")
+    _logger.info("[daily_report] 正在收集数据…")
     data = _collect_data(report_type)
 
     # --- 拆解 DDL ---
@@ -408,7 +408,7 @@ def build_report(report_type: str = "evening") -> str:
 {data_ctx}
 {_build_care_note()}"""
 
-    print("[daily_report] 正在生成汇报…")
+    _logger.info("[daily_report] 正在生成汇报…")
     try:
         agent_cfg = agent.load_agent_config()
         client = agent._make_client(agent_cfg)
@@ -440,7 +440,7 @@ def build_report(report_type: str = "evening") -> str:
         return text or "(报告生成失败，请重试)"
 
     except Exception as e:
-        print(f"[daily_report] AI 生成失败，降级为纯文本模式: {e}")
+        _logger.warning(f"[daily_report] AI 生成失败，降级为纯文本模式: {e}")
         fallback_schedule_label = "明日课程" if report_type == "evening" else "今日课程"
         return _fallback_report(date_str, today_ddls, week_ddls, far_ddls,
                                 _fmt_schedule(schedule_raw), _fmt_lab(lab_raw), _fmt_jwc(jwc_raw),

--- a/scripts/email_watcher.py
+++ b/scripts/email_watcher.py
@@ -34,6 +34,9 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
 from sjtu_agent.paths import CONFIG_PATH, DATA_DIR, ENV_PATH, atomic_write_json, read_json_safe
+from sjtu_agent.logging import get_logger
+
+_logger = get_logger("email_watcher")
 
 _STATE_PATH = DATA_DIR / "email_watcher_state.json"
 _CHECK_INTERVAL = 60
@@ -145,7 +148,7 @@ def _check_new_emails(last_uid: int, sent_uids: set) -> list[dict]:
     """IMAP readonly 连接，拉取 UID > last_uid 且不在 sent_uids 中的新邮件。"""
     username, password = _get_creds()
     if not username or not password:
-        print("[email_watcher] 凭据未配置，跳过")
+        _logger.warning("[email_watcher] 凭据未配置，跳过")
         return []
 
     ctx = ssl.create_default_context()
@@ -154,7 +157,7 @@ def _check_new_emails(last_uid: int, sent_uids: set) -> list[dict]:
         m.login(username, password)
         m.select("INBOX", readonly=True)
     except Exception as e:
-        print(f"[email_watcher] IMAP 连接失败: {e}")
+        _logger.warning(f"[email_watcher] IMAP 连接失败: {e}")
         return []
 
     try:
@@ -194,7 +197,7 @@ def _check_new_emails(last_uid: int, sent_uids: set) -> list[dict]:
         return new_emails
 
     except Exception as e:
-        print(f"[email_watcher] 检查邮件异常: {e}")
+        _logger.warning(f"[email_watcher] 检查邮件异常: {e}")
         return []
     finally:
         try:
@@ -238,22 +241,24 @@ def run_once(last_push_time: float = 0.0) -> float:
             new_last = max(state["last_uid"], uid)
             _save_state(new_last, state["sent_uids"])
             state["last_uid"] = new_last
-        print(f"[{datetime.now(CST):%H:%M}] 新邮件 uid={uid} {em['subject'][:30]} "
-              f"推送{'OK' if ok else 'FAIL'}")
+        if ok:
+            _logger.info(f"[{datetime.now(CST):%H:%M}] 新邮件 uid={uid} {em['subject'][:30]} 推送OK")
+        else:
+            _logger.warning(f"[{datetime.now(CST):%H:%M}] 新邮件 uid={uid} {em['subject'][:30]} 推送FAIL")
 
     return last_push_time
 
 
 def run_loop() -> None:
     """持续轮询模式。"""
-    print(f"[email_watcher] 启动，间隔 {_CHECK_INTERVAL}s")
+    _logger.info(f"[email_watcher] 启动，间隔 {_CHECK_INTERVAL}s")
     _check_interval = _CHECK_INTERVAL
     last_push_time = 0.0
     while True:
         try:
             last_push_time = run_once(last_push_time)
         except Exception as e:
-            print(f"[email_watcher] 错误: {e}")
+            _logger.warning(f"[email_watcher] 错误: {e}")
         time.sleep(_check_interval)
 
 

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -56,6 +56,9 @@ from sjtu_agent.feishu.rendering import (
     build_card_content,
 )
 from sjtu_agent.feishu.conversations import FeishuConversationManager
+from sjtu_agent.logging import get_logger
+
+_logger = get_logger("feishu_bot")
 
 
 def _load_cfg() -> dict:
@@ -396,7 +399,7 @@ def _call_reply(req) -> object | None:
     try:
         return _api_client.im.v1.message.reply(req)
     except Exception as e:
-        print(f"[feishu] reply API 异常: {e}")
+        _logger.warning(f"[feishu] reply API 异常: {e}")
         return None
 
 
@@ -439,7 +442,7 @@ def _reply_text(message_id: str, text: str) -> None:
         if resp is None:
             break
         if not resp.success():
-            print(f"[feishu] post 回复失败 code={resp.code} msg={resp.msg}，降级为 text")
+            _logger.warning(f"[feishu] post 回复失败 code={resp.code} msg={resp.msg}，降级为 text")
             # 只发送剩余未成功段落为纯文本
             remaining = [c for chunk in para_chunks[idx:] for p in chunk for el in p
                          for c in (el.get("text", "") + chr(10))]
@@ -468,11 +471,11 @@ def _reply_card(message_id: str, text: str) -> None:
     if resp is None:
         return
     if not resp.success():
-        print(f"[feishu] card 回复失败 code={resp.code} msg={resp.msg}")
+        _logger.warning(f"[feishu] card 回复失败 code={resp.code} msg={resp.msg}")
         # 降级为 text（此时表格渲染为纯文本）
         _reply_raw_text(message_id, text)
     else:
-        print(f"[feishu] card 回复成功")
+        _logger.info(f"[feishu] card 回复成功")
 
 
 def _reply_raw_text(message_id: str, text: str) -> None:
@@ -494,7 +497,7 @@ def _reply_raw_text(message_id: str, text: str) -> None:
         if resp is None:
             break
         if not resp.success():
-            print(f"[feishu] 回复失败 code={resp.code} msg={resp.msg}")
+            _logger.warning(f"[feishu] 回复失败 code={resp.code} msg={resp.msg}")
             break
 
 
@@ -523,7 +526,7 @@ def _send_to_chat(chat_id: str, text: str) -> None:
         )
         resp = _api_client.im.v1.message.create(req)
         if not resp.success():
-            print(f"[feishu] 主动发送 card 失败 code={resp.code} msg={resp.msg}")
+            _logger.warning(f"[feishu] 主动发送 card 失败 code={resp.code} msg={resp.msg}")
         return
 
     # 普通内容 → post
@@ -544,7 +547,7 @@ def _send_to_chat(chat_id: str, text: str) -> None:
         )
         resp = _api_client.im.v1.message.create(req)
         if not resp.success():
-            print(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
+            _logger.warning(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
     else:
         # fallback text
         req = (
@@ -561,7 +564,7 @@ def _send_to_chat(chat_id: str, text: str) -> None:
         )
         resp = _api_client.im.v1.message.create(req)
         if not resp.success():
-            print(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
+            _logger.warning(f"[feishu] 主动发送失败 code={resp.code} msg={resp.msg}")
 
 
 # ── 事件处理 ──────────────────────────────────────────────────────────────────
@@ -769,7 +772,7 @@ def _handle_commands(open_id: str, text: str) -> str | None:
         except Exception as e:
             import traceback
             tb = traceback.format_exc()
-            print(tb)
+            _logger.error(tb)
             return f"[eat] 查询失败：{e}\n```\n{tb[-500:]}\n```"
     if cmd == "/template":
         sub = parts[1].strip() if len(parts) > 1 else ""
@@ -839,7 +842,7 @@ def _process_hw_command(sender_open_id: str, message_id: str, text: str) -> None
     except Exception as e:
         import traceback
         traceback.print_exc()
-        print(f"[feishu] /hw 命令异常: {e}")
+        _logger.error(f"[feishu] /hw 命令异常: {e}")
         _reply_text(message_id, f"[homework] 出错：{e}")
     finally:
         _hw_in_progress.discard(sender_open_id)
@@ -853,7 +856,7 @@ def _process_news_command(sender_open_id: str, message_id: str) -> None:
     except Exception as e:
         import traceback
         traceback.print_exc()
-        print(f"[feishu] /news 命令异常: {e}")
+        _logger.error(f"[feishu] /news 命令异常: {e}")
         _reply_text(message_id, f"[news] 出错：{e}")
 
 
@@ -938,9 +941,9 @@ def _try_extract_memory(open_id: str, conv: dict) -> None:
                 "msg_count": len(conv.get("messages", [])),
                 "type": "session_summary",
             })
-            print(f"[feishu] 记忆已提取: {summary[:60]}...")
+            _logger.info(f"[feishu] 记忆已提取: {summary[:60]}...")
     except Exception as e:
-        print(f"[feishu] 记忆提取失败: {e}")
+        _logger.warning(f"[feishu] 记忆提取失败: {e}")
 
 
 def _run_fn_with_timeout(fn, timeout: float, *args):
@@ -975,7 +978,7 @@ def _process_in_thread(sender_open_id: str, message_id: str, text: str) -> None:
     try:
         conv, meta, lock = _conv_mgr.get_active(sender_open_id)
     except Exception as e:
-        print(f"[feishu] get_active 异常: {e}")
+        _logger.warning(f"[feishu] get_active 异常: {e}")
         return
     if not lock.acquire(blocking=False):
         _reply_text(message_id, "上一条消息还在处理中，请稍候…")
@@ -983,11 +986,11 @@ def _process_in_thread(sender_open_id: str, message_id: str, text: str) -> None:
     try:
         reply = _run_fn_with_timeout(_capture_turn, _CAPTURE_TIMEOUT, conv, text, sender_open_id)
     except TimeoutError:
-        print(f"[feishu] LLM 调用超时（{_CAPTURE_TIMEOUT}s），释放锁")
+        _logger.warning(f"[feishu] LLM 调用超时（{_CAPTURE_TIMEOUT}s），释放锁")
         _reply_text(message_id, "处理超时，请稍后重试")
         return
     except Exception as e:
-        print(f"[feishu] 处理出错：{e}")
+        _logger.warning(f"[feishu] 处理出错：{e}")
         _reply_text(message_id, f"出错了：{e}")
         return
     finally:
@@ -1005,7 +1008,7 @@ def _process_media_in_thread(sender_open_id: str, message_id: str, msg_type: str
     try:
         conv, meta, lock = _conv_mgr.get_active(sender_open_id)
     except Exception as e:
-        print(f"[feishu] get_active 异常: {e}")
+        _logger.warning(f"[feishu] get_active 异常: {e}")
         return
     if not lock.acquire(blocking=False):
         _reply_text(message_id, "上一条消息还在处理中，请稍候…")
@@ -1072,10 +1075,10 @@ def _process_media_in_thread(sender_open_id: str, message_id: str, msg_type: str
     try:
         _run_fn_with_timeout(_do_media_process, _CAPTURE_TIMEOUT)
     except TimeoutError:
-        print(f"[feishu] 媒体处理超时（{_CAPTURE_TIMEOUT}s），释放锁")
+        _logger.warning(f"[feishu] 媒体处理超时（{_CAPTURE_TIMEOUT}s），释放锁")
         _reply_text(message_id, "处理超时，请稍后重试")
     except Exception as e:
-        print(f"[feishu] 媒体处理出错：{e}")
+        _logger.warning(f"[feishu] 媒体处理出错：{e}")
         _reply_text(message_id, f"附件处理失败：{e}")
     finally:
         _conv_mgr.save()
@@ -1100,15 +1103,15 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
 
         # ── 去重：飞书可能因 ack 超时重发同一事件 ──────────────────────
         if _is_duplicate(message_id):
-            print(f"[feishu] 跳过重复消息 message_id={message_id}")
+            _logger.info(f"[feishu] 跳过重复消息 message_id={message_id}")
             return
 
         # ── 忽略积压的旧消息（Bot 断连期间飞书积累的事件，重启后被重放）──
         _MAX_MSG_AGE_SEC = 300  # 5 min — covers bot restart warmup (health check ~30s)
         create_time_ms = int(getattr(msg, "create_time", 0) or 0)
         if create_time_ms and time.time() - create_time_ms / 1000 > _MAX_MSG_AGE_SEC:
-            print(f"[feishu] 跳过过期消息 message_id={message_id} "
-                  f"age={time.time() - create_time_ms / 1000:.0f}s")
+            _logger.info(f"[feishu] 跳过过期消息 message_id={message_id} "
+                         f"age={time.time() - create_time_ms / 1000:.0f}s")
             return
 
         media_supported = msg_type in {"image", "file", "audio", "media"}
@@ -1119,7 +1122,7 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
                 return
             # 内容去重：防止飞书用不同 message_id 重发同一事件
             if _is_duplicate_content(sender_open_id, text):
-                print(f"[feishu] 跳过重复内容: {text[:40]!r}")
+                _logger.info(f"[feishu] 跳过重复内容: {text[:40]!r}")
                 return
         elif not media_supported:
             _reply_text(message_id, f"(暂不支持的消息类型: {msg_type}，目前支持文本、图片、文件、音频、视频)")
@@ -1134,18 +1137,18 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
                 if now - last < _COOLDOWN_SEC:
                     return  # 冷却期内，跳过重复
                 _recent_updates_cooldown[sender_open_id] = now
-            print(f"[feishu] 拦截近期更新: {text[:40]!r}")
+            _logger.info(f"[feishu] 拦截近期更新: {text[:40]!r}")
             _reply_text(message_id, _RECENT_UPDATES_TEXT)
             return
 
         # 过滤"清空聊天记录"/撤回消息产生的系统通知
         if text in {"此消息已删除", "该消息已被撤回"}:
-            print(f"[feishu] 跳过已删除/撤回的系统消息 message_id={message_id}")
+            _logger.info(f"[feishu] 跳过已删除/撤回的系统消息 message_id={message_id}")
             return
 
         # 白名单检查（所有命令和对话均需校验）
         if ALLOWED_OPEN_IDS and sender_open_id not in ALLOWED_OPEN_IDS:
-            print(f"[feishu] [!] 未授权 open_id：{sender_open_id}")
+            _logger.info(f"[feishu] [!] 未授权 open_id：{sender_open_id}")
             _reply_text(message_id, "你不在该机器人的允许列表中。\n"
                         f"请把这个 open_id 加入 config.json 的 feishu_allowed_open_ids:\n"
                         f"{sender_open_id}")
@@ -1154,7 +1157,7 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
         # ── 多对话命令拦截 ──────────────────────────────────────────
         # /hw 系列是重命令（网络 I/O + LLM），放到后台线程避免阻塞 event loop
         if t.lower().startswith("/hw"):
-            print(f"[feishu] 命令（后台执行）: {text[:40]!r}")
+            _logger.info(f"[feishu] 命令（后台执行）: {text[:40]!r}")
             # 在主线程中提前保存 /hw do 上下文，避免后台线程延迟导致丢失
             parts = text.strip().split(maxsplit=2)
             if len(parts) >= 3 and parts[1].lower() in ("do", "past"):
@@ -1184,19 +1187,19 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
 
         # /news 也是重命令（网络 I/O + LLM 排序），后台执行
         if t.lower().startswith("/news"):
-            print(f"[feishu] 命令（后台执行）: {text[:40]!r}")
+            _logger.info(f"[feishu] 命令（后台执行）: {text[:40]!r}")
             _reply_text(message_id, "[news] 正在生成校园新闻摘要，请稍候…")
             _EXECUTOR.submit(_process_news_command, sender_open_id, message_id)
             return
 
         cmd_result = _handle_commands(sender_open_id, text)
         if cmd_result is not None:
-            print(f"[feishu] 命令: {text[:40]!r}")
+            _logger.info(f"[feishu] 命令: {text[:40]!r}")
             _reply_text(message_id, cmd_result)
             return
 
-        print(f"[feishu] 收到消息 from open_id={sender_open_id[:12]}… "
-              f"chat_type={chat_type} text={text[:60]!r}")
+        _logger.info(f"[feishu] 收到消息 from open_id={sender_open_id[:12]}… "
+                     f"chat_type={chat_type} text={text[:60]!r}")
 
         if WHOAMI_MODE:
             _reply_text(
@@ -1207,29 +1210,29 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
             return
 
         if ALLOWED_OPEN_IDS and sender_open_id not in ALLOWED_OPEN_IDS:
-            print(f"[feishu] [!] 未授权 open_id：{sender_open_id}")
+            _logger.info(f"[feishu] [!] 未授权 open_id：{sender_open_id}")
             _reply_text(message_id, "你不在该机器人的允许列表中。\n"
                         f"请把这个 open_id 加入 config.json 的 feishu_allowed_open_ids:\n"
                         f"{sender_open_id}")
             return
 
         if not ALLOWED_OPEN_IDS:
-            print(f"[feishu] [i] 白名单为空，已允许所有人；建议把此 open_id 加入白名单："
-                  f"{sender_open_id}")
+            _logger.info(f"[feishu] [i] 白名单为空，已允许所有人；建议把此 open_id 加入白名单："
+                         f"{sender_open_id}")
 
         # ── 保存 open_id 供 daily_report 推送使用 ──────────────────────
         if sender_open_id:
             try:
                 cfg_data = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
             except Exception as e:
-                print(f"[feishu] 跳过 open_id 持久化：config.json 读取失败: {e}")
+                _logger.info(f"[feishu] 跳过 open_id 持久化：config.json 读取失败: {e}")
                 cfg_data = None
             if cfg_data is not None and cfg_data.get("feishu_open_id") != sender_open_id:
                 try:
                     cfg_data["feishu_open_id"] = sender_open_id
                     CONFIG_PATH.write_text(json.dumps(cfg_data, ensure_ascii=False, indent=2), encoding="utf-8")
                 except Exception as e:
-                    print(f"[feishu] open_id 写入失败: {e}")
+                    _logger.info(f"[feishu] open_id 写入失败: {e}")
 
         # ── 提交到后台线程，立即返回 ──
         if msg_type == "text":
@@ -1238,7 +1241,7 @@ def _handle_message(data: P2ImMessageReceiveV1) -> None:
             _EXECUTOR.submit(_process_media_in_thread, sender_open_id, message_id, msg_type, msg.content)
 
     except Exception as e:
-        print(f"[feishu] handler 异常：{e}")
+        _logger.warning(f"[feishu] handler 异常：{e}")
 
 
 # ── 心跳与健壮性 ────────────────────────────────────────────────────────────

--- a/scripts/news_digest.py
+++ b/scripts/news_digest.py
@@ -20,7 +20,11 @@ sys.path.insert(0, str(ROOT))
 
 from dotenv import load_dotenv
 from sjtu_agent.paths import ENV_PATH
+from sjtu_agent.logging import get_logger
+
 load_dotenv(ENV_PATH)
+
+_logger = get_logger("news_digest")
 
 
 def main():
@@ -48,9 +52,9 @@ def main():
             if cfg.get("api_key") and cfg.get("model"):
                 llm_client = _make_client(cfg)
                 model = cfg["model"]
-                print(f"[news] LLM 已就绪：{model}", flush=True)
+                _logger.info(f"[news] LLM 已就绪：{model}")
         except Exception as e:
-            print(f"[news] LLM 初始化失败，降级到关键词排序：{e}", flush=True)
+            _logger.warning(f"[news] LLM 初始化失败，降级到关键词排序：{e}")
 
     from sjtu_agent.news_aggregator import NewsAggregator
     aggregator = NewsAggregator(llm_client=llm_client, model=model)
@@ -63,23 +67,23 @@ def main():
     if not args.dry_run:
         ok = aggregator.send_via_telegram(html_digest)
         if ok:
-            print("[news] ✅ Telegram 推送成功", flush=True)
+            _logger.info("[news] ✅ Telegram 推送成功")
         else:
-            print("[news] ⚠ Telegram 推送失败或未配置", flush=True)
+            _logger.warning("[news] ⚠ Telegram 推送失败或未配置")
 
         ok_wx = aggregator.send_via_wechat(md_digest)
         if ok_wx:
-            print("[news] ✅ 微信推送成功", flush=True)
+            _logger.info("[news] ✅ 微信推送成功")
         else:
-            print("[news] ⚠ 微信推送失败或未配置", flush=True)
+            _logger.warning("[news] ⚠ 微信推送失败或未配置")
 
         ok_fs = aggregator.send_via_feishu(feishu_paras)
         if ok_fs:
-            print("[news] ✅ 飞书推送成功", flush=True)
+            _logger.info("[news] ✅ 飞书推送成功")
         else:
-            print("[news] ⚠ 飞书推送失败或未配置", flush=True)
+            _logger.warning("[news] ⚠ 飞书推送失败或未配置")
     else:
-        print("[news] --dry-run 模式，跳过推送", flush=True)
+        _logger.info("[news] --dry-run 模式，跳过推送")
 
 
 def _test_source(source_name: str):

--- a/scripts/qq_bot.py
+++ b/scripts/qq_bot.py
@@ -49,9 +49,14 @@ from sjtu_agent.bots._core import (
     run_one_turn_multimodal,
 )
 
+from sjtu_agent.logging import get_logger
+
 import agent
 import botpy
 from botpy.message import Message, DirectMessage
+
+
+_logger = get_logger("qq_bot")
 
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mKABCDEFGHJKST]")
@@ -71,7 +76,7 @@ APP_ID = str(cfg.get("qq_app_id", "")).strip()
 APP_SECRET = str(cfg.get("qq_app_secret", "")).strip()
 
 if not APP_ID or not APP_SECRET:
-    print("❌ config.json missing qq_app_id / qq_app_secret")
+    _logger.error("❌ config.json missing qq_app_id / qq_app_secret")
     sys.exit(1)
 
 
@@ -316,7 +321,7 @@ class QQAgentClient(botpy.Client):
     async def on_ready(self):
         me = getattr(getattr(self, "robot", None), "username", "")
         me_id = getattr(getattr(self, "robot", None), "id", "")
-        print(f"[qq] gateway ready: username={me or '-'} id={me_id or '-'}")
+        _logger.info(f"[qq] gateway ready: username={me or '-'} id={me_id or '-'}")
 
     async def _reply_once(self, message, content: str) -> None:
         msg_id = str(getattr(message, "id", "") or "")
@@ -429,7 +434,7 @@ class QQAgentClient(botpy.Client):
         await self._reply_chunks(message, reply)
 
     async def on_at_message_create(self, message: Message):
-        print("[qq] recv at_message_create")
+        _logger.info("[qq] recv at_message_create")
         user_id = str(getattr(getattr(message, "author", None), "id", "") or "")
         text = _normalize_text(getattr(message, "content", ""))
         await self._process(message, user_id, text)
@@ -438,18 +443,18 @@ class QQAgentClient(botpy.Client):
         # In OpenClaw/public-messages mode, C2C events are the canonical path.
         # Handling both direct_message_create and c2c_message_create can cause
         # mixed user-id sources and duplicate/conflicting replies.
-        print("[qq] recv direct_message_create (ignored; use c2c path)")
+        _logger.info("[qq] recv direct_message_create (ignored; use c2c path)")
         return
 
     async def on_group_at_message_create(self, message):  # botpy newer versions
-        print("[qq] recv group_at_message_create")
+        _logger.info("[qq] recv group_at_message_create")
         author = getattr(message, "author", None)
         user_id = str(getattr(author, "member_openid", "") or "")
         text = _normalize_text(getattr(message, "content", ""))
         await self._process(message, user_id or "group_user", text)
 
     async def on_c2c_message_create(self, message):  # botpy newer versions
-        print("[qq] recv c2c_message_create")
+        _logger.info("[qq] recv c2c_message_create")
         author = getattr(message, "author", None)
         user_id = str(getattr(author, "user_openid", "") or "")
         text = _normalize_text(getattr(message, "content", ""))
@@ -510,12 +515,12 @@ def main() -> None:
     intents = _build_intents()
     client = QQAgentClient(intents=intents)
     print(f"✅ QQ Bot starting with appid={APP_ID}")
-    print(f"[qq] intents: {_describe_intents(intents)}")
+    _logger.info(f"[qq] intents: {_describe_intents(intents)}")
     _, allowed_ids = _runtime_policy()
     if not allowed_ids:
-        print("[i] qq_allowed_user_ids is empty: allowing all users.")
+        _logger.info("[i] qq_allowed_user_ids is empty: allowing all users.")
     else:
-        print(f"[i] qq_allowed_user_ids count={len(allowed_ids)}")
+        _logger.info(f"[i] qq_allowed_user_ids count={len(allowed_ids)}")
     client.run(appid=APP_ID, secret=APP_SECRET)
 
 

--- a/scripts/shuiyuan_watcher.py
+++ b/scripts/shuiyuan_watcher.py
@@ -33,6 +33,9 @@ from sjtu_agent.paths import (
     atomic_write_json,
     read_json_safe,
 )
+from sjtu_agent.logging import get_logger
+
+_logger = get_logger("shuiyuan_watcher")
 
 CST = timezone(timedelta(hours=8))
 STATE_FILE = DATA_DIR / ".shuiyuan_watcher_state.json"
@@ -104,9 +107,8 @@ def _ts() -> str:
 def main():
     cfg = _load_cfg()
     if not cfg["cookie"] or not cfg["telegram_token"] or not cfg["telegram_chat_id"]:
-        print(
-            "[shuiyuan_watcher] 缺少配置：请在 config.json 设置 shuiyuan_watcher.cookie / telegram_token / telegram_allowed_ids",
-            flush=True,
+        _logger.warning(
+            "[shuiyuan_watcher] 缺少配置：请在 config.json 设置 shuiyuan_watcher.cookie / telegram_token / telegram_allowed_ids"
         )
         return
 
@@ -115,7 +117,7 @@ def main():
     interval = cfg["check_interval"]
 
     state = load_state()
-    print(f"[{_ts()}] 开始监控（topic={topic_id}），当前 {state['posts_count']} 楼", flush=True)
+    _logger.info(f"[{_ts()}] 开始监控（topic={topic_id}），当前 {state['posts_count']} 楼")
 
     while True:
         try:
@@ -138,14 +140,13 @@ def main():
                 save_state(new_state)
                 state = new_state
                 if send_telegram(msg, cfg["telegram_token"], cfg["telegram_chat_id"]):
-                    print(
-                        f"[{_ts()}] 通知已发送！第{info['last_post_number']}楼 by {info['last_post_username']}",
-                        flush=True,
+                    _logger.info(
+                        f"[{_ts()}] 通知已发送！第{info['last_post_number']}楼 by {info['last_post_username']}"
                     )
             else:
-                print(f"[{_ts()}] 无新回复，当前 {state['posts_count']} 楼", flush=True)
+                _logger.info(f"[{_ts()}] 无新回复，当前 {state['posts_count']} 楼")
         except Exception as e:
-            print(f"[{_ts()}] 出错: {e}", flush=True)
+            _logger.warning(f"[{_ts()}] 出错: {e}")
         time.sleep(interval)
 
 if __name__ == "__main__":

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -43,9 +43,14 @@ from sjtu_agent.bots._core import (
     run_one_turn_multimodal,
 )
 
+from sjtu_agent.logging import get_logger
+
 import telebot
 import agent
 import ddl_checker as dc
+
+
+_logger = get_logger("telegram_bot")
 
 # ── 配置加载 ──────────────────────────────────────────────────────────────────
 
@@ -58,7 +63,7 @@ BOT_TOKEN   = cfg.get("telegram_token", "")
 ALLOWED_IDS = set(int(x) for x in cfg.get("telegram_allowed_ids", []))
 
 if not BOT_TOKEN:
-    print("❌ config.json 中未设置 telegram_token，请先运行 setup_config.py")
+    _logger.error("❌ config.json 中未设置 telegram_token，请先运行 setup_config.py")
     sys.exit(1)
 
 bot = telebot.TeleBot(BOT_TOKEN)
@@ -245,7 +250,7 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
                     "content": [{"type": "text", "text": fallback_text}],
                 })
         except Exception as e:
-            print(f"[telegram] 最终回复合成失败: {e}")
+            _logger.warning(f"[telegram] 最终回复合成失败: {e}")
         return full_text
 
     # ── OpenAI 兼容路径 ──────────────────────────────────────────────────────
@@ -342,7 +347,7 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
         if fb_text:
             sess["messages"].append({"role": "assistant", "content": fb_text})
     except Exception as e:
-        print(f"[telegram] 最终回复合成失败: {e}")
+        _logger.warning(f"[telegram] 最终回复合成失败: {e}")
 
     # 记录对话到 conversation_log（供用户画像更新使用）
     try:
@@ -1188,10 +1193,10 @@ def _wait_for_network(max_wait: int = 120, interval: int = 5) -> "telebot.types.
         except Exception as e:
             remaining = deadline - _time.monotonic()
             if remaining <= 0:
-                print(f"❌ 网络等待超时（{max_wait}s），最后一次错误：{e}")
+                _logger.error(f"❌ 网络等待超时（{max_wait}s），最后一次错误：{e}")
                 raise
             wait = min(interval, remaining)
-            print(f"[WARN] 第 {attempt} 次连接失败（网络未就绪？），{wait:.0f}s 后重试：{e}")
+            _logger.warning(f"[WARN] 第 {attempt} 次连接失败（网络未就绪？），{wait:.0f}s 后重试：{e}")
             _time.sleep(wait)
 
 
@@ -1217,7 +1222,7 @@ if __name__ == "__main__":
             try:
                 bot.send_message(_uid, startup_text, parse_mode="HTML")
             except Exception as _e:
-                print(f"[WARN] 上线通知发送失败 uid={_uid}: {_e}")
+                _logger.warning(f"[WARN] 上线通知发送失败 uid={_uid}: {_e}")
 
     # 向 Telegram 服务器注册命令列表，用户输入 / 时会弹出自动补全菜单
     from telebot.types import BotCommand

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -35,7 +35,6 @@ import base64
 import io
 import atexit
 import json
-import logging
 import os
 import random
 import re
@@ -63,10 +62,12 @@ from sjtu_agent.bots._core import (
     run_one_turn_multimodal,
 )
 
+from sjtu_agent.logging import get_logger
+
 import agent
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-logger = logging.getLogger("wechat_bot")
+
+_logger = get_logger("wechat_bot")
 
 # ── ilink 接口常量 ─────────────────────────────────────────────────────────────
 
@@ -167,15 +168,15 @@ def do_login() -> tuple[str, str, str]:
     """
     print("\n正在获取微信登录二维码…")
     resp = httpx.get(f"{ILINK_BASE}/ilink/bot/get_bot_qrcode?bot_type=3", timeout=15)
-    print(f"[debug] get_bot_qrcode HTTP {resp.status_code}")
-    print(f"[debug] get_bot_qrcode headers: {dict(resp.headers)}")
-    print(f"[debug] get_bot_qrcode body: {resp.text}")
+    _logger.debug(f"[debug] get_bot_qrcode HTTP {resp.status_code}")
+    _logger.debug(f"[debug] get_bot_qrcode headers: {dict(resp.headers)}")
+    _logger.debug(f"[debug] get_bot_qrcode body: {resp.text}")
     resp.raise_for_status()
     data = resp.json()
     qrcode_key = data["qrcode"]
     qrcode_url = data["qrcode_img_content"]
-    print(f"[debug] qrcode key: {qrcode_key}")
-    print(f"[debug] qrcode url: {qrcode_url}")
+    _logger.debug(f"[debug] qrcode key: {qrcode_key}")
+    _logger.debug(f"[debug] qrcode url: {qrcode_url}")
 
     # 在终端打印 ASCII 二维码
     qr = qrcode.QRCode(border=1)
@@ -199,21 +200,21 @@ def do_login() -> tuple[str, str, str]:
             try:
                 status = status_resp.json()
             except Exception:
-                print(f"[debug] poll #{poll_count} HTTP {status_resp.status_code} non-JSON body: {status_resp.text!r}")
+                _logger.debug(f"[debug] poll #{poll_count} HTTP {status_resp.status_code} non-JSON body: {status_resp.text!r}")
                 time.sleep(2)
                 continue
         except httpx.ReadTimeout:
             # 正常行为，继续轮询
             continue
         except Exception as e:
-            logger.warning(f"轮询扫码状态出错（继续重试）：{e}")
+            _logger.warning(f"轮询扫码状态出错（继续重试）：{e}")
             time.sleep(2)
             continue
 
         s = status.get("status", "")
         # 只在状态变化或异常时打印完整 body，避免刷屏
         if s != last_status or s not in ("waiting", "scaned"):
-            print(f"[debug] poll #{poll_count} HTTP {status_resp.status_code} status={s!r} full body: {status}")
+            _logger.debug(f"[debug] poll #{poll_count} HTTP {status_resp.status_code} status={s!r} full body: {status}")
             last_status = s
 
         if s == "scaned":
@@ -504,9 +505,9 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
     )
 
     if text:
-        logger.info(f"收到消息 from={from_user[:8]}…：{text[:50]}")
+        _logger.info(f"收到消息 from={from_user[:8]}…：{text[:50]}")
     else:
-        logger.info(f"收到媒体消息 from={from_user[:8]}…：{(media or {}).get('type', 'unknown')}")
+        _logger.info(f"收到媒体消息 from={from_user[:8]}…：{(media or {}).get('type', 'unknown')}")
 
     # 发送"正在输入"状态
     client.send_typing(ctx_token)
@@ -588,7 +589,7 @@ def handle_message(client: ILinkClient, msg: dict) -> None:
             # 微信消息长度限制约 4096，超出则分段发送
             _send_chunks(client, reply, from_user, ctx_token)
         except Exception as e:
-            logger.error(f"处理消息时出错：{e}", exc_info=True)
+            _logger.error(f"处理消息时出错：{e}", exc_info=True)
             try:
                 client.send(f"❌ 出错了：{e}", to_user_id=from_user, context_token=ctx_token)
             except Exception:
@@ -610,7 +611,7 @@ def _send_chunks(client: ILinkClient, text: str, to_user: str, ctx_token: str,
 
 def run_bot(client: ILinkClient) -> None:
     """主消息循环：长轮询接收消息并处理。"""
-    logger.info("✅ 微信 bot 已启动，等待消息…")
+    _logger.info("✅ 微信 bot 已启动，等待消息…")
     cfg = _load_cfg()
     to_user = cfg.get("wechat_to_user_id", "")
     ctx_token = cfg.get("wechat_context_token", "")
@@ -644,7 +645,7 @@ def run_bot(client: ILinkClient) -> None:
         except Exception as e:
             consecutive_errors += 1
             wait = min(5 * consecutive_errors, 60)
-            logger.warning(f"getupdates 出错（{consecutive_errors}次），{wait}s 后重试：{e}")
+            _logger.warning(f"getupdates 出错（{consecutive_errors}次），{wait}s 后重试：{e}")
             time.sleep(wait)
 
 
@@ -705,7 +706,7 @@ def send_reminder_via_wechat(title: str, subtitle: str, body: str) -> None:
             text += f"\n{body}"
         bot.push(text)
     except Exception as e:
-        logger.warning(f"微信推送失败：{e}")
+        _logger.warning(f"微信推送失败：{e}")
 
 
 # ── 入口 ──────────────────────────────────────────────────────────────────────

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -38,8 +38,10 @@ from sjtu_agent.paths import (
 )
 from sjtu_agent.parsing import parse_file as parse_router_file
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.logging import get_logger
 
 ROOT = PROJECT_ROOT
+_logger = get_logger("tools")
 _INTERACTIVE_CHAT_ENV = "SJTU_AGENT_INTERACTIVE_CHAT"
 _PARSE_BACKEND_INSTALL = {
     "paddleocr": {"label": "OCR", "modules": ["paddleocr"], "packages": ["paddleocr==3.6.0"]},
@@ -2119,7 +2121,7 @@ def _fetch_ddls_parallel(cfg: dict, skip_canvas=False, skip_aihaoke=False,
             try:
                 all_ddl.extend(fut.result())
             except Exception as e:
-                print(f"[DDL] {futures[fut]} 拉取失败：{e}")
+                _logger.warning("[DDL] %s 拉取失败：%s", futures[fut], e)
 
     _ddl_cache_set(cache_key, all_ddl)
     return all_ddl
@@ -2248,7 +2250,7 @@ def _classify_canvas_ddls(ddls: list) -> list:
             d["type_confidence"] = c.get("confidence", 0.0)
 
     except Exception as e:
-        print(f"[DDL classify] LLM 分类失败，全部标记为 unknown: {e}")
+        _logger.warning("[DDL classify] LLM 分类失败，全部标记为 unknown: %s", e)
         for idx, d in need_llm:
             d.setdefault("type", "unknown")
             d.setdefault("type_confidence", 0.0)
@@ -3107,15 +3109,15 @@ def _install_missing_backend_package(backend: str) -> tuple[bool, str]:
     if not packages:
         return False, f"no package configured for backend: {backend}"
     cmd = [sys.executable, "-m", "pip", "install", *packages]
-    print(f"[parse] Installing {' '.join(packages)} ...")
+    _logger.info("[parse] Installing %s ...", " ".join(packages))
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode == 0:
-        print(f"[parse] Installed {' '.join(packages)}.")
+        _logger.info("[parse] Installed %s.", " ".join(packages))
         return True, ""
     err = (proc.stderr or proc.stdout or "").strip()
     if len(err) > 800:
         err = err[-800:]
-    print(f"[parse] Install failed ({' '.join(packages)}): {err or 'unknown error'}")
+    _logger.error("[parse] Install failed (%s): %s", " ".join(packages), err or "unknown error")
     return False, err
 
 

--- a/sjtu_agent/homework_agent.py
+++ b/sjtu_agent/homework_agent.py
@@ -17,8 +17,11 @@ from pathlib import Path
 
 from sjtu_agent.paths import ASSIGNMENTS_DIR
 from sjtu_agent.config import cfg as _cfg
+from sjtu_agent.logging import get_logger
 
 import agent
+
+_logger = get_logger("homework_agent")
 
 
 def _get_feishu_config() -> dict | None:
@@ -213,10 +216,10 @@ def _fetch_pending(include_past: bool = False) -> list[dict]:
         CST = timezone(timedelta(hours=8))
         now = datetime.now(CST)
         past = [d for d in ddls if d.get("due") and hasattr(d["due"], "timestamp") and d["due"] < now]
-        print(f"[homework] Canvas 共 {len(ddls)} 个作业，{len(past)} 个历史")
+        _logger.info(f"[homework] Canvas 共 {len(ddls)} 个作业，{len(past)} 个历史")
         return past
     pending = [d for d in ddls if not d.get("submitted")]
-    print(f"[homework] Canvas 共 {len(ddls)} 个作业，{len(pending)} 个未提交")
+    _logger.info(f"[homework] Canvas 共 {len(ddls)} 个作业，{len(pending)} 个未提交")
     return pending
 
 
@@ -254,7 +257,7 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
                         brief: bool = False, answer_mode: bool = False) -> str:
     """使用本地 Claude Code CLI 解题。answer_mode=True 输出完整答案。"""
     if not _CLAUDE_BIN or not Path(_CLAUDE_BIN).exists():
-        print("[homework] Claude Code 不可用，回退到 API 调用")
+        _logger.warning("[homework] Claude Code 不可用，回退到 API 调用")
         return solve_homework(course, aname, content, brief=brief)
 
     import subprocess
@@ -328,14 +331,14 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=10)
-            print("[homework] Claude Code 超时（已终止进程），回退 API")
+            _logger.warning("[homework] Claude Code 超时（已终止进程），回退 API")
             return solve_homework(course, aname, content, brief=brief)
 
         output = stdout.strip()
         if proc.returncode != 0 and not output:
-            print(f"[homework] Claude Code 失败 ({proc.returncode}), 回退 API")
+            _logger.warning(f"[homework] Claude Code 失败 ({proc.returncode}), 回退 API")
             if stderr:
-                print(f"  stderr: {stderr[:200]}")
+                _logger.warning(f"  stderr: {stderr[:200]}")
             return solve_homework(course, aname, content, brief=brief)
 
         # 提取 SUMMARY 作为飞书回复
@@ -351,7 +354,7 @@ def _claude_code_solve(hw_dir: Path, course: str, aname: str, content: str,
                 proc.kill()
             except Exception:
                 pass
-        print(f"[homework] Claude Code 异常: {e}, 回退 API")
+        _logger.warning(f"[homework] Claude Code 异常: {e}, 回退 API")
         return solve_homework(course, aname, content, brief=brief)
 
 
@@ -382,7 +385,7 @@ def _download_and_analyze_one(d: dict, idx: int, brief: bool = False,
             include_past=True,  # 允许下载历史作业
         )
     except Exception as e:
-        print(f"[homework] 下载失败 {course}/{aname}: {e}")
+        _logger.warning(f"[homework] 下载失败 {course}/{aname}: {e}")
 
     content = read_assignment_content(hw_dir)
     if "[无可读文件]" in content:
@@ -406,7 +409,7 @@ def _download_and_analyze_one(d: dict, idx: int, brief: bool = False,
             try: old.unlink()
             except Exception: pass
 
-    print(f"[homework] 解题: {course} - {aname}")
+    _logger.info(f"[homework] 解题: {course} - {aname}")
     feishu_reply = _claude_code_solve(hw_dir, course, aname, content, brief=brief, answer_mode=answer_mode)
 
     # 生成解答文件（从 Claude Code 写入的 _解答.md 读取完整内容）
@@ -415,9 +418,9 @@ def _download_and_analyze_one(d: dict, idx: int, brief: bool = False,
     title = f"{course} — {aname}"
     try:
         files = generate_solution_files(title, full_solution, hw_dir, answer_mode=answer_mode)
-        print(f"[homework] 已生成 {len(files)} 个文件: {files}")
+        _logger.info(f"[homework] 已生成 {len(files)} 个文件: {files}")
     except Exception as e:
-        print(f"[homework] 文件生成失败: {e}")
+        _logger.warning(f"[homework] 文件生成失败: {e}")
 
     # 收集下载文件信息
     file_info = ""
@@ -468,7 +471,7 @@ def run_homework_check(due_within_days: int = 0, specific_idx: int | None = None
     pending = _fetch_pending(include_past=include_past)
     if due_within_days > 0:
         pending = _filter_by_due(pending, due_within_days)
-        print(f"[homework] 过滤后 {len(pending)} 个 {due_within_days} 天内到期")
+        _logger.info(f"[homework] 过滤后 {len(pending)} 个 {due_within_days} 天内到期")
 
     if not pending:
         label = f"{due_within_days} 天内" if due_within_days > 0 else ""
@@ -495,7 +498,7 @@ def run_homework_check_and_push(due_within_days: int = 3,
     result = run_homework_check(due_within_days, specific_idx)
     cfg = _get_feishu_config()
     if not cfg:
-        print("[homework] 飞书未配置，仅打印：\n" + result)
+        _logger.warning("[homework] 飞书未配置，仅打印：\n" + result)
         return
 
     import requests
@@ -506,7 +509,7 @@ def run_homework_check_and_push(due_within_days: int = 3,
             timeout=10,
         )
         if r.status_code != 200 or r.json().get("code") != 0:
-            print(f"[homework] 飞书 token 获取失败")
+            _logger.warning("[homework] 飞书 token 获取失败")
             return
         token = r.json()["tenant_access_token"]
 
@@ -524,8 +527,8 @@ def run_homework_check_and_push(due_within_days: int = 3,
                 timeout=15,
             )
             if resp.status_code != 200 or resp.json().get("code") != 0:
-                print(f"[homework] 推送失败: {resp.text[:100]}")
+                _logger.warning(f"[homework] 推送失败: {resp.text[:100]}")
                 return
-        print("[homework] 飞书推送完成")
+        _logger.info("[homework] 飞书推送完成")
     except Exception as e:
-        print(f"[homework] 推送异常: {e}")
+        _logger.warning(f"[homework] 推送异常: {e}")


### PR DESCRIPTION
## 日志改造 C2+C3

### C2: daemon 诊断迁移（11 文件，-125 print）
feishu_bot(34)、qq_bot(9)、telegram_bot(6)、wechat_bot(14)、homework_agent(17)、news_digest(9)、daily_report(12)、aihot_push(7)、care_check(6)、email_watcher(6)、shuiyuan_watcher(5)。

保留交互式：QR 登录、启动横幅、--test/--dry-run 报告正文输出。

### C3: ddl_checker + _core 迁移（-62 print）
ddl_checker 57 处转 logger（info/warning/error 分级）；保留 print_report 表格、CLI 进度、验证码交互。
_core 5 处；保留 11 处 Playwright 自动登录引导。

### 结果
全项目 print 523→336（-187），192 处结构化日志。剩余 print 均为交互式/CLI 用户可见。
统一 logger（sjtu_agent/logging.py）写 DATA_DIR/logs/*.log + 轮转 + stdout 镜像，修复 Windows pythonw 下 print 丢失。

304 测试全过。