### PR TITLE
feat: bot profile accumulation, telegram report gating, CLI profile injection

### DIFF
--- a/scripts/daily_report.py
+++ b/scripts/daily_report.py
@@ -33,12 +33,32 @@ import ddl_checker as dc
 
 # ── Telegram 推送 ─────────────────────────────────────────────────────────────
 
+def _telegram_bot_running() -> bool:
+    """Telegram bot 是否在运行（心跳文件新鲜度，与飞书同一 >90s 超时规则）。"""
+    try:
+        from sjtu_agent.paths import DATA_DIR
+        hb_file = DATA_DIR / "telegram_heartbeat.json"
+        if not hb_file.exists():
+            return False
+        data = json.loads(hb_file.read_text(encoding="utf-8"))
+        last = data.get("last_heartbeat", "")
+        if not last:
+            return False
+        last_dt = dt.datetime.fromisoformat(last)
+        return (dt.datetime.now() - last_dt).total_seconds() <= 90
+    except Exception:
+        return False
+
+
 def _send_telegram(text: str) -> None:
     """向所有 allowed_ids 分块推送 Telegram 消息。"""
     _cfg.reload_if_changed()
     cfg = _cfg.raw()
     if not cfg.get("telegram_enabled", True):
         _logger.info("[daily_report] Telegram 推送已关闭，跳过")
+        return
+    if not _telegram_bot_running():
+        _logger.info("[daily_report] Telegram bot 未在运行（心跳超时），跳过推送")
         return
     token = cfg.get("telegram_token", "")
     allowed_ids = cfg.get("telegram_allowed_ids", [])

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -38,6 +38,7 @@ from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx,
     model_supports_vision as _model_supports_vision,
+    log_turn,
 )
 
 import lark_oapi as lark
@@ -1012,6 +1013,8 @@ def _process_in_thread(sender_open_id: str, message_id: str, text: str) -> None:
         _conv_mgr.save()
         lock.release()
     _reply_text(message_id, reply)
+    # 记录到用户画像（conversation_log + 关键词），失败静默
+    log_turn(text, reply)
     # 记忆提取不阻塞锁 — 在发送回复后异步进行
     try:
         _try_extract_memory(sender_open_id, conv)
@@ -1094,6 +1097,7 @@ def _process_media_in_thread(sender_open_id: str, message_id: str, msg_type: str
         user_text += "\n\n请根据已提取内容回答；若信息不足，再向用户追问。"
         reply = _capture_turn(conv, user_text, sender_open_id)
         _reply_text(message_id, reply)
+        log_turn(user_text, reply)
 
     try:
         _run_fn_with_timeout(_do_media_process, _CAPTURE_TIMEOUT)

--- a/scripts/qq_bot.py
+++ b/scripts/qq_bot.py
@@ -43,6 +43,7 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    log_turn as _log_turn,
     make_session,
     model_supports_vision as _model_supports_vision,
     run_one_turn,
@@ -432,6 +433,8 @@ class QQAgentClient(botpy.Client):
             lock.release()
 
         await self._reply_chunks(message, reply)
+        # 记录到用户画像（conversation_log + 关键词），失败静默
+        _log_turn(text, reply)
 
     async def on_at_message_create(self, message: Message):
         _logger.info("[qq] recv at_message_create")

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -1203,6 +1203,27 @@ def _wait_for_network(max_wait: int = 120, interval: int = 5) -> "telebot.types.
             _time.sleep(wait)
 
 
+def _heartbeat_worker(interval: float = 30) -> None:
+    """后台线程：每 interval 秒写一次心跳，供 daily_report 判断 bot 运行状态。"""
+    import atexit as _atexit
+    from sjtu_agent.paths import DATA_DIR
+    hb_file = DATA_DIR / "telegram_heartbeat.json"
+    _atexit.register(lambda: hb_file.write_text(
+        json.dumps({"status": "stopped", "last_heartbeat": ""}, ensure_ascii=False),
+        encoding="utf-8",
+    ) if hb_file.parent.exists() else None)
+    while True:
+        try:
+            hb_file.parent.mkdir(parents=True, exist_ok=True)
+            hb_file.write_text(json.dumps({
+                "status": "running",
+                "last_heartbeat": _dt.datetime.now().isoformat(),
+            }, ensure_ascii=False), encoding="utf-8")
+        except Exception:
+            pass
+        _dt.time.sleep(interval)
+
+
 if __name__ == "__main__":
     if "--test" in sys.argv:
         me = bot.get_me()
@@ -1241,4 +1262,8 @@ if __name__ == "__main__":
     ])
     print("   已注册 8 条命令")
     print(f"   等待消息… （Ctrl+C 停止）")
