### PR TITLE
chore: bump version to 0.7.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.6"
+version = "0.7.7"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"


### PR DESCRIPTION
## v0.7.7

### 双模型视觉架构（#116 + 修复）
- **独立视觉模型**：主模型不支持视觉时，用配置的视觉模型（如 Qwen3-VL-8B）识图，OCR 兜底
- `sjtu_agent/vision.py`：`load_vision_config` + `analyze_image`
- setup 向导视觉模型独立步骤（主模型已配置也会出现；API key getpass 不回显）
- CLI `--vision-*` 参数
- README 视觉模型配置说明
- 飞书识图优先级：视觉模型 > OCR > 提示