### PR TITLE
feat(agent): context engineering — stable prefix, quality budget, skills wiring

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -125,16 +125,20 @@ Loop Engineering  → 设计"自动操作 Agent 的系统"
 
 ## 五、实施路线（增量、每步可测）
 
+**已完成（上下文工程单元）**：
+- ✅ **Phase 1 稳定前缀**：动态时间/记忆移出 system prompt → 用户消息；system 稳定喂缓存（5 个入口全改）
+- ✅ **Phase 2 Clearing + 质量预算**：tool 结果清理（无损）+ 64K 质量预算折叠带摘要（缓存感知）
+- ✅ **skills 死代码修复**：`build_system_prompt()` 接入全部入口（CLI / 4 bot / web），prompt-only skills 生效
+- ✅ **web 聊天补齐**：稳定前缀 + skills + trim 钩子（原绕过点）
+
 | Phase | 内容 | 价值 | 风险 |
 |-------|------|------|------|
-| **1. 稳定前缀** | 动态时间/记忆移出 system prompt → 用户消息；system 稳定喂缓存（**已实现**） | 🔴 缓存命中、成本大降 | 低 |
-| **2. Clearing + 质量预算** | tool 结果清理 + 高阈值折叠（带摘要、缓存感知） | 🔴 抗腐烂、防健忘 | 低 |
-| **3. Prompt 审计** | SYSTEM_PROMPT 分层重构（含修复 build_system_prompt 死代码） | 🟡 指令遵循更稳 | 低 |
+| **3. Prompt 审计** | SYSTEM_PROMPT（638 行）分层重构 | 🟡 指令遵循更稳 | 低 |
 | **4. Harness** | schema 校验 + execute_python 拦截 + 调用日志 | 🟡 可靠/安全 | 中 |
 | **5. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
 | **6. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
 
-每步独立测试（现有 342 个测试作回归基线），可随时停下不返工。
+每步独立测试（现有 353 个测试作回归基线），可随时停下不返工。
 
 ---
 

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -127,13 +127,14 @@ Loop Engineering  → 设计"自动操作 Agent 的系统"
 
 | Phase | 内容 | 价值 | 风险 |
 |-------|------|------|------|
-| **1. Context 预算** | `trim_session()` 滑动窗口 + tool 结果清理 | 🔴 降成本、缓腐烂 | 低 |
-| **2. Prompt 审计** | SYSTEM_PROMPT 分层重构 | 🟡 指令遵循更稳 | 低 |
-| **3. Harness** | schema 校验 + execute_python 拦截 + 调用日志 | 🟡 可靠/安全 | 中 |
-| **4. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
-| **5. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
+| **1. 稳定前缀** | 动态时间/记忆移出 system prompt → 用户消息；system 稳定喂缓存（**已实现**） | 🔴 缓存命中、成本大降 | 低 |
+| **2. Clearing + 质量预算** | tool 结果清理 + 高阈值折叠（带摘要、缓存感知） | 🔴 抗腐烂、防健忘 | 低 |
+| **3. Prompt 审计** | SYSTEM_PROMPT 分层重构（含修复 build_system_prompt 死代码） | 🟡 指令遵循更稳 | 低 |
+| **4. Harness** | schema 校验 + execute_python 拦截 + 调用日志 | 🟡 可靠/安全 | 中 |
+| **5. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
+| **6. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
 
-每步独立测试（现有 341 个测试作回归基线），可随时停下不返工。
+每步独立测试（现有 342 个测试作回归基线），可随时停下不返工。
 
 ---
 

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -212,7 +212,7 @@ def _init_messages(sess: dict) -> None:
         pass
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _FS_CTX + _inject_profile_ctx(),
+        "content": agent.SYSTEM_PROMPT + _FS_CTX + _inject_profile_ctx(),
     })
 
 
@@ -230,14 +230,15 @@ def _extract_assistant_reply(sess: dict) -> str:
 
 
 def _capture_turn(sess: dict, user_text: str, open_id: str = "") -> str:
-    """Run one agent turn, return the assistant reply text."""
+    """Run one agent turn, return the assistant reply text.
+
+    稳定前缀：system 不含时间/记忆（都随用户消息注入），保证缓存命中。
+    """
     _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        base = agent.SYSTEM_PROMPT + _build_date_ctx() + _FS_CTX + _inject_profile_ctx()