+
+    # ── 启动心跳线程（供 daily_report 判断 bot 运行状态）─────────────────
+    threading.Thread(target=_heartbeat_worker, daemon=True, name="tg-hb").start()
+
     bot.infinity_polling(timeout=30, long_polling_timeout=30)

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -56,6 +56,7 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    log_turn as _log_turn,
     make_session,
     model_supports_vision as _model_supports_vision,
     run_one_turn,
@@ -273,8 +274,10 @@ def _init_messages(sess: dict) -> None:
 
 
 def _capture_turn(sess: dict, user_text: str) -> str:
-    """运行一轮对话，返回 Agent 回复文本。"""
-    return run_one_turn(sess, user_text)
+    """运行一轮对话，返回 Agent 回复文本，并记录到用户画像。"""
+    reply = run_one_turn(sess, user_text)
+    _log_turn(user_text, reply)
+    return reply
 
 
 def _capture_turn_multimodal(sess: dict, content: list) -> str:

--- a/sjtu_agent/agent/chat_loop.py
+++ b/sjtu_agent/agent/chat_loop.py
@@ -333,7 +333,8 @@ def chat_loop(client, model: str):
         f"「本学年」= {_cur_xnm}学年"
         f"（query_grades: year='{_cur_xnm}', semester=''）。"
     )
-    messages = [{"role": "system", "content": SYSTEM_PROMPT + _date_ctx}]
+    from sjtu_agent.bots._core import build_profile_ctx  # 局部导入避免循环依赖
+    messages = [{"role": "system", "content": SYSTEM_PROMPT + _date_ctx + build_profile_ctx()}]
     model_box  = [model]   # 用列表包裹使内部可修改
     client_box = [client]  # 同理，切换模型时可替换 client
 
@@ -433,7 +434,8 @@ def chat_loop(client, model: str):
             model_box[0] = updated["model"]
             # 切换协议时重置对话，避免消息格式冲突
             messages.clear()
-            messages.append({"role": "system", "content": SYSTEM_PROMPT})
+            from sjtu_agent.bots._core import build_profile_ctx  # 局部导入避免循环依赖
+            messages.append({"role": "system", "content": SYSTEM_PROMPT + build_profile_ctx()})
             proto = "Anthropic" if _is_anthropic_model(updated["model"]) else "OpenAI"
             print(f"  已切换到: {updated['model']}  [协议: {proto}]（已保存，对话已重置）\n")
             continue

