### PR TITLE
chore: bump version to 0.7.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.4"
+version = "0.7.5"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"


### PR DESCRIPTION
## v0.7.5

### P1 技术债务（#110 + #111）
- **Notifier 收尾**：remind_check/care_check 改用共享 send_notification；Telegram 分块 + feishu 缓存 token + win32 Toast
- **BotRunner 去重**：新建 sjtu_agent/bots/_core.py，4 bot 共享会话核心（-220 行）
- **日志统一**：sjtu_agent/logging.py，print 523→336（-187 转结构化日志）