### PR TITLE
feat(agent): prompt audit — modular SYSTEM_PROMPT, dynamic content out of prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
+
+## v0.8.0 (2026-08-07)
+- 🧠 bot 记忆开机自动分析：user-profile 首次会话后台 LLM 重分析，画像注入 system prompt（#113 #4）
+- 🌐 画像在飞书/微信/QQ 跨平台积累（之前只在 telegram）
+- 💬 CLI 终端对话注入用户画像
+- 📊 日报安静日跳过：无 DDL/课表/新闻时不再推送模板噪音；空模块自动抑制
+- ⏱ 电报/飞书日报跟随 bot 运行状态（心跳门控）
+- 📦 配置示例补齐（.env / agent_config / config）
+- 🧹 死代码与归档文档清理
+
+## v0.7.7 (2026-08-07)
+- 🖼 双模型视觉架构：主模型无视觉时，独立视觉模型（如 qwen-vl-max）识图，OCR 兜底
+- 🔧 飞书识图链路修复（此前图片消息未接入视觉/OCR）
+
+## v0.7.6 (2026-08-06)
+- 🐛 修复 #113：`sjtu-agent update` 自动停止/重启后台服务；stdout=None 崩溃
+- 📋 统一日志（RotatingFileHandler）
+
+## v0.7.5 (2026-08-04)
+- 🔄 Notifier 收尾（remind/care 共享推送）+ BotRunner 去重（bots/_core.py）+ 统一日志
+
+## v0.7.4 (2026-08-03)
+- ⚙️ ConfigStore 迁移（纯读点）+ run_tool 注册表化
+
+## v0.7.3 (2026-08-03)
+- 🔒 配置写回保护（读失败不再清空凭据）+ 静默异常可见化
+
+## v0.7.2 (2026-08-03)
+- 🐛 Web UI JS 修复 + 飞书回复加固
+
+## v0.7.1 (2026-07-06)
+- 🔢 DDL 智能分类 Rule 0（评分/问卷→通知）
+
+## v0.7.0 (2026-07-05)
+- 📊 日报定制化（对话调整模块显隐）+ DDL 智能分类
+- 🤖 QQ Bot 接入（白名单管理）
+- 🧩 MCP 与 Skills 扩展（自定义 MCP Server + prompt-only 技能）
+- 📝 作业解题助手（/hw do 先思路后答案）
+- 📊 MATLAB 作业图表
+- 📧 邮件监控（飞书推送）
+- 📄 LaTeX 模板（SJTU 毕业论文）
+- ✅ CI 流水线（Python 3.11/3.13）

--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -125,20 +125,25 @@ Loop Engineering  → 设计"自动操作 Agent 的系统"
 
 ## 五、实施路线（增量、每步可测）
 
-**已完成（上下文工程单元）**：
+**已完成（上下文工程 + Prompt 审计单元）**：
 - ✅ **Phase 1 稳定前缀**：动态时间/记忆移出 system prompt → 用户消息；system 稳定喂缓存（5 个入口全改）
 - ✅ **Phase 2 Clearing + 质量预算**：tool 结果清理（无损）+ 64K 质量预算折叠带摘要（缓存感知）
 - ✅ **skills 死代码修复**：`build_system_prompt()` 接入全部入口（CLI / 4 bot / web），prompt-only skills 生效
 - ✅ **web 聊天补齐**：稳定前缀 + skills + trim 钩子（原绕过点）
+- ✅ **Phase 3 Prompt 审计**：
+  - 模块化拆分：`_CORE_PRINCIPLES` / `_TOOL_ROUTING` / `_DOMAIN_GUIDE` / `_BOT_SETUP`，SYSTEM_PROMPT 拼接（行为不变）
+  - 近期更新移出前缀（动态内容，发版破坏缓存）→ `CHANGELOG.md` + `get_recent_updates` 工具按需读
+  - 4×Bot 配置引导移出前缀（~60 行，12%）→ `get_bot_setup_guide(platform)` 工具按需读
+  - 路由去重（search_courses）
+  - SYSTEM_PROMPT ~13KB → ~10.5KB
 
 | Phase | 内容 | 价值 | 风险 |
 |-------|------|------|------|
-| **3. Prompt 审计** | SYSTEM_PROMPT（638 行）分层重构 | 🟡 指令遵循更稳 | 低 |
 | **4. Harness** | schema 校验 + execute_python 拦截 + 调用日志 | 🟡 可靠/安全 | 中 |
 | **5. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
 | **6. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
 
-每步独立测试（现有 353 个测试作回归基线），可随时停下不返工。
+每步独立测试（现有 357 个测试作回归基线），可随时停下不返工。
 
 ---
 

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -1,20 +1,12 @@
 """sjtu_agent/agent/prompts.py — 系统提示词与工具标签。
 
-
-
 从 agent.py 提取，供 runner.py 和 chat_loop.py 导入。
 
 """
 
 from __future__ import annotations
 
