### PR TITLE
feat(agent): harness — tool schema validation, execute_python guard, call logging

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -136,14 +136,14 @@ Loop Engineering  → 设计"自动操作 Agent 的系统"
   - 4×Bot 配置引导移出前缀（~60 行，12%）→ `get_bot_setup_guide(platform)` 工具按需读
   - 路由去重（search_courses）
   - SYSTEM_PROMPT ~13KB → ~10.5KB
+- ✅ **Phase 4 Harness**：工具 schema 校验（必填 + 类型规约）+ `execute_python` 危险操作静态拦截（破坏性 git / os.system / shell=True / rmtree / 删写关键配置）+ 工具调用日志（脱敏参数/耗时/结果长度）
 
 | Phase | 内容 | 价值 | 风险 |
 |-------|------|------|------|
-| **4. Harness** | schema 校验 + execute_python 拦截 + 调用日志 | 🟡 可靠/安全 | 中 |
 | **5. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
 | **6. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
 
-每步独立测试（现有 357 个测试作回归基线），可随时停下不返工。
+每步独立测试（现有 367 个测试作回归基线），可随时停下不返工。
 
 ---
 

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -3692,13 +3692,94 @@ _TOOL_REGISTRY = {
 }
 
 
+# ── 工具 schema 校验（Harness）─────────────────────────────────────────────
+
+# 从 TOOLS 构建 name → parameters schema 的查找表（含 MCP 外的内置工具）
+_TOOL_SCHEMAS: dict[str, dict] = {}
+for _t in TOOLS:
+    _fn = _t.get("function", {})
+    if _fn.get("name"):
+        _TOOL_SCHEMAS[_fn["name"]] = _fn.get("parameters") or {}
+
+
+def _coerce_args(name: str, args: dict | None) -> tuple[dict | None, str | None]:
+    """按工具 schema 校验必填 + 规约参数类型。返回 (coerced_args, error)。
+
+    - 无 schema（如 mcp__* 外部工具）→ 原样放行
+    - 缺必填 → 明确报错（替代晦涩的 TypeError 崩溃）
+    - 已知参数按类型规约（"true"→True, "3"→3），规约失败 → 报错
+    - 未知参数保留透传（schema 可能不全，不拦截）
+    """
+    schema = _TOOL_SCHEMAS.get(name)
+    if not schema:
+        return args or {}, None
+    properties = schema.get("properties") or {}
+    required = schema.get("required") or []
+
+    coerced = dict(args or {})
+    for key, spec in properties.items():
+        if key not in coerced:
+            continue
+        val = coerced[key]
+        t = spec.get("type")
+        try:
+            if t == "integer":
+                coerced[key] = int(val)
+            elif t == "number":
+                coerced[key] = float(val)
+            elif t == "boolean":
+                coerced[key] = val if isinstance(val, bool) else str(val).lower() in ("true", "1", "yes")
+            elif t == "array" and not isinstance(val, list):
+                coerced[key] = [val]
+            elif t == "object" and not isinstance(val, dict):
+                coerced[key] = {}
+        except (TypeError, ValueError):
+            return None, f"参数 {key} 类型错误：期望 {t}，实际 {val!r}"
+
+    for req in required:
+        if req not in coerced:
+            return None, f"缺少必填参数: {req}"
+    return coerced, None
+
+
+_SENSITIVE_ARG_KEYS = ("token", "secret", "password", "api_key", "app_secret")
+
+
+def _log_tool_call(name: str, args: dict | None, elapsed: float, result) -> None:
+    """记录一次工具调用（可观测）：名称 / 参数（脱敏）/ 耗时 / 结果长度。"""
+    try:
+        safe_args = {}
+        for k, v in (args or {}).items():
+            kl = k.lower()
+            if any(s in kl for s in _SENSITIVE_ARG_KEYS):
+                safe_args[k] = "***"
+            elif isinstance(v, (str, int, float, bool)):
+                safe_args[k] = v
+            else:
+                safe_args[k] = type(v).__name__
+        r_len = len(str(result)) if result else 0
+        _logger.info("[tool] %s args=%s %.3fs result_len=%d", name, safe_args, elapsed, r_len)
+    except Exception:
+        pass
+
+
 def run_tool(name: str, args: dict) -> str:
     try:
         if name.startswith("mcp__"):
             from sjtu_agent.extensions.mcp_client import call_tool
             return call_tool(name, args or {})
         fn = _TOOL_REGISTRY.get(name)