-        if open_id:
-            base += _inject_memory_ctx(open_id, user_text)
-        sess["messages"][0]["content"] = base
-    sess["messages"].append({"role": "user", "content": user_text})
+    ctx = _build_date_ctx()
+    if open_id:
+        ctx += _inject_memory_ctx(open_id, user_text)
+    sess["messages"].append({"role": "user", "content": ctx + "\n\n" + user_text})
 
     agent._run_one_turn(
         sess["client_box"][0],
@@ -294,12 +295,10 @@ def _is_duplicate_content(sender_id: str, text: str) -> bool:
 
 def _capture_turn_multimodal(sess: dict, content: list, open_id: str = "") -> str:
     _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        base = agent.SYSTEM_PROMPT + _build_date_ctx() + _FS_CTX + _inject_profile_ctx()
-        if open_id:
-            base += _inject_memory_ctx(open_id, "")
-        sess["messages"][0]["content"] = base
-    sess["messages"].append({"role": "user", "content": content})
+    ctx = _build_date_ctx()
+    if open_id:
+        ctx += _inject_memory_ctx(open_id, "")
+    sess["messages"].append({"role": "user", "content": [{"type": "text", "text": ctx + "\n"}] + list(content)})
 
     agent._run_one_turn(
         sess["client_box"][0],

--- a/scripts/feishu_bot.py
+++ b/scripts/feishu_bot.py
@@ -212,7 +212,7 @@ def _init_messages(sess: dict) -> None:
         pass
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _FS_CTX + _inject_profile_ctx(),
+        "content": agent.build_system_prompt() + _FS_CTX + _inject_profile_ctx(),
     })
 
 

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -98,7 +98,7 @@ def _init_messages(sess: dict) -> None:
     """首次对话时注入 system prompt（稳定前缀：不含时间，时间每轮进用户消息）。"""
     if sess["messages"]:
         return
-    sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _TG_CTX + _build_profile_ctx()})
+    sess["messages"].append({"role": "system", "content": agent.build_system_prompt() + _TG_CTX + _build_profile_ctx()})
 
 
 # ── 输出捕获 ──────────────────────────────────────────────────────────────────

--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -37,6 +37,7 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    build_profile_ctx as _build_profile_ctx,
     make_session,
     model_supports_vision as _model_supports_vision,
     run_one_turn,
@@ -94,10 +95,10 @@ _TG_CTX = (
 
 
 def _init_messages(sess: dict) -> None:
-    """首次对话时注入 system prompt；后续每轮由 _capture_turn 刷新时间。"""
+    """首次对话时注入 system prompt（稳定前缀：不含时间，时间每轮进用户消息）。"""
     if sess["messages"]:
         return
-    sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX})
+    sess["messages"].append({"role": "system", "content": agent.SYSTEM_PROMPT + _TG_CTX + _build_profile_ctx()})
 
 
 # ── 输出捕获 ──────────────────────────────────────────────────────────────────
@@ -129,9 +130,7 @@ def _streamed_turn(sess: dict, user_text: str, on_progress, on_tool_result=None)
     import json as _json
 
     _init_messages(sess)
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        sess["messages"][0]["content"] = agent.SYSTEM_PROMPT + _build_date_ctx() + _TG_CTX
-    sess["messages"].append({"role": "user", "content": user_text})
+    sess["messages"].append({"role": "user", "content": _build_date_ctx() + "\n\n" + user_text})
 
     client = sess["client_box"][0]
     model = sess["model_box"][0]

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -56,6 +56,7 @@ from sjtu_agent.paths import CONFIG_PATH
 from sjtu_agent.config import cfg as _cfg
 from sjtu_agent.bots._core import (
     build_date_ctx as _build_date_ctx,
+    build_profile_ctx as _build_profile_ctx,
     log_turn as _log_turn,
     make_session,
     model_supports_vision as _model_supports_vision,
@@ -269,7 +270,7 @@ def _init_messages(sess: dict) -> None:
         return
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_date_ctx(),
+        "content": agent.SYSTEM_PROMPT + _build_profile_ctx(),
     })
 
 

--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -270,7 +270,7 @@ def _init_messages(sess: dict) -> None:
         return
     sess["messages"].append({
         "role": "system",
-        "content": agent.SYSTEM_PROMPT + _build_profile_ctx(),
+        "content": agent.build_system_prompt() + _build_profile_ctx(),
     })
 
 

--- a/sjtu_agent/agent/chat_loop.py
+++ b/sjtu_agent/agent/chat_loop.py
@@ -300,9 +300,11 @@ def setup_agent_config() -> dict:
 # ══════════════════════════════════════════════════════════════════════════════
 
 
-def chat_loop(client, model: str):
+def _build_date_ctx() -> str:
+    """当前时间 + 学期上下文（每次调用刷新，注入到用户消息而非 system 前缀，
+    保持 system prompt 稳定 → DeepSeek 前缀缓存命中）。"""
     import datetime as _dt