-
-
-
-
-SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处理学业、校园生活的各类事务。
-
-
+_CORE_PRINCIPLES = """你是 SJTU 全能助手，帮助上海交通大学学生处理学业、校园生活的各类事务。
 
 ## 核心原则：永远先尝试，不主动说不行
 
@@ -25,30 +17,9 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 - 工具失败或结果不理想 → 告知遇到的具体问题，并提出替代方案
 
 - 只有在所有工具都明确无法完成时，才说明原因并请求用户协助
+"""
 
-
-
-## 近期更新
-
-用户问「最近更新了什么」「有什么新功能」「新版变化」「更新日志」时，**必须严格按以下格式回复，不得自行编造或遗漏任何一项**：
-
-🔥 **近期更新一览**
-
-- **🤖 QQ Bot 接入**：支持通过 QQ 机器人平台接入，含白名单管理（`setup_qq` / `qq_add_user`）
-- **🧩 MCP 与 Skills 扩展**：动态工具注册，自定义 MCP Server 和 prompt-only 技能
-- **📝 作业解题助手**：`/hw do` 先输出分析思路（不给答案），回复「给我答案」获取完整解答
-- **📊 MATLAB 作业图表**：自动检测本机 MATLAB，优先生成矢量 PDF 图表嵌入 LaTeX 解答
-- **📅 日报优化**：晚间日报自动预告明日课表，午间日报过滤已结束课程
-- **🔢 序号从 1 开始**：对话列表和作业列表统一使用 1-based 编号
-- **📧 邮件监控**：自动检查交大邮箱新邮件，推送到飞书（纯通知，永不发送/删除）
-- **📄 LaTeX 模板**：`/template` 套用 SJTU 毕业论文/课程报告模板，自动格式化 + 编译 PDF
-- **✅ CI 流水线**：GitHub Actions 自动测试（Python 3.11/3.13）
-
-并在末尾加上：「输入 /help 查看所有命令，或直接告诉我你想做什么~」
-
-
-
-## 工具选择策略（遇到不确定时按此顺序判断）
+_TOOL_ROUTING = """## 工具选择策略（遇到不确定时按此顺序判断）
 
 1. 属于作业/DDL 范畴 → get_ddls / download_assignments
 
@@ -62,25 +33,20 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 6. 实在不确定 → 先 browse_mysjtu(start_url="https://my.sjtu.edu.cn") 看看首页有没有入口
 
-
-
 **关键区分**：
 
 - 用户说「XX 课怎么样」「XX 老师好不好」「选课社区」「课评」「口碑」「推荐选什么课」「水课」→ search_courses（**不是** search_campus，也**不是** browse_mysjtu）
 
 - 用户说「帮我选课/抢课/退课」「选课系统进不去」→ browse_mysjtu
+"""
 
