### PR TITLE
fix: Windows 后台 stdout=None 崩溃 + update 前停后台服务 (issue #113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 config.json
 agent_config.json
+.mcp.json
 __pycache__/
 *.pyc
 .pytest_cache/

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -1,5 +1,19 @@
 """SJTU Agent package metadata and shared utilities."""
 
+# ── Windows 后台 stdout/stderr 保护 ─────────────────────────────────────────
+# 在 psmux / Task Scheduler（pythonw 无控制台）下运行 daemon 时，sys.stdout /
+# sys.stderr 可能是 None。任何 print(..., flush=True) 或 logging.StreamHandler
+# 调用 .flush() 都会抛 "'NoneType' object has no attribute 'flush'"。
+# 这里是包导入最早执行的代码，所有 bot/daemon 都 import sjtu_agent，故能覆盖
+# 全部入口：把 None 替换为 devnull（写入即丢弃），前台有控制台时不受影响。
+import os
+import sys
+
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w", encoding="utf-8")
+
 __all__ = ["__version__"]
 
 __version__ = "0.7.5"

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from sjtu_agent import __version__
 from sjtu_agent.paths import describe_runtime_paths
-from sjtu_agent.scheduler import available_service_names, current_platform_name, install_daemons
+from sjtu_agent.scheduler import available_service_names, current_platform_name, daemon_status, install_daemons, uninstall_daemons
 from sjtu_agent.setup_wizard import register_setup_parser
 from sjtu_agent.terminal_ui import print_json
 
@@ -105,6 +105,22 @@ def _cmd_update(args: argparse.Namespace) -> int:
         print("   请确认项目是通过 git clone 安装的。")
         return 1
 
+    # ── 1.5 检测已安装的后台服务 ───────────────────────────────────────────
+    # 后台 daemon 在 git pull + reinstall 后仍引用旧模块路径，会导致
+    # ModuleNotFoundError（issue #113）。检测到后，在更新前停止、更新后重启。
+    _installed_daemons: list[tuple[str, list[str]]] = []  # [(backend, [names])]
+    for _backend in ("taskschd", "psmux"):
+        try:
+            _st = daemon_status(backend=_backend)
+            _names = [
+                s["name"] for s in (_st.get("services") or [])
+                if isinstance(s, dict) and s.get("installed")
+            ]
+            if _names:
+                _installed_daemons.append((_backend, _names))
+        except Exception:
+            pass
+
     # ── 1. 显示待更新内容 ──────────────────────────────────────────────────
     if not args.skip_git:
         # 获取当前 HEAD 和远端 HEAD 的差异
@@ -162,6 +178,13 @@ def _cmd_update(args: argparse.Namespace) -> int:
                                 print(f"  • {line}")
 
     # ── 2. git pull ────────────────────────────────────────────────────────
+    # 确认要更新后，先停后台服务（避免更新后旧模块引用报错）
+    for _backend, _names in _installed_daemons:
+        print(f"[i] 更新前停止后台服务（{_backend}）: {', '.join(_names)}")
+        try:
+            uninstall_daemons(service_names=tuple(_names), backend=_backend)
+        except Exception as e:
+            print(f"[!] 停止后台服务失败（可忽略）: {e}")
     if not args.skip_git:
         print("\n正在拉取最新代码…")
         # 先尝试 fast-forward（最简单，无冲突）
@@ -217,6 +240,15 @@ def _cmd_update(args: argparse.Namespace) -> int:
                 print(f"已刷新 .pth 文件：{pth_path}")
         except Exception as _e:
             print(f"（写 .pth 失败，非致命：{_e}）")
+
+    # ── 5.5 重启后台服务 ──────────────────────────────────────────────────
+    if _installed_daemons:
+        for _backend, _names in _installed_daemons:
+            print(f"[i] 更新后重启后台服务（{_backend}）: {', '.join(_names)}")
+            try:
+                install_daemons(service_names=tuple(_names), backend=_backend)
+            except Exception as e:
+                print(f"[!] 重启后台服务失败: {e}")
 
     # ── 6. 打印新版本 ────────────────────────────────────────────────────
     try:


### PR DESCRIPTION
## Issue #113 修复

### 1. 'NoneType' object has no attribute 'flush'（飞书 bot 后台崩溃）
**根因**：psmux / Task Scheduler（pythonw 无控制台）下 `sys.stdout`/`sys.stderr` 为 `None`，`print(..., flush=True)` 或 logging StreamHandler 调 `.flush()` 崩溃。
**修复**：`sjtu_agent/__init__.py`（包导入最早执行，所有 bot/daemon 覆盖）检测 None 时替换为 devnull（写入即丢弃）。前台不受影响。

### 2. sjtu-agent update 后 ModuleNotFoundError
**根因**：后台 daemon 在 git pull + reinstall 后引用旧模块路径。
**修复**：`_cmd_update` 更新前检测并停止已安装后台服务（taskschd + psmux），更新后重启。

### 验证
- stdout=None 场景验证（exit 0，devnull 替换）
- 219 测试通过

### 未做（已记录到 issue）
- 识图：bot 未接入图片消息路径（img1 证实非 OCR 问题）
- 记忆：开机不自动读取 user-profile