-    _now = _dt.datetime.now()
+    _now = _dt.datetime.now(_dt.timezone(_dt.timedelta(hours=8)))
     _year = _now.year
     _month = _now.month
     # 判断当前学期：9-1月=第1学期(秋), 2-6月=第2学期(春), 7-8月=第3学期(夏)
@@ -321,8 +323,7 @@ def chat_loop(client, model: str):
         _cur_xqm = "3"
         _prev_xnm = _year - 1
         _prev_xqm = "2"
-
-    _date_ctx = (
+    return (
         f"\n\n## 当前时间（自动注入，每次对话刷新）\n"
         f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。\n"
         f"当前学期：{_cur_xnm}-{_cur_xnm+1}学年第{_cur_xqm}学期。\n"
@@ -333,8 +334,12 @@ def chat_loop(client, model: str):
         f"「本学年」= {_cur_xnm}学年"
         f"（query_grades: year='{_cur_xnm}', semester=''）。"
     )
+
+
+def chat_loop(client, model: str):
     from sjtu_agent.bots._core import build_profile_ctx  # 局部导入避免循环依赖
-    messages = [{"role": "system", "content": SYSTEM_PROMPT + _date_ctx + build_profile_ctx()}]
+    # 稳定前缀：system prompt 不含时间（时间每轮注入用户消息，保证缓存命中）
+    messages = [{"role": "system", "content": SYSTEM_PROMPT + build_profile_ctx()}]
     model_box  = [model]   # 用列表包裹使内部可修改
     client_box = [client]  # 同理，切换模型时可替换 client
 
@@ -364,7 +369,7 @@ def chat_loop(client, model: str):
         setup_json = json.dumps(setup, ensure_ascii=False)
         messages.append({
             "role": "user",
-            "content": f"配置检查结果：{setup_json}\n请根据结果告知我缺少哪些配置，并引导我完成设置。",
+            "content": _build_date_ctx() + f"\n\n配置检查结果：{setup_json}\n请根据结果告知我缺少哪些配置，并引导我完成设置。",
         })
         _run_one_turn(client_box[0], model_box[0], messages)
         print("输入问题继续对话，输入 quit 退出。\n")
@@ -440,7 +445,7 @@ def chat_loop(client, model: str):
             print(f"  已切换到: {updated['model']}  [协议: {proto}]（已保存，对话已重置）\n")
             continue
 
-        messages.append({"role": "user", "content": user_input})
+        messages.append({"role": "user", "content": _build_date_ctx() + "\n\n" + user_input})
         try:
             _run_one_turn(client_box[0], model_box[0], messages)
         except KeyboardInterrupt:

--- a/sjtu_agent/agent/chat_loop.py
+++ b/sjtu_agent/agent/chat_loop.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 
 from sjtu_agent.paths import AGENT_CONFIG_PATH, ENV_PATH, DDL_CACHE_PATH
 from sjtu_agent.terminal_ui import print_markdown_message, print_rule
-from sjtu_agent.agent.prompts import SYSTEM_PROMPT
+from sjtu_agent.agent.prompts import build_system_prompt
 from sjtu_agent.agent.runner import _make_client, _run_one_turn, _is_anthropic_model, Spinner
 from sjtu_agent.agent.tools import TOOLS, run_tool, _fetch_ddls_parallel, _ddl_cache_get, tool_check_setup, _load_reminders
 
@@ -339,7 +339,7 @@ def _build_date_ctx() -> str:
 def chat_loop(client, model: str):
     from sjtu_agent.bots._core import build_profile_ctx  # 局部导入避免循环依赖
     # 稳定前缀：system prompt 不含时间（时间每轮注入用户消息，保证缓存命中）
-    messages = [{"role": "system", "content": SYSTEM_PROMPT + build_profile_ctx()}]
+    messages = [{"role": "system", "content": build_system_prompt() + build_profile_ctx()}]
     model_box  = [model]   # 用列表包裹使内部可修改
     client_box = [client]  # 同理，切换模型时可替换 client
 
@@ -440,7 +440,7 @@ def chat_loop(client, model: str):
             # 切换协议时重置对话，避免消息格式冲突
             messages.clear()
             from sjtu_agent.bots._core import build_profile_ctx  # 局部导入避免循环依赖
-            messages.append({"role": "system", "content": SYSTEM_PROMPT + build_profile_ctx()})
+            messages.append({"role": "system", "content": build_system_prompt() + build_profile_ctx()})
             proto = "Anthropic" if _is_anthropic_model(updated["model"]) else "OpenAI"
             print(f"  已切换到: {updated['model']}  [协议: {proto}]（已保存，对话已重置）\n")
             continue

--- a/sjtu_agent/agent/context.py
+++ b/sjtu_agent/agent/context.py
@@ -1,0 +1,150 @@
+"""sjtu_agent/agent/context.py — 会话上下文质量管理（Phase 2）。
+
+前提（2026 共识）：1M 窗口下容量不是约束，但 **Context Rot 在长上下文仍发生**
+（"1M 只是悬崖来得更晚"）。所以这里管的是**质量**（抗腐烂），不是容量：
+
+- clear_stale_tool_results()  无损清理：旧轮次 tool 结果换占位符（效果已持久化，
+  原文是腐烂主因之一）。确定性占位符 → 折叠后缓存可重新命中。
+- trim_session()              质量预算：历史超 64K 时按轮次折叠最旧对话，
+  保留最近几轮原文 + 插入要点摘要（保留用户意图/关键信息，防"健忘"）。
+  Rarely 触发（为质量非容量），打断缓存前缀是偶尔可接受的代价。
+
+缓存感知：折叠/清理都是确定性操作（同一输入 → 同一输出），执行一次后历史稳定，
+缓存从折叠点重新命中。
+"""
+
+from __future__ import annotations
+
+# 历史（不含 system）的质量预算。1M 下远低于容量上限，触发=抗腐烂。
+SESSION_QUALITY_BUDGET = 64_000
+# 折叠时保留最近几轮原文（模型最可能需要引用近况）
+KEEP_RECENT_TURNS = 3
+# 清理 tool 结果时保留最近几轮的（模型可能还在引用）
+KEEP_RECENT_TOOL_RESULTS = 2
+
+_TOOL_RESULT_PLACEHOLDER = "[工具结果已清理（效果已持久化），如需详情可重新查询]"
+
+
+def _estimate_tokens(text: object) -> int:
+    """粗略 token 估算（无 tiktoken 依赖，够预算控制用）。中英混排 ≈ len//3。"""
+    if not text:
+        return 0
+    return max(1, len(str(text)) // 3)
+
+
+def _session_history_cost(messages: list) -> int:
+    """非 system 消息的估算 token 总量。"""
+    return sum(
+        _estimate_tokens(m.get("content", ""))
+        for m in messages
+        if m.get("role") != "system"
+    )
+
+
+def _user_indices(messages: list) -> list[int]:
+    return [i for i, m in enumerate(messages) if m.get("role") == "user"]
+
+
+def clear_stale_tool_results(
+    messages: list, keep_recent: int = KEEP_RECENT_TOOL_RESULTS
+) -> int:
+    """把最近 keep_recent 轮之外的 tool_result 内容替换为占位符。
+
+    保留 tool_call_id（API 需要 tool_calls 与结果对应）；占位符确定性，
+    之后缓存可从折叠点重新命中。返回清理条数。
+    """
+    users = _user_indices(messages)
+    if not users:
+        return 0
+    cutoff = users[-keep_recent] if len(users) >= keep_recent else users[0]
+    cleared = 0
+    for i, m in enumerate(messages):
+        if m.get("role") == "tool" and i < cutoff:
+            content = m.get("content", "")
+            if content and isinstance(content, str) and not content.startswith("["):
+                m["content"] = _TOOL_RESULT_PLACEHOLDER
+                cleared += 1
+    return cleared
+
+
+def _build_fold_digest(folded_messages: list) -> str:
+    """从被折叠的消息提取要点摘要（不调 LLM，保真）。
+
+    每轮取用户消息核心（去掉注入的时间前缀）前 ~40 字，去重。让模型知道
+    之前聊过什么主题，细节才让用户重述。保留决定/标识符类信息优先。
+    """
+    lines: list[str] = []
+    seen: set[str] = set()
+    for m in folded_messages:
+        if m.get("role") != "user":
+            continue
+        text = str(m.get("content") or "").strip()
+        # 剥掉注入的时间前缀（"## 当前时间…\n\n" 之后才是用户原话）
+        if "\n\n" in text:
+            text = text.split("\n\n", 1)[1].strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        brief = text if len(text) <= 40 else text[:37] + "…"
+        lines.append(brief)
+    if not lines:
+        return ""
+    return "折叠前曾讨论：" + "；".join(lines[:6]) + "。"
+
+
+def trim_session(
+    messages: list, budget: int = SESSION_QUALITY_BUDGET
+) -> int:
+    """质量预算控制：清理旧 tool 结果 + 超预算时按轮次折叠最旧对话。
+
+    就地修改 messages（各入口持有同一 list 引用）。返回处理的条数
+    （清理的 tool 结果数 + 折叠的轮次数）。折叠时保留最近几轮原文，
+    并插入一条 system 摘要提示（防健忘）。
+    """
+    if not messages:
+        return 0
+
+    cleared = clear_stale_tool_results(messages)
+    total = _session_history_cost(messages)
+    if total <= budget:
+        return cleared
+
+    users = _user_indices(messages)
+    if not users:
+        return cleared
+    # 保护最近 KEEP_RECENT_TURNS 轮（含其 tool 结果），只折叠更早的
+    protected_start = users[-KEEP_RECENT_TURNS] if len(users) > KEEP_RECENT_TURNS else None
+
+    folded: list = []
+    removed = 0
+    while total > budget:
+        first_user = next((i for i, m in enumerate(messages) if m.get("role") == "user"), None)
+        if first_user is None:
+            break
+        if protected_start is not None and first_user >= protected_start:
+            break  # 只剩保护轮次，不再折叠
+        end = next(
+            (i for i in range(first_user + 1, len(messages)) if messages[i].get("role") == "user"),
+            len(messages),
+        )
+        if protected_start is not None and end > protected_start:
+            end = protected_start
+        chunk = messages[first_user:end]
+        chunk_cost = sum(_estimate_tokens(m.get("content", "")) for m in chunk)
+        folded.extend(chunk)
+        del messages[first_user:end]
+        total -= chunk_cost
+        removed += 1
+        if removed > 100:  # 保险
+            break
+
+    if folded:
+        digest = _build_fold_digest(folded)
+        note = "（上下文预算：更早的对话已折叠。"
+        if digest:
+            note += digest + " "
+        note += "如需恢复细节可让用户重述或查询日志。）"
+        insert_at = 1 if messages and messages[0].get("role") == "system" else 0
+        messages.insert(insert_at, {"role": "system", "content": note})
+
+    return cleared + removed

--- a/sjtu_agent/agent/runner.py
+++ b/sjtu_agent/agent/runner.py
@@ -578,6 +578,10 @@ def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> No
 
 
 def _run_one_turn(client, model: str, messages: list) -> None:
+    # 上下文质量管理（Phase 2）：清理旧 tool 结果 + 超质量预算折叠最旧轮次。
+    # 所有入口（bots / feishu / CLI）都经过这里，单点覆盖。
+    from sjtu_agent.agent.context import trim_session
+    trim_session(messages)
     if _is_anthropic_model(model):
         _run_one_turn_anthropic(client, model, messages)
     else:

--- a/sjtu_agent/bots/_core.py
+++ b/sjtu_agent/bots/_core.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime as _dt
 import re
 
-from sjtu_agent.agent import SYSTEM_PROMPT, _run_one_turn
+from sjtu_agent.agent import _run_one_turn, build_system_prompt
 
 # Each bot previously defined this regex locally; kept here once. feishu never
 # needed it because it doesn't capture stdout — the shared path also doesn't.
@@ -170,7 +170,7 @@ def init_messages(sess: dict, platform_ctx: str = "") -> None:
         return
     sess["messages"].append({
         "role": "system",
-        "content": SYSTEM_PROMPT + platform_ctx + build_profile_ctx(),
+        "content": build_system_prompt() + platform_ctx + build_profile_ctx(),
     })
 
 

--- a/sjtu_agent/bots/_core.py
+++ b/sjtu_agent/bots/_core.py
@@ -161,26 +161,17 @@ def make_session(agent_cfg: dict | None = None) -> dict:
 
 
 def init_messages(sess: dict, platform_ctx: str = "") -> None:
-    """首次对话注入 system prompt；后续由 refresh_system_prompt 刷新时间。"""
+    """首次对话注入 system prompt。
+
+    稳定前缀：system 不含时间（时间每轮注入用户消息），保证 DeepSeek
+    前缀缓存命中。画像（build_profile_ctx）低频变化，留在前缀可被缓存。
+    """
     if sess["messages"]:
         return
     sess["messages"].append({
         "role": "system",
-        "content": SYSTEM_PROMPT + build_date_ctx() + platform_ctx + build_profile_ctx(),
+        "content": SYSTEM_PROMPT + platform_ctx + build_profile_ctx(),
     })
-
-
-def refresh_system_prompt(sess: dict, platform_ctx: str = "",
-                          extra_suffix_fn=None, user_text: str = "") -> None:
-    """每轮刷新 [0] system 内容（时间过期）+ 可选额外上下文。
-
-    extra_suffix_fn(user_text) -> str 是飞书记忆注入的钩子。
-    """
-    if sess["messages"] and sess["messages"][0]["role"] == "system":
-        base = SYSTEM_PROMPT + build_date_ctx() + platform_ctx + build_profile_ctx()
-        if extra_suffix_fn:
-            base += extra_suffix_fn(user_text)
-        sess["messages"][0]["content"] = base
 
 
 def log_turn(user_text, reply) -> None:
@@ -212,21 +203,22 @@ def extract_assistant_reply(sess: dict) -> str:
     return "(已完成)"
 
 
-def run_one_turn(sess: dict, user_text: str, platform_ctx: str = "",
-                 extra_suffix_fn=None) -> str:
-    """追加文本用户轮次 → 跑 LLM → 返回 assistant 回复。"""
+def run_one_turn(sess: dict, user_text: str, platform_ctx: str = "") -> str:
+    """追加文本用户轮次 → 跑 LLM → 返回 assistant 回复。
+
+    动态时间（build_date_ctx）注入到用户消息首部，保持 system 前缀稳定
+    （缓存命中），模型仍能从最新一轮读到当前时间/学期。
+    """
     init_messages(sess, platform_ctx)
-    refresh_system_prompt(sess, platform_ctx, extra_suffix_fn, user_text)
-    sess["messages"].append({"role": "user", "content": user_text})
+    sess["messages"].append({"role": "user", "content": build_date_ctx() + "\n\n" + user_text})
     _run_one_turn(sess["client_box"][0], sess["model_box"][0], sess["messages"])
     return extract_assistant_reply(sess)
 
 
-def run_one_turn_multimodal(sess: dict, content: list, platform_ctx: str = "",
-                            extra_suffix_fn=None) -> str:
+def run_one_turn_multimodal(sess: dict, content: list, platform_ctx: str = "") -> str:
     """同 run_one_turn，但用户消息是 OpenAI multimodal content list。"""
     init_messages(sess, platform_ctx)
-    refresh_system_prompt(sess, platform_ctx, extra_suffix_fn, "")
-    sess["messages"].append({"role": "user", "content": content})
+    ctx = {"type": "text", "text": build_date_ctx() + "\n"}
+    sess["messages"].append({"role": "user", "content": [ctx] + list(content)})
     _run_one_turn(sess["client_box"][0], sess["model_box"][0], sess["messages"])
     return extract_assistant_reply(sess)

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -369,15 +369,16 @@ def _stream_chat(user_message: str):
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
     import agent as _agent
 
+    _now = _dt.datetime.now()
+    _date_ctx = (
+        f"\n\n## 当前时间\n"
+        f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
+    )
     if not _chat_history:
-        _now = _dt.datetime.now()
-        _date_ctx = (
-            f"\n\n## 当前时间\n"
-            f"现在：{_now.strftime('%Y年%m月%d日 %H:%M')}，星期{'一二三四五六日'[_now.weekday()]}。"
-        )
-        _chat_history.append({"role": "system", "content": _agent.SYSTEM_PROMPT + _date_ctx})
+        # 稳定前缀（含 prompt-only skills）；时间每轮注入用户消息 → 缓存命中
+        _chat_history.append({"role": "system", "content": _agent.build_system_prompt()})
 
-    _chat_history.append({"role": "user", "content": user_message})
+    _chat_history.append({"role": "user", "content": _date_ctx + "\n\n" + user_message})
 
     try:
         client, model, proto = _get_chat_client()

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -408,6 +408,10 @@ def _stream_chat_anthropic(client, model, _agent, max_rounds, _sse):
     """Anthropic Messages API 流式 + tool_use 循环。"""
     global _chat_history
 
+    # 上下文质量管理（web 独立流式不经过 runner._run_one_turn）
+    from sjtu_agent.agent.context import trim_session
+    trim_session(_chat_history)
+
     system_msg = ""
     for m in _chat_history:
         if m["role"] == "system":
@@ -516,6 +520,9 @@ def _stream_chat_openai(client, model, _agent, max_rounds, _sse):
     """OpenAI Chat Completions 流式 + tool_calls 循环。"""
     global _chat_history
 
+    # 上下文质量管理（与 runner._run_one_turn 同钩子，web 独立流式不经过它）
+    from sjtu_agent.agent.context import trim_session
+    trim_session(_chat_history)
     messages = list(_chat_history)
 
     for _round in range(max_rounds):

--- a/tests/test_bots_core.py
+++ b/tests/test_bots_core.py
@@ -66,4 +66,26 @@ def test_run_one_turn_multimodal(monkeypatch):
     reply = core.run_one_turn_multimodal(sess, content, "【平台】")
 
     assert reply == "多模态回复"
-    assert sess["messages"][1]["content"] == content
+    # 时间注入为首个 text 元素，原始内容保留在其后
+    user_content = sess["messages"][1]["content"]
+    assert user_content[0]["type"] == "text"
+    assert "当前时间" in user_content[0]["text"]
+    assert user_content[1:] == content
+
+
+def test_stable_prefix_system_has_no_date(monkeypatch):
+    """Phase 1 稳定前缀：system 不含时间（时间注入用户消息），保证缓存命中。"""
+    import sjtu_agent.bots._core as core
+
+    sess = {"messages": [], "model_box": ["deepseek-chat"], "client_box": [object()]}
+    core.init_messages(sess, "【平台】")
+    sys_content = sess["messages"][0]["content"]
+    assert "当前学期" not in sys_content  # 动态时间/学期不进 system 前缀
+    assert "【平台】" in sys_content
+
+    # run_one_turn 把时间放用户消息首部
+    monkeypatch.setattr(core, "_run_one_turn", lambda c, m, msgs: None)
+    sess2 = {"messages": [], "model_box": ["deepseek-chat"], "client_box": [object()]}
+    core.run_one_turn(sess2, "你好")
+    assert "当前学期" in sess2["messages"][1]["content"]
+    assert "你好" in sess2["messages"][1]["content"]

--- a/tests/test_bots_core.py
+++ b/tests/test_bots_core.py
@@ -73,6 +73,26 @@ def test_run_one_turn_multimodal(monkeypatch):
     assert user_content[1:] == content
 
 
+def test_build_system_prompt_includes_skills(monkeypatch):
+    """build_system_prompt 注入启用技能（修复死代码）。"""
+    from sjtu_agent.agent.prompts import build_system_prompt
+    monkeypatch.setattr(
+        "sjtu_agent.extensions.skills.build_skill_prompt",
+        lambda: "\n\n## 技能\n能力X",
+    )
+    result = build_system_prompt()
+    assert "能力X" in result
+
+
+def test_init_messages_uses_build_system_prompt(monkeypatch):
+    """_core.init_messages 走 build_system_prompt（带 skills）。"""
+    import sjtu_agent.bots._core as core
+    monkeypatch.setattr(core, "build_system_prompt", lambda *a: "SYSTEM_WITH_SKILLS")
+    sess = {"messages": [], "model_box": ["m"], "client_box": [object()]}
+    core.init_messages(sess, "平台")
+    assert "SYSTEM_WITH_SKILLS" in sess["messages"][0]["content"]
+
+
 def test_stable_prefix_system_has_no_date(monkeypatch):
     """Phase 1 稳定前缀：system 不含时间（时间注入用户消息），保证缓存命中。"""
     import sjtu_agent.bots._core as core

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,111 @@
+"""Tests for sjtu_agent/agent/context.py — Phase 2 context quality management.
+
+Covers:
+- _estimate_tokens: rough estimator
+- clear_stale_tool_results: clears old tool results, keeps recent turns
+- _build_fold_digest: strips date prefix, dedupes, preserves user intent
+- trim_session: folds oldest turns over quality budget, protects recent turns
+"""
+
+from sjtu_agent.agent.context import (
+    _build_fold_digest,
+    _estimate_tokens,
+    _session_history_cost,
+    clear_stale_tool_results,
+    trim_session,
+)
+
+
+def _tool_history(n_user: int = 3):
+    """构造 n_user 轮历史，每轮 user 带时间前缀 + 可选 tool 结果。"""
+    msgs = [{"role": "system", "content": "S"}]
+    for i in range(n_user):
+        msgs.append({"role": "user", "content": f"## 当前时间\n现在：2026年\n\n第{i}轮用户问题"})
+        msgs.append({"role": "assistant", "content": None, "tool_calls": [{"id": f"t{i}"}]})
+        msgs.append({"role": "tool", "tool_call_id": f"t{i}", "content": f"RESULT_{i}_" + "x" * 200})
+        msgs.append({"role": "assistant", "content": f"第{i}轮回复"})
+    return msgs
+
+
+# ── _estimate_tokens ────────────────────────────────────────────────────────
+
+def test_estimate_tokens():
+    assert _estimate_tokens("") == 0
+    assert _estimate_tokens(None) == 0
+    assert _estimate_tokens("x" * 300) == 100
+
+
+# ── clear_stale_tool_results ────────────────────────────────────────────────
+
+def test_clear_old_keeps_recent_two_turns():
+    msgs = _tool_history(3)  # 3 轮，3 个 tool 结果
+    n = clear_stale_tool_results(msgs)
+    assert n == 1  # 只清最旧 1 轮的（keep_recent=2）
+    assert msgs[3]["content"].startswith("[工具结果已清理")
+    assert msgs[7]["content"] == msgs[7]["content"]  # 最近两轮的保留
+
+
+def test_clear_idempotent():
+    msgs = _tool_history(3)
+    clear_stale_tool_results(msgs)
+    assert clear_stale_tool_results(msgs) == 0
+
+
+def test_clear_noop_with_single_turn():
+    msgs = _tool_history(1)
+    assert clear_stale_tool_results(msgs) == 0  # 只有一轮，无旧结果可清
+
+
+# ── _build_fold_digest ──────────────────────────────────────────────────────
+
+def test_fold_digest_strips_date_prefix():
+    msgs = [
+        {"role": "user", "content": "## 当前时间\n现在：2026年\n\n帮我查这周DDL"},
+        {"role": "assistant", "content": "ok"},
+    ]
+    digest = _build_fold_digest(msgs)
+    assert "帮我查这周DDL" in digest
+    assert "当前时间" not in digest  # 时间前缀被剥掉
+
+
+def test_fold_digest_dedupes():
+    msgs = [
+        {"role": "user", "content": "## 当前时间\n\n完全相同一句话"},
+        {"role": "assistant", "content": "a"},
+        {"role": "user", "content": "## 当前时间\n\n完全相同一句话"},
+        {"role": "assistant", "content": "b"},
+    ]
+    digest = _build_fold_digest(msgs)
+    assert digest.count("完全相同一句话") == 1
+
+
+# ── trim_session ────────────────────────────────────────────────────────────
+
+def test_trim_noop_under_budget():
+    msgs = [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+    assert trim_session(msgs, budget=8000) == 0
+    assert len(msgs) == 3
+
+
+def test_trim_folds_oldest_protects_recent():
+    # 6 轮大内容 → 触发折叠
+    msgs = [{"role": "system", "content": "S"}]
+    for i in range(6):
+        msgs.append({"role": "user", "content": f"## 当前时间\n\n第{i}轮用户问题" + "x" * 300})
+        msgs.append({"role": "assistant", "content": "回复" + "y" * 300})
+    n = trim_session(msgs, budget=800)
+    assert n > 0
+    assert _session_history_cost(msgs) <= 800
+    # 折叠摘要已插入（system 角色）
+    notes = [m for m in msgs if m.get("role") == "system" and "折叠前曾讨论" in m.get("content", "")]
+    assert notes
+    # 保护最近轮次：最后的 user 消息仍在
+    assert any("第5轮用户问题" in str(m.get("content", "")) for m in msgs if m.get("role") == "user")
+
+
+def test_trim_clears_then_folds():
+    """tool 结果大时先清理（无损）再折叠。"""
+    msgs = _tool_history(8)  # 8 轮，每轮 tool 结果 ~200 字
+    n = trim_session(msgs, budget=400)
+    assert n > 0
+    assert _session_history_cost(msgs) <= 400


### PR DESCRIPTION
## 概述

上下文工程单元（设计文档 `docs/AGENT_ARCHITECTURE.md` Phase 1-2 + 附带修复）。5 个 commit，353 测试通过。

### Phase 1 — 稳定 system 前缀（缓存命中）
**问题**：动态时间/学期/画像/记忆全写进 system prompt 并每轮重建 → DeepSeek 自动前缀缓存**每轮失效**（0 命中）。
**修复**：system prompt 稳定（`SYSTEM_PROMPT + 平台 + 画像`，不含时间）；当前时间每轮注入**用户消息** → 前缀稳定、缓存持续命中（命中价 $0.0028/M vs miss $0.14/M，50 倍）。
覆盖全部 5 个入口：CLI / telegram / wechat / qq（走 _core）/ feishu / web。

### Phase 2 — 上下文质量（抗腐烂 + 防健忘）
1M 窗口下容量不是约束，但 Context Rot 仍发生。设计要点（2026 共识）：
- **Clearing（无损）**：旧轮次 tool 结果 → 确定性占位符（效果已持久化），去腐烂主源
- **质量预算（64K，非容量）**：超预算折叠最旧轮次，保留最近 3 轮原文
- **折叠带摘要**：保留用户意图（去时间前缀、去重）→ 不"健忘"
- **缓存感知**：确定性操作 → 折叠后缓存重新命中；罕见触发可接受

### 附带修复
- **skills 死代码**：`build_system_prompt()`（含 prompt-only skills）从未被调用 → 聊天里 skills 不生效。已接入全部入口。
- **web 聊天补齐**：独立流式绕过 `_run_one_turn` → 补稳定前缀 + skills + trim 钩子。

### 测试
- 新增 `tests/test_context.py`（9 个：清理/摘要/折叠/保护轮次）
- `test_bots_core.py` +skills 注入 + 稳定前缀测试
- 全量 **353 passed**

### 相关
- 设计文档：`docs/AGENT_ARCHITECTURE.md`