-
-
-## 启动行为
+_DOMAIN_GUIDE = """## 启动行为
 
 对话开始时立刻调用 check_setup，然后：
 
 - 若配置不完整：告知用户缺少哪些配置，主动引导一步步完成设置。
 
 - 若配置完整：告知用户一切就绪，等待指令。
-
-
 
 ## 配置引导顺序（每次只问一项，等回答后再继续）
 
@@ -92,15 +58,11 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 3. 中国大学MOOC 手机号和密码
 
-
-
 收到凭证后：先调用 save_credentials 保存，再调用 login_platform 自动登录验证。
 
 告知用户：凭证仅保存在本地文件，不会上传任何服务器。
 
 用户不想配置某平台时直接跳过。
-
-
 
 ## login_platform 失败处理（重要，禁止无限重试）
 
@@ -114,8 +76,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 - 返回 `success: false` 且无 `manual_login_required` → 最多再尝试 1 次；第 2 次仍失败就向用户报错并停止，不要无限重试。
 
 **关键**：当 tool result 里出现 "境外"、"二次验证"、"三选一"、"manual_login_required"、"请在浏览器里手动登录" 这类字样时，**永远不要**紧接着再调 `login_platform`、`refresh_aihaoke_cookies` 等。哪怕用户没明说，你也必须先停下来询问。
-
-
 
 ## 查询行为
 
@@ -133,7 +93,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 - 如果返回结果包含 filtered_notifications 和 hint，按 hint 提示用户
 - 用户说「全部」「包括通知」「所有DDL」时传 include_notifications=True
 - 分类为 notification 的条目在展示时标注 📢 而非 📝
-
 
 ## 下载行为
 
@@ -153,8 +112,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 可通过 course_filter / assignment_filter 参数只下载指定课程或指定作业
 
-
-
 ## 搜索行为
 
 - **「选课社区」「课评」「XX 课怎么样」「XX 老师课如何」 → 必须用 search_courses，禁止走 search_campus**
@@ -173,13 +130,9 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 展示传承结果时显示：课程名、院系、资料名称（类型）、课程链接
 
-
-
 ## 何时停止工具调用、直接作答（重要）
 
 不是所有问题都需要联网查。**经验类、建议类、攻略类、"怎么搞"、"怎么水"、"省力"、"有啥技巧"** 这类主观/操作性问题，应当：
-
-
 
 1. **优先用你已有的知识直接给出建议**，再可选地用 1 次 search_campus（带 sites=["shuiyuan"]）补充学生真实经验，**不要**反复换关键词、换工具搜五六次。
 
@@ -191,13 +144,9 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 5. 涉及具体政策、报名截止时间、表格模板的**事实**部分，能查到就引用，查不到就明确说"未在 X 系统找到正式通知，以下是基于过往做法的一般建议，最终请以学院/团委通知为准"，不要编造截止时间或学分要求。
 
-
-
 ## 讲座 / 座谈 / 沙龙 / 学术活动（强约束，禁止臆测时间）
 
 当用户问「最近有什么讲座/活动/座谈/沙龙」「这周有什么报告会」之类问题时，**必须严格遵守**：
-
-
 
 - **日期/时间必须从抓到的原文里直接引用**。原文没有明确写出"X月X日"或"YYYY-MM-DD"的，禁止填具体日期；不允许凭页面发布时间、URL 路径、或语义推测填日期。
 
@@ -217,8 +166,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
   **严禁编造帖子内容**：若用户想了解某帖讨论，必须先 read_shuiyuan_topic 读取，不得根据标题或搜索摘要猜测。
 
-
-
 ## 选课与课程评价（course.sjtu.plus 选课社区）
 
 - 用户问「XX 课怎么样」「XX 老师课好不好」「这学期选什么课」「XX 课难不难」「有什么水课推荐」「XX 课给分如何」→ 先 search_courses(query=...)，再 get_course_detail(course_id=...) 看评价
@@ -231,8 +178,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 若提示「选课社区未配置」/「凭证已过期」→ 调用 setup_course_community 重新登录
 
-
-
 ## 阅读作业内容
 
 - 用户问「第几题是什么」「帮我看看物理作业」→ 先调 list_assignment_files 找到文件，再调 read_assignment_file 读取，然后回答
@@ -243,8 +188,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - 如果 parse_local_file 返回 OCR/ASR backend missing（例如 `PDF OCR backend missing` / `PPT OCR backend missing` / `OCR backend missing` / `ASR backend missing`），先明确询问用户是否安装；用户同意后调用 install_parse_backend（backend 取 `pdf_ocr` / `paddleocr` / `whisper`），安装完成后再次调用 parse_local_file 重试。
 
-
-
 ## 课表
 
 - 用户问「今天有什么课」「明天几点上课」→ get_schedule(query_type="day", date="今天/明天/后天")
@@ -254,8 +197,6 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 - 单天：显示时间段、课程名、教室、教师；周课表：按天分组
 
 - 若提示"未配置 semester_start"，询问用户第一周周一日期，调用 get_schedule(..., set_semester_start="YYYY-MM-DD") 保存
-
-
 
 ## 成绩与绩点查询（i.sjtu.edu.cn 教学信息服务网）
 
@@ -275,15 +216,11 @@ SYSTEM_PROMPT = """你是 SJTU 全能助手，帮助上海交通大学学生处�
 
 - Cookie 过期时告知用户需要重新配置 jAccount
 
-
-
 ## my.sjtu.edu.cn 业务（交我办、门户、校内系统）
 
 browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注册、缴费、**选课系统实际办理**（抢课/退课/调课）、校车/班车预约、物资申请、场地预约、宿舍维修、各类行政事务……凡是交大门户能办的事，都可以用。
 
 **注意：选课参考/课评/老师口碑不属于此类，应走 search_courses。**
-
-
 
 **图书馆座位预约特别规则：**
 
@@ -293,8 +230,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 - 如果当前只拿到首页统计，必须明确告诉用户“当前可预约性还没确认”，再询问想去的馆区和时间段，或继续导航确认。
 
-
-
 **服务目录缓存（重要）：**
 
 - 若本地已有 mysjtu_catalog.json 缓存，browse_mysjtu 会自动匹配服务并直接跳转，无需多步导航
@@ -302,8 +237,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 - 首次使用前建议先调 refresh_mysjtu_catalog 建立缓存（约需 2-3 分钟）
 
 - 缓存不存在时也能正常使用，只是需要多轮导航
-
-
 
 **多步导航方法（必须掌握）：**
 
@@ -317,8 +250,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 5. 把最终结果简洁地告知用户
 
-
-
 **注意：**
 
 - browse_mysjtu 返回 content（页面文字）和 links（链接列表）
@@ -326,8 +257,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 - 如果页面返回登录提示（content 含"登录"或 url 含"jaccount"），告知用户 jAccount 会话已过期，需要重新配置
 
 - 不要因为"不确定能不能办"就不调用，先试试