-        r = fn(**(args or {})) if fn else {"error": f"未知工具: {name}"}
+        if not fn:
+            return json.dumps({"error": f"未知工具: {name}"}, ensure_ascii=False)
+        coerced, err = _coerce_args(name, args)
+        if err:
+            return json.dumps({"error": err}, ensure_ascii=False)
+        import time as _time
+        _t0 = _time.monotonic()
+        r = fn(**coerced)
+        _elapsed = _time.monotonic() - _t0
+        # 调用日志（可观测）：工具名 / 参数 / 耗时 / 结果长度
+        _log_tool_call(name, args, _elapsed, r)
     except Exception as e:
         r = {"error": str(e)}
     return json.dumps(r, ensure_ascii=False)

--- a/sjtu_agent/agent/tools/_python_exec.py
+++ b/sjtu_agent/agent/tools/_python_exec.py
@@ -1,9 +1,40 @@
 """Dynamic Python execution tool."""
 
+import re as _re
 import subprocess as _sp
 import sys as _sys
 
 from sjtu_agent.paths import PROJECT_ROOT, ENV_PATH
+
+# ── 危险操作静态守卫（确定性约束 > 概率性遵守，Harness）──────────────────────
+# execute_python 在受信任本地环境跑任意代码；这里在子进程启动前做一层静态拦截，
+# 挡住常见的破坏性操作（删关键文件 / 覆盖配置 / 破坏 git / 任意 shell）。
+# 注意：这是护栏不是沙箱——纵深防御的一层，配合敏感 env 剥离使用。
+
+_DANGEROUS_PATTERNS: list[tuple[_re.Pattern, str]] = [
+    (_re.compile(r"git.{0,30}(reset.{0,20}--hard|clean\s+-[fd]|push.{0,20}(--force|\s-f\b)|checkout.{0,10}--|rebase\b)", _re.IGNORECASE),
+     "破坏性 git 操作（reset --hard / clean / push --force / checkout -- / rebase）"),
+    (_re.compile(r"os\.system\s*\(", _re.IGNORECASE), "os.system 任意 shell 执行"),
+    (_re.compile(r"shell\s*=\s*True", _re.IGNORECASE), "shell=True 执行任意命令"),
+    (_re.compile(r"shutil\.rmtree\s*\(", _re.IGNORECASE), "递归删除目录（shutil.rmtree）"),
+    (_re.compile(r"os\.(remove|unlink)\s*\([^)]*(config\.json|agent_config|\.env|user_profile|\.git)"),
+     "删除关键文件（config.json / .env / agent_config / user_profile / .git）"),
+    (_re.compile(r"\.unlink\s*\([^)]*(config\.json|agent_config|\.env|user_profile|\.git)"),
+     "删除关键文件（config.json / .env / agent_config / user_profile / .git）"),
+]
+
+_CONFIG_MARKERS = ("CONFIG_PATH", "config.json", "agent_config", ".env", "user_profile")
+_WRITE_OPS = ("write_text", "write_bytes", "os.remove", "os.unlink", ".unlink(", ".rmdir(", "shutil.rmtree")
+
+
+def _guard_code(code: str) -> str | None:
+    """静态扫描代码，命中危险模式返回错误信息，否则返回 None。"""
+    for pattern, reason in _DANGEROUS_PATTERNS:
+        if pattern.search(code):
+            return f"危险操作被拦截：{reason}。如需执行请改用更安全的方式，或告诉用户手动处理。"
+    if any(m in code for m in _CONFIG_MARKERS) and any(w in code for w in _WRITE_OPS):
+        return "危险操作被拦截：检测到对关键配置文件（config.json / .env / agent_config / user_profile）的写或删除操作。凭据/配置不应被脚本覆盖。"
+    return None
 
 
 TOOLS_ENTRIES = [
@@ -53,6 +84,11 @@ TOOLS_ENTRIES = [
 
 
 def tool_execute_python(code: str, timeout: int = 60) -> dict:
+    # 危险操作静态拦截（Harness）：先于子进程执行
+    blocked = _guard_code(code)
+    if blocked:
+        return {"ok": False, "error": blocked, "blocked": True}
+
     preamble = (
         "import sys, os\n"
         f"sys.path.insert(0, {str(PROJECT_ROOT)!r})\n"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,73 @@
+"""Tests for Harness layer (Phase 4): schema validation, execute_python guard, tool logging."""
+
+from sjtu_agent.agent.tools import run_tool
+from sjtu_agent.agent.tools._core import _coerce_args, _log_tool_call
+from sjtu_agent.agent.tools._python_exec import _guard_code
+
+
+# ── schema 校验 ─────────────────────────────────────────────────────────────
+
+def test_coerce_required_field():
+    """缺必填参数 → 明确报错（而非 TypeError 崩溃）。"""
+    coerced, err = _coerce_args("get_schedule", {})
+    assert err and "必填" in err
+
+
+def test_coerce_boolean_and_integer():
+    coerced, err = _coerce_args("get_ddls", {"classify": "true", "include_notifications": "false"})
+    assert err is None
+    assert coerced["classify"] is True
+    assert coerced["include_notifications"] is False
+
+    coerced, err = _coerce_args("get_schedule", {"query_type": "week", "week_offset": "1"})
+    assert err is None
+    assert coerced["week_offset"] == 1
+
+
+def test_coerce_unknown_or_mcp_passthrough():
+    """无 schema（mcp 外部工具）或未知工具 → 放行不拦截。"""
+    coerced, err = _coerce_args("mcp__some_tool", {"a": 1})
+    assert err is None
+    assert coerced == {"a": 1}
+
+
+def test_run_tool_unknown():
+    assert "未知工具" in run_tool("no_such_tool", {})
+
+
+# ── execute_python 守卫 ─────────────────────────────────────────────────────
+
+def test_guard_allows_safe_code():
+    assert _guard_code('print("hi"); import json; data = {"a": 1}') is None
+
+
+def test_guard_blocks_destructive_git():
+    assert _guard_code("git reset --hard") is not None
+    assert _guard_code('subprocess.run(["git", "reset", "--hard"])') is not None
+    assert _guard_code("git clean -fd") is not None
+    assert _guard_code("git push origin --force") is not None
+
+
+def test_guard_blocks_shell_and_delete():
+    assert _guard_code('subprocess.run("rm -rf /", shell=True)') is not None
+    assert _guard_code("import shutil; shutil.rmtree('/tmp/x')") is not None
+    assert _guard_code('os.remove("config.json")') is not None
+    assert _guard_code("import os; os.remove('agent_config.json')") is not None
+
+
+def test_guard_blocks_config_write():
+    assert _guard_code('Path("config.json").write_text("{}")') is not None
+    assert _guard_code("CONFIG_PATH.write_text('x')") is not None
+
+
+def test_guard_allows_safe_git():
+    assert _guard_code("git status") is None
+    assert _guard_code("git log --oneline") is None
+
+
+# ── 工具调用日志（不抛异常）─────────────────────────────────────────────────
+
+def test_log_tool_call_no_crash():
+    _log_tool_call("setup_telegram", {"telegram_token": "SECRET", "flag": True}, 0.01, {"ok": True})
+    _log_tool_call("get_ddls", {}, 0.5, "big result")
+    _log_tool_call("x", {"nested": {"a": 1}}, 0.0, None)


### PR DESCRIPTION
## 概述

Harness 单元（设计文档 Phase 4）。1 个 commit，367 测试通过。原则：**确定性约束 > 概率性遵守**（不靠模型自觉）。

### 工具 schema 校验
`run_tool` 入口按工具 schema 校验：
- 缺必填参数 → 明确报错（替代晦涩的 TypeError 崩溃）
- 类型规约：`"true"`→`True`、`"3"`→`3`（模型常传字符串形式的布尔/整数）
- 未知参数透传（schema 可能不全）；MCP 外部工具放行

### execute_python 危险操作拦截
静态守卫在子进程运行前拦截：
- 破坏性 git：`reset --hard` / `clean` / `push --force` / `checkout --` / `rebase`（含 list 参数形式如 `["git","reset","--hard"]`）
- 任意 shell：`os.system`、`shell=True`
- `shutil.rmtree` 递归删除
- 删除/覆盖关键配置：`config.json` / `.env` / `agent_config` / `user_profile`

> 这是护栏不是沙箱（配合已有的敏感 env 剥离，纵深防御）；静态正则拦截常见破坏模式，非绕不可过的安全边界。

### 工具调用日志（可观测）
每次工具调用记录：名称 / 参数（**脱敏** token/secret/password/api_key）/ 耗时 / 结果长度。

### 测试
- 新增 `tests/test_harness.py`（10 个：必填/类型规约/守卫拦截与放行/日志不崩溃）
- 全量 **367 passed**

### 相关
- 设计文档：`docs/AGENT_ARCHITECTURE.md`（Phase 4 标记完成）