--- a/sjtu_agent/bots/_core.py
+++ b/sjtu_agent/bots/_core.py
@@ -150,6 +150,18 @@ def refresh_system_prompt(sess: dict, platform_ctx: str = "",
         sess["messages"][0]["content"] = base
 
 
+def log_turn(user_text, reply) -> None:
+    """记录一轮对话到用户画像（conversation_log + 关键词）。失败静默，不影响主流程。
+
+    telegram 直接调用 profile.log_conversation，feishu/wechat/qq 走这里统一接入。
+    """
+    try:
+        from sjtu_agent.news_aggregator.profile import log_conversation
+        log_conversation(user_text or "", reply or "")
+    except Exception:
+        pass
+
+
 def extract_assistant_reply(sess: dict) -> str:
     """从消息历史取最后一条 assistant 文本（飞书已验证的可靠方式）。
 

--- a/tests/test_bot_turn_logging.py
+++ b/tests/test_bot_turn_logging.py
@@ -1,0 +1,38 @@
+"""Tests for A: shared log_turn helper (画像积累接入 feishu/wechat/qq)."""
+
+from sjtu_agent.news_aggregator import profile
+from sjtu_agent.bots._core import log_turn
+
+
+def test_log_turn_calls_log_conversation(monkeypatch):
+    calls = []
+    monkeypatch.setattr(profile, "log_conversation", lambda u, r: calls.append((u, r)))
+    log_turn("你好", "你好呀")
+    assert calls == [("你好", "你好呀")]
+
+
+def test_log_turn_empty_args(monkeypatch):
+    calls = []
+    monkeypatch.setattr(profile, "log_conversation", lambda u, r: calls.append((u, r)))
+    log_turn("", "")
+    assert calls == [("", "")]
+
+
+def test_log_turn_silent_on_error(monkeypatch):
+    def boom(u, r):
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(profile, "log_conversation", boom)
+    log_turn("hi", "yo")  # 不应抛出
+
+
+def test_wechat_capture_turn_logs(monkeypatch):
+    from scripts import wechat_bot
+
+    seen = {}
+    monkeypatch.setattr(wechat_bot, "run_one_turn", lambda sess, text: "回复")
+    monkeypatch.setattr(wechat_bot, "_log_turn", lambda u, r: seen.update(u=u, r=r))
+
+    reply = wechat_bot._capture_turn({"messages": []}, "你好")
+    assert reply == "回复"
+    assert seen == {"u": "你好", "r": "回复"}

--- a/tests/test_daily_report.py
+++ b/tests/test_daily_report.py
@@ -90,3 +90,31 @@ def test_section_has_content_news_and_tips():
     assert daily_report._section_has_content("news", [], None, None, None, "") is False
     # tips 始终保留
     assert daily_report._section_has_content("tips", [], None, None, None, "") is True
+
+
+# ── _telegram_bot_running ───────────────────────────────────────────────────
+
+def _write_tg_heartbeat(monkeypatch, tmp_path, last_heartbeat: str | None):
+    hb = tmp_path / "telegram_heartbeat.json"
+    if last_heartbeat is None:
+        hb.write_text(json.dumps({"status": "stopped", "last_heartbeat": ""}), encoding="utf-8")
+    else:
+        hb.write_text(json.dumps({"status": "running", "last_heartbeat": last_heartbeat}), encoding="utf-8")
+    monkeypatch.setattr(paths, "DATA_DIR", tmp_path)
+
+
+def test_telegram_bot_running_fresh(monkeypatch, tmp_path):
+    fresh = (dt.datetime.now() - dt.timedelta(seconds=10)).isoformat()
+    _write_tg_heartbeat(monkeypatch, tmp_path, fresh)
+    assert daily_report._telegram_bot_running() is True
+
+
+def test_telegram_bot_running_stale(monkeypatch, tmp_path):
+    stale = (dt.datetime.now() - dt.timedelta(seconds=120)).isoformat()
+    _write_tg_heartbeat(monkeypatch, tmp_path, stale)
+    assert daily_report._telegram_bot_running() is False
+
+
+def test_telegram_bot_running_missing_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths, "DATA_DIR", tmp_path)
+    assert daily_report._telegram_bot_running() is False


### PR DESCRIPTION
## 概述

三个小的 bot/画像 改进，积累成一个 PR：

### A. 画像积累接入 feishu/wechat/qq
之前只有 telegram 调 `log_conversation`，飞书/微信/QQ 用户（主平台）的画像关键词不积累，导致刚上线的"开机画像分析"（#113 #4）对飞书几乎无效。
- 新增共享 `log_turn()`（`bots/_core.py`），失败静默
- 接入 feishu（文本+媒体路径）、wechat `_capture_turn`、qq `_process`

### B. Telegram 报告 bot 门控
与既有飞书门控对等：telegram_bot 写 `telegram_heartbeat.json`，`daily_report._send_telegram` 心跳超时（>90s）时跳过推送。启动器/停止 bot 后，telegram 日报不再照常推。

### C. CLI chat 画像注入
终端对话的 system prompt 注入 `build_profile_ctx()`（persona + interests），CLI 也"认识"用户。

## 测试
- 新增 `tests/test_bot_turn_logging.py`（log_turn 调用/静默/wechat 包装）
- `test_daily_report.py` 补 `_telegram_bot_running` 心跳测试
- 全量 **334 passed**

## 相关
- issue #113 #4（画像开机分析）的配套补全