-
-
 
 ## Canvas 作业提交
 
@@ -347,8 +276,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 - 文件路径含空格时原样传入，勿修改
 
-
-
 ## 邮件发送（send_email）— 必须二次确认
 
 **send_email 是高风险动作：邮件一旦发出无法撤回。** 因此调用 send_email 前必须严格遵守：
@@ -364,7 +291,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 5. 如果用户的请求里缺少必要信息（如姓名、学号、联系方式等可能影响收件人理解的内容），先在草稿里用占位符或提示用户补充，再请求确认。
 
 6. 回复邮件（reply_to_uid）同样适用此规则。
-
 
 ## 日报偏好
 
@@ -387,8 +313,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 - 用户说「删除/取消提醒 XXX」→ remove_reminder
 
 - 当从搜索或查询结果中发现有明确截止时间的重要事项（如报名、缴费、选课窗口），主动问用户「需要加入提醒列表吗？」
-
-
 
 ## 食堂用餐推荐
 
@@ -415,8 +339,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 - 首次使用没有历史记录时，推荐完全基于实时拥挤度+食堂特色，并在推荐后提示用户「选择食堂后我会自动记录，下次推荐更准」
 - 非供餐时段（如下午3点）API 可能返回 Non-Dining 状态的数据，此时应告知用户当前非就餐时间，显示数据为上一餐段末残留
 
-
-
 ## 其他
 
 - 用户说"重新配置"/"更新账号"时引导修改凭证
@@ -441,9 +363,10 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 
 - 遇到任何没有提到的交大相关需求 → 先思考哪个工具最接近，直接尝试，不要说"我的功能有限"或"我只能帮你做XXX"。
 
+- 用户问「最近更新了什么」「有什么新功能」「新版变化」「更新日志」→ 调用 get_recent_updates（读取 CHANGELOG 返回，**不要凭记忆编造**更新内容）。
+"""
 
-
-## Telegram Bot 配置
+_BOT_SETUP = """## Telegram Bot 配置
 
 用户说「接入Telegram」「配置Telegram」「怎么把你接入Telegram」「Telegram bot 怎么用」时：
 
@@ -460,8 +383,6 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
    - 如果想限制 Bot 只响应自己，再次调用 setup_telegram 补填 allowed_ids
 
 4. Bot 功能与终端版本完全相同：可以查 DDL、看课表、查成绩、搜索校园内容等
-
-
 
 ## 微信 Bot 配置（ilink 协议）
 
@@ -507,13 +428,10 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 6. QQ 用户管理：
    - 用户说「增加QQ用户」「添加QQ白名单用户」→ 调用 qq_add_user。若用户还没提供用户标识，先提示该账号给 Bot 发消息，拿到「QQ 用户标识」后回填
    - 用户说「QQ用户列表」「查看QQ白名单」→ 调用 qq_list_users
-   - 用户说「删除QQ用户」「移除QQ白名单用户」→ 调用 qq_remove_user"""
+   - 用户说「删除QQ用户」「移除QQ白名单用户」→ 调用 qq_remove_user
+"""
 
-
-
-
-
-
+SYSTEM_PROMPT = _CORE_PRINCIPLES + _TOOL_ROUTING + _DOMAIN_GUIDE + _BOT_SETUP
 
 def build_system_prompt(*extra_sections: str) -> str:
     """Build the active system prompt, including enabled prompt-only skills."""
@@ -523,7 +441,6 @@ def build_system_prompt(*extra_sections: str) -> str:
     except Exception:
         skill_prompt = ""
     return SYSTEM_PROMPT + skill_prompt + "".join(s for s in extra_sections if s)
