### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ New code should go into `sjtu_agent/`, not these root or script files.
 
 ### Refactoring status
 
-Refactoring status (as of v0.7.7):
+Refactoring status (as of v0.8.0):
 - **Done**: Phase 2.1 (agent.py split into `sjtu_agent/agent/`), tools.py split into `agent/tools/` subpackage (7 domain-specific submodules + `_report_prefs.py`, `_core.py` ~3700 lines)
 - **Partial**: Phase 1 (ConfigStore) — 类已实现 + 测试，纯读取点已迁移（20 处）；受保护的读写路径（setup/save + P0 凭据保护）保留直接文件操作。`run_tool` 已注册表化（`_TOOL_REGISTRY`）
 - **Not done**: Phase 2.2 (BotRunner base class to deduplicate telegram/wechat ~65% shared code), Phase 3 (Notifier abstraction, BasePlatform for DDL scrapers), Phase 4 (unified logging)

--- a/README.md
+++ b/README.md
@@ -333,4 +333,4 @@ sjtu-agent install-daemons
 
 ## 版本
 
-当前版本：**v0.7.7**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。
+当前版本：**v0.8.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -564,7 +564,7 @@ The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on 
 
 ## Version
 
-Current version: **v0.7.7**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
+Current version: **v0.8.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
 
 ## Release Notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.7.7"
+version = "0.8.0"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.7"
+__version__ = "0.8.0"


### PR DESCRIPTION
## v0.8.0

版本 bump + 文档同步。

### Changes since v0.7.7

**新功能**
- 🧠 bot 记忆开机自动分析（issue #113 #4）：user-profile 开机（首次会话）后台 LLM 重分析，画像注入 system prompt
- 🌐 画像在飞书/微信/QQ 也积累（之前只在 telegram），共享 `log_turn()`
- 💬 CLI 终端对话也注入用户画像

**体验改进**
- 📊 日报安静日跳过：无 DDL/课表/新闻时跳过整次报告，空模块自动抑制（暑假不再推送模板噪音）
- ⏱ 电报/飞书日报跟随 bot 运行状态（心跳门控，bot 停止则不再推送）

**文档/清理**
- 配置示例补齐（`.env.example` / 新增 `agent_config.example.json` / `config.example.json`）
- README_EN 同步到 v0.7.7 内容、官方申请书刷新、README 引用修正
- 删除归档文档（REFACTOR_PLAN / NEWS_AGGREGATOR_PLAN / superpowers workspace）、死代码清理

测试：**334 passed**（CI 双 Python 版本验证）
