### PR TITLE
chore: bump version to 0.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.5"
+version = "0.7.6"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"


### PR DESCRIPTION
## v0.7.6

### Bug 修复（issue #113）
- **'NoneType' flush 崩溃**：Windows 后台（psmux/Task Scheduler）stdout/stderr 为 None 导致崩溃，包入口加保护
- **update 停后台服务**：`sjtu-agent update` 自动停/启已安装后台服务，避免更新后 ModuleNotFoundError