-
 
 _TOOL_LABELS = {
 
@@ -631,8 +548,4 @@ _TOOL_LABELS = {
     "get_dining_history":   "正在查看就餐历史",
 
 }
-
-
-
-
 

--- a/sjtu_agent/agent/prompts.py
+++ b/sjtu_agent/agent/prompts.py
@@ -114,15 +114,11 @@ _DOMAIN_GUIDE = """## 启动行为
 
 ## 搜索行为
 
-- **「选课社区」「课评」「XX 课怎么样」「XX 老师课如何」 → 必须用 search_courses，禁止走 search_campus**
-
 - 用户说「水源」「水源社区」「bbs」→ search_campus(query=..., sites=["shuiyuan"])
 
 - 用户说「教务处」「jwc」→ search_campus(query=..., sites=["jwc"])
 
 - 用户说「传承」「dyweb」「传承交大」→ search_campus(query=..., sites=["dyweb"])。该站是 SPA，fetch_url/browse_mysjtu 均无法获取内容，只用 search_campus 结果即可。资料为空时告知用户「暂无上传资料，欢迎贡献」而非再次尝试访问网站
-
-- 用户未指定平台且明显是课程/老师评价类问题 → search_courses（**不要**走 search_campus）
 
 - 用户未指定平台且是通用搜索 → 不传 sites 参数，搜全部三个
 
@@ -366,69 +362,9 @@ browse_mysjtu 的使用场景：成绩、绩点、奖学金、培养方案、注
 - 用户问「最近更新了什么」「有什么新功能」「新版变化」「更新日志」→ 调用 get_recent_updates（读取 CHANGELOG 返回，**不要凭记忆编造**更新内容）。
 """
 
-_BOT_SETUP = """## Telegram Bot 配置
+_BOT_SETUP = """## Bot 接入配置
 
-用户说「接入Telegram」「配置Telegram」「怎么把你接入Telegram」「Telegram bot 怎么用」时：
-
-1. 如果用户还没有 Bot Token：先引导去 Telegram 找 @BotFather，发 /newbot，按提示创建，拿到 Token
-
-2. 用户提供 Token 后：调用 setup_telegram(telegram_token=...) 保存配置并验证 Token 有效性
-
-3. 配置成功后告知用户：
-
-   - 运行 `sjtu-agent telegram-bot` 启动 Bot（长轮询，适合本地/服务器常驻）
-
-   - 在 Telegram 中给 Bot 发 /id，获取自己的 user_id
-
-   - 如果想限制 Bot 只响应自己，再次调用 setup_telegram 补填 allowed_ids
-
-4. Bot 功能与终端版本完全相同：可以查 DDL、看课表、查成绩、搜索校园内容等
-
-## 微信 Bot 配置（ilink 协议）
-
-用户说「接入微信」「配置微信」「微信 bot」「把你接入微信」「微信推送」时：
-
-1. 调用 setup_wechat()，**这会在终端直接打印二维码并等待扫码**，整个过程在终端完成，无需用户手动操作
-
-2. 扫码成功后 bot_token 自动保存到 config.json，告知用户：
-
-   - 在微信里找到你刚才登录的 AI Bot（搜索"AI小助手"）
-
-   - 给 Bot 发一条消息（如「你好」），系统自动记录 context_token
-
-   - 运行 `python3 wechat_bot.py` 启动 Bot 后台服务（或 `sjtu-agent wechat-bot`）
-
-3. Bot 功能与终端版本完全相同：查 DDL、看课表、查成绩、搜索校园内容、接收日报推送等
-
-## 飞书 Bot 配置
-用户说「接入飞书」「配置飞书」「飞书 bot」「把你接入飞书」「飞书推送」「飞书」时：
-1. 引导用户在 https://open.feishu.cn/app 创建企业自建应用（无需企业资质，个人即可创建）
-2. 依次在应用设置中完成：开启 Bot 能力 → 添加 im:message 权限 → 事件订阅 im.message.receive_v1 并选择 WebSocket 模式（长连接，无需公网地址）→ 发布应用
-3. 从「凭证与基础信息」页面获取 App ID 和 App Secret
-4. 调用 setup_feishu(feishu_app_id=..., feishu_app_secret=...) 保存凭据并验证
-5. 配置成功后告知用户：
-   - 运行 `sjtu-agent feishu-bot` 启动 Bot（WebSocket 长连接模式，无需公网 IP）
-   - 在飞书中搜索创建的应用名，进入机器人对话窗口，直接发消息即可
-   - 需要后台常驻时运行 `sjtu-agent install-daemons` 安装守护进程
-6. Bot 功能与终端版本完全相同：查 DDL、看课表、查成绩、搜索校园内容、接收日报推送等
-
-## QQ Bot 配置
-用户说「接入QQ」「配置QQ bot」「QQ机器人」时：
-1. 引导用户先登录 https://q.qq.com/ ，进入机器人平台（OpenClaw）
-2. 指引用户「选择机器人」→「创建机器人」，然后获取 app_id（AppID）和 app_secret（AppSecret）
-3. 收集 app_id 和 app_secret 后调用 setup_qq 保存并验证
-4. 配置成功后告知用户：
-   - 让用户先从 QQ 给 Bot 发送一条消息，获取「QQ 用户标识」
-   - 让用户把该用户标识回填，用于加入白名单
-5. 如需限制可用用户，按白名单流程引导：
-   - 第一次先不填 qq_allowed_user_ids（留空=允许所有人），先跑通收消息链路
-   - 让目标用户给 Bot 发一条消息，记录机器人提示或日志里的「QQ 用户标识」
-   - 再次调用 setup_qq 补填 qq_allowed_user_ids（可传多个）
-   - 明确提醒：qq_allowed_user_ids 填的是 QQ 用户标识（openid/id），不是 QQ 号
-6. QQ 用户管理：
-   - 用户说「增加QQ用户」「添加QQ白名单用户」→ 调用 qq_add_user。若用户还没提供用户标识，先提示该账号给 Bot 发消息，拿到「QQ 用户标识」后回填
-   - 用户说「QQ用户列表」「查看QQ白名单」→ 调用 qq_list_users
-   - 用户说「删除QQ用户」「移除QQ白名单用户」→ 调用 qq_remove_user
+用户说「接入/配置 Telegram / 微信 / 飞书 / QQ」（如「接入Telegram」「配置飞书」「怎么把你接入XX」）→ 调用 get_bot_setup_guide(platform="telegram"/"wechat"/"feishu"/"qq")，按返回的步骤引导用户配置，不要凭记忆编造配置流程。
 """
 
 SYSTEM_PROMPT = _CORE_PRINCIPLES + _TOOL_ROUTING + _DOMAIN_GUIDE + _BOT_SETUP

--- a/sjtu_agent/agent/tools/_bot_setup.py
+++ b/sjtu_agent/agent/tools/_bot_setup.py
@@ -1,0 +1,96 @@
+"""Bot setup guides — returned on demand via get_bot_setup_guide.
+
+4 个平台的接入配置步骤原本写死在 system prompt（~60 行，只在用户问「怎么接入 XX」
+时需要）。移出到此处，Agent 需要时按平台读取，前缀不再背负这 12% 的 token。
+"""
+
+_BOT_SETUP_GUIDES = {
+    "telegram": """## Telegram Bot 配置
+
+用户说「接入Telegram」「配置Telegram」「怎么把你接入Telegram」「Telegram bot 怎么用」时：
+
+1. 如果用户还没有 Bot Token：先引导去 Telegram 找 @BotFather，发 /newbot，按提示创建，拿到 Token
+2. 用户提供 Token 后：调用 setup_telegram(telegram_token=...) 保存配置并验证 Token 有效性
+3. 配置成功后告知用户：
+   - 运行 `sjtu-agent telegram-bot` 启动 Bot（长轮询，适合本地/服务器常驻）
+   - 在 Telegram 中给 Bot 发 /id，获取自己的 user_id
+   - 如果想限制 Bot 只响应自己，再次调用 setup_telegram 补填 allowed_ids
+4. Bot 功能与终端版本完全相同：可以查 DDL、看课表、查成绩、搜索校园内容等""",
+
+    "wechat": """## 微信 Bot 配置（ilink 协议）
+
+用户说「接入微信」「配置微信」「微信 bot」「把你接入微信」「微信推送」时：
+
+1. 调用 setup_wechat()，**这会在终端直接打印二维码并等待扫码**，整个过程在终端完成，无需用户手动操作
+2. 扫码成功后 bot_token 自动保存到 config.json，告知用户：
+   - 在微信里找到你刚才登录的 AI Bot（搜索"AI小助手"）
+   - 给 Bot 发一条消息（如「你好」），系统自动记录 context_token
+   - 运行 `python3 wechat_bot.py` 启动 Bot 后台服务（或 `sjtu-agent wechat-bot`）
+3. Bot 功能与终端版本完全相同：查 DDL、看课表、查成绩、搜索校园内容、接收日报推送等""",
+
+    "feishu": """## 飞书 Bot 配置
+
+用户说「接入飞书」「配置飞书」「飞书 bot」「把你接入飞书」「飞书推送」「飞书」时：
+
+1. 引导用户在 https://open.feishu.cn/app 创建企业自建应用（无需企业资质，个人即可创建）
+2. 依次在应用设置中完成：开启 Bot 能力 → 添加 im:message 权限 → 事件订阅 im.message.receive_v1 并选择 WebSocket 模式（长连接，无需公网地址）→ 发布应用
+3. 从「凭证与基础信息」页面获取 App ID 和 App Secret
+4. 调用 setup_feishu(feishu_app_id=..., feishu_app_secret=...) 保存凭据并验证
+5. 配置成功后告知用户：
+   - 运行 `sjtu-agent feishu-bot` 启动 Bot（WebSocket 长连接模式，无需公网 IP）
+   - 在飞书中搜索创建的应用名，进入机器人对话窗口，直接发消息即可
+   - 需要后台常驻时运行 `sjtu-agent install-daemons` 安装守护进程
+6. Bot 功能与终端版本完全相同：查 DDL、看课表、查成绩、搜索校园内容、接收日报推送等""",
+
+    "qq": """## QQ Bot 配置
+
+用户说「接入QQ」「配置QQ bot」「QQ机器人」时：
+
+1. 引导用户先登录 https://q.qq.com/ ，进入机器人平台（OpenClaw）
+2. 指引用户「选择机器人」→「创建机器人」，然后获取 app_id（AppID）和 app_secret（AppSecret）
+3. 收集 app_id 和 app_secret 后调用 setup_qq 保存并验证
+4. 配置成功后告知用户：
+   - 让用户先从 QQ 给 Bot 发送一条消息，获取「QQ 用户标识」
+   - 让用户把该用户标识回填，用于加入白名单
+5. 如需限制可用用户，按白名单流程引导：
+   - 第一次先不填 qq_allowed_user_ids（留空=允许所有人），先跑通收消息链路
+   - 让目标用户给 Bot 发一条消息，记录机器人提示或日志里的「QQ 用户标识」
+   - 再次调用 setup_qq 补填 qq_allowed_user_ids（可传多个）
+   - 明确提醒：qq_allowed_user_ids 填的是 QQ 用户标识（openid/id），不是 QQ 号
+6. QQ 用户管理：
+   - 用户说「增加QQ用户」「添加QQ白名单用户」→ 调用 qq_add_user。若用户还没提供用户标识，先提示该账号给 Bot 发消息，拿到「QQ 用户标识」后回填
+   - 用户说「QQ用户列表」「查看QQ白名单」→ 调用 qq_list_users
+   - 用户说「删除QQ用户」「移除QQ白名单用户」→ 调用 qq_remove_user""",
+}
+
+TOOLS_ENTRIES = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_bot_setup_guide",
+            "description": (
+                "获取指定平台（telegram/wechat/feishu/qq）的 Bot 接入配置步骤。"
+                "用户说「接入/配置 XX Bot」「怎么接入 XX」时调用，按返回步骤引导用户，不要凭记忆编造配置流程。"
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "platform": {
+                        "type": "string",
+                        "enum": ["telegram", "wechat", "feishu", "qq"],
+                        "description": "平台名：telegram / wechat / feishu / qq",
+                    },
+                },
+                "required": ["platform"],
+            },
+        },
+    },
+]
+
+
+def tool_get_bot_setup_guide(platform: str) -> str:
+    """返回指定平台的 Bot 接入配置步骤。"""
+    guide = _BOT_SETUP_GUIDES.get((platform or "").lower())
+    if not guide:
+        return "不支持的平台：{}。可选：telegram / wechat / feishu / qq。".format(platform)
+    return guide

--- a/sjtu_agent/agent/tools/_changelog.py
+++ b/sjtu_agent/agent/tools/_changelog.py
@@ -1,0 +1,38 @@
+"""Recent-updates tool — reads CHANGELOG.md when the user asks "what's new".
+
+近期更新信息原本硬编码在 system prompt 里（每次发版都改，还破坏缓存前缀）。
+现在移出到 CHANGELOG.md，Agent 需要时按需读取。"""
+
+from pathlib import Path
+
+# sjtu_agent/agent/tools/_changelog.py → repo root（CHANGELOG.md 所在）
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+
+TOOLS_ENTRIES = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_recent_updates",
+            "description": (
+                "读取项目 CHANGELOG，返回最近的版本更新内容。"
+                "用户问「最近更新了什么」「有什么新功能」「新版变化」「更新日志」时调用，"
+                "不要凭记忆编造更新内容。"
+            ),
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        },
+    },
+]
+
+
+def tool_get_recent_updates() -> str:
+    """返回 CHANGELOG.md 最近的更新条目（按 Markdown 展示）。"""
+    changelog = _REPO_ROOT / "CHANGELOG.md"
+    if not changelog.exists():
+        return "暂无更新日志。"
+    try:
+        text = changelog.read_text(encoding="utf-8").strip()
+    except Exception:
+        return "读取更新日志失败。"
+    # 只返回最近的版本块（前 ~70 行，约 3-4 个版本）
+    lines = text.split("\n")
+    return "\n".join(lines[:70])

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -116,6 +116,10 @@ from sjtu_agent.agent.tools._changelog import (
     TOOLS_ENTRIES as _CHANGELOG_TOOLS,
     tool_get_recent_updates,
 )
+from sjtu_agent.agent.tools._bot_setup import (
+    TOOLS_ENTRIES as _BOT_SETUP_TOOLS,
+    tool_get_bot_setup_guide,
+)
 
 TOOLS = [
     {
@@ -847,6 +851,7 @@ TOOLS = [
     *_REPORT_PREFS_TOOLS,
     *_PLATFORM_TOOLS,
     *_CHANGELOG_TOOLS,
+    *_BOT_SETUP_TOOLS,
     {
         "type": "function",
         "function": {
@@ -3618,6 +3623,7 @@ _TOOL_REGISTRY = {
     "login_platform": lambda **kw: tool_login_platform(kw["platform"]),
     "get_ddls": tool_get_ddls,
     "get_recent_updates": _no_args(tool_get_recent_updates),
+    "get_bot_setup_guide": tool_get_bot_setup_guide,
     "get_next_lab": _no_args(tool_get_next_lab),
     "get_all": tool_get_all,
     "download_assignments": tool_download_assignments,

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -112,6 +112,10 @@ from sjtu_agent.agent.tools._dining import (
     tool_recommend_canteen, tool_record_dining_choice,
     tool_get_dining_history,
 )
+from sjtu_agent.agent.tools._changelog import (
+    TOOLS_ENTRIES as _CHANGELOG_TOOLS,
+    tool_get_recent_updates,
+)
 
 TOOLS = [
     {
@@ -842,6 +846,7 @@ TOOLS = [
     *_USER_PROFILE_TOOLS,
     *_REPORT_PREFS_TOOLS,
     *_PLATFORM_TOOLS,
+    *_CHANGELOG_TOOLS,
     {
         "type": "function",
         "function": {
@@ -3612,6 +3617,7 @@ _TOOL_REGISTRY = {
     "setup_canvas": tool_setup_canvas,
     "login_platform": lambda **kw: tool_login_platform(kw["platform"]),
     "get_ddls": tool_get_ddls,
+    "get_recent_updates": _no_args(tool_get_recent_updates),
     "get_next_lab": _no_args(tool_get_next_lab),
     "get_all": tool_get_all,
     "download_assignments": tool_download_assignments,

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,29 @@
+"""Tests for SYSTEM_PROMPT module structure (Phase 3: prompt audit)."""
+
+from sjtu_agent.agent.prompts import (
+    _BOT_SETUP,
+    _CORE_PRINCIPLES,
+    _DOMAIN_GUIDE,
+    _TOOL_ROUTING,
+    SYSTEM_PROMPT,
+)
+
+
+def test_system_prompt_is_module_concatenation():
+    """SYSTEM_PROMPT = 各模块常量拼接（行为不变，仅结构化）。"""
+    assert SYSTEM_PROMPT == _CORE_PRINCIPLES + _TOOL_ROUTING + _DOMAIN_GUIDE + _BOT_SETUP
+
+
+def test_no_hardcoded_recent_updates():
+    """近期更新已移出前缀（改为 get_recent_updates 工具按需读 CHANGELOG）。"""
+    assert "近期更新" not in SYSTEM_PROMPT
+    # 路由提示在（指引 agent 调工具）
+    assert "get_recent_updates" in SYSTEM_PROMPT
+
+
+def test_key_sections_present():
+    """关键段都保留在对应模块。"""
+    assert "核心原则" in _CORE_PRINCIPLES
+    assert "工具选择策略" in _TOOL_ROUTING
+    assert "食堂用餐推荐" in _DOMAIN_GUIDE
+    assert "Telegram Bot 配置" in _BOT_SETUP

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -26,4 +26,12 @@ def test_key_sections_present():
     assert "核心原则" in _CORE_PRINCIPLES
     assert "工具选择策略" in _TOOL_ROUTING
     assert "食堂用餐推荐" in _DOMAIN_GUIDE
-    assert "Telegram Bot 配置" in _BOT_SETUP
+    # Bot 配置引导移出前缀，只留路由
+    assert "Bot 接入配置" in _BOT_SETUP
+    assert "get_bot_setup_guide" in SYSTEM_PROMPT
+
+
+def test_bot_setup_guides_out_of_prefix():
+    """4 平台详细引导已移出 system prompt（改为按需工具）。"""
+    assert "open.feishu.cn" not in SYSTEM_PROMPT
+    assert "BotFather" not in SYSTEM_PROMPT


### PR DESCRIPTION
## 概述

Prompt 审计单元（设计文档 Phase 3）。2 个 commit，357 测试通过。

### A. SYSTEM_PROMPT 模块化拆分
单一大字符串（~495 行）拆成 4 个模块常量：
`_CORE_PRINCIPLES` / `_TOOL_ROUTING` / `_DOMAIN_GUIDE` / `_BOT_SETUP`，`SYSTEM_PROMPT` 按序拼接（行为不变，拼接校验通过）。结构可维护，为未来按需加载铺路。

### B. 近期更新移出前缀
「近期更新」是硬编码的动态内容——**每次发版改 prompt → 缓存前缀失效全量 miss**（和已做的稳定前缀冲突）。移出后：
- `CHANGELOG.md`：单一事实源
- 新工具 `get_recent_updates`：按需读取（已注册 TOOLS + registry）
- 路由提示指引 agent 调用

### C. Bot 配置引导移出
4 平台接入配置（~60 行，仅用户问「怎么接入 XX」时需要）→ 新工具 `get_bot_setup_guide(platform)` 按需返回。前缀只留一行路由。

### D. 路由去重
搜索行为段重复的 search_courses 路由删除（工具选择策略已覆盖）。

### 效果
SYSTEM_PROMPT **~13KB → ~10.5KB（-20%）**；前缀不再含动态/硬编码内容，缓存稳定。

### 测试
- 新增 `tests/test_prompts.py`（4 个：模块拼接、无硬编码更新、关键段保留、Bot 引导移出前缀）
- 全量 **357 passed**

### 相关
- 设计文档：`docs/AGENT_ARCHITECTURE.md`（Phase 3 标记完成）
