### PR TITLE
feat(agent): loop — iteration budget, network retry cap, converge

### DIFF
--- a/docs/AGENT_ARCHITECTURE.md
+++ b/docs/AGENT_ARCHITECTURE.md
@@ -137,13 +137,13 @@ Loop Engineering  → 设计"自动操作 Agent 的系统"
   - 路由去重（search_courses）
   - SYSTEM_PROMPT ~13KB → ~10.5KB
 - ✅ **Phase 4 Harness**：工具 schema 校验（必填 + 类型规约）+ `execute_python` 危险操作静态拦截（破坏性 git / os.system / shell=True / rmtree / 删写关键配置）+ 工具调用日志（脱敏参数/耗时/结果长度）
+- ✅ **Phase 5 Loop**：迭代预算（8 轮工具循环超限收敛，无工具强制合成回复）+ 网络/超时重试上限（2 次后 raise）+ `_converge_openai`/`_converge_anthropic`（openai + anthropic 双路径）
 
 | Phase | 内容 | 价值 | 风险 |
 |-------|------|------|------|
-| **5. Loop** | 迭代预算 + 重试 + 轻量反射 | 🟢 更自主 | 中 |
 | **6. Graph 评估** | Plan-Execute 试点 | 🟢 复杂任务 | 高（可后置） |
 
-每步独立测试（现有 367 个测试作回归基线），可随时停下不返工。
+每步独立测试（现有 375 个测试作回归基线），可随时停下不返工。
 
 ---
 

--- a/sjtu_agent/agent/runner.py
+++ b/sjtu_agent/agent/runner.py
@@ -23,6 +23,11 @@ from sjtu_agent.paths import AGENT_CONFIG_PATH, ENV_PATH
 from sjtu_agent.terminal_ui import print_markdown_message, print_rule
 from sjtu_agent.agent.prompts import _TOOL_LABELS
 
+# ── Loop 边界（Phase 5）：迭代预算 + 网络重试上限 ────────────────────────────
+# 防止模型无限调工具 / 网络持续失败导致死循环。
+_MAX_TOOL_ITERATIONS = 8   # 单轮最多工具调用迭代次数，超出后收敛
+_MAX_NETWORK_RETRIES = 2   # 网络/超时重试上限
+
 
 def _get_tools():
     """Lazy import TOOLS，避免 runner ↔ tools 循环依赖。"""
@@ -277,8 +282,14 @@ def _run_one_turn_openai(client: OpenAI, model: str, messages: list) -> None:
     - 正文内容流式缓冲，结束后用 print_markdown_message 统一渲染 markdown
     """
     spinner = Spinner()
+    iteration = 0
+    retries = 0
 
     while True:
+        iteration += 1
+        if iteration > _MAX_TOOL_ITERATIONS:
+            break  # 迭代预算耗尽 → 收敛（下方 _converge_openai）
+
         # ── 流式请求 ────────────────────────────────────────────────────────
         spinner.start("等待响应…")
         try:
@@ -289,7 +300,8 @@ def _run_one_turn_openai(client: OpenAI, model: str, messages: list) -> None:
         except Exception as e:
             spinner.stop()
             err = str(e).lower()
-            if "timeout" in err or "timed out" in err or "read" in err:
+            if ("timeout" in err or "timed out" in err or "read" in err) and retries < _MAX_NETWORK_RETRIES:
+                retries += 1
                 import time as _time
                 print(f"\r[提示] 网络超时，5 秒后重试…（{e}）")
                 _time.sleep(5)
@@ -345,6 +357,31 @@ def _run_one_turn_openai(client: OpenAI, model: str, messages: list) -> None:
                 spinner.stop()
             messages.append({"role": "tool", "tool_call_id": tc["id"], "content": result})
 
+    # 迭代预算耗尽：无工具调用，强制模型合成最终回复
+    _converge_openai(client, model, messages)
+
+
+def _converge_openai(client: OpenAI, model: str, messages: list) -> None:
+    """迭代预算耗尽时收敛：无工具调用，强制生成最终回复（流式，保持 UX）。"""
+    spinner = Spinner()
+    spinner.start("已达到工具调用上限，正在汇总…")
+    full = ""
+    try:
+        stream = client.chat.completions.create(
+            model=model, messages=messages, timeout=180, stream=True,
+        )
+        full, _reasoning, _tcm = _stream_with_think_tags(stream, spinner)
+    except Exception:
+        full = ""
+    finally:
+        spinner.stop()
+    if full:
+        print_markdown_message("Agent", full)
+    messages.append({
+        "role": "assistant",
+        "content": full or "(已达工具调用上限，未能完成任务。请尝试把任务拆小，或分步询问。)",
+    })
+
 
 def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> None:
     """流式调用 Anthropic Messages API（SSE），实时显示 thinking block 和正文。"""
@@ -365,7 +402,14 @@ def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> No
         "user-agent":         ua,
     }
 
+    iteration = 0
+    retries = 0
+
     while True:
+        iteration += 1
+        if iteration > _MAX_TOOL_ITERATIONS:
+            break  # 迭代预算耗尽 → 收敛（下方 _converge_anthropic）
+
         api_msgs = []
         for m in messages:
             if m["role"] == "system":
@@ -506,10 +550,13 @@ def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> No
             if in_thinking or in_text:
                 sys.stdout.write("\033[0m\n")
                 sys.stdout.flush()
-            import time as _time
-            print(f"\r[提示] 网络连接失败，5 秒后重试…（{type(e).__name__}: {e}）")
-            _time.sleep(5)
-            continue
+            if retries < _MAX_NETWORK_RETRIES:
+                retries += 1
+                import time as _time
+                print(f"\r[提示] 网络连接失败，5 秒后重试…（{type(e).__name__}: {e}）")
+                _time.sleep(5)
+                continue
+            raise
         except Exception as e:
             spinner.stop()
             if in_thinking or in_text:
@@ -535,12 +582,14 @@ def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> No
         if error_payload:
             import time as _time
             msg = (error_payload.get("message") or str(error_payload))[:200]
-            if "overload" in msg.lower() or "过载" in msg:
+            if ("overload" in msg.lower() or "过载" in msg) and retries < _MAX_NETWORK_RETRIES:
+                retries += 1
                 print(f"\r[提示] 模型过载，10 秒后重试…")
                 _time.sleep(10)
                 continue
-            if error_payload.get("type") == "invalid_request_error" and "500" in str(error_payload):
-                import time as _time
+            if (error_payload.get("type") == "invalid_request_error" and "500" in str(error_payload)
+                    and retries < _MAX_NETWORK_RETRIES):
+                retries += 1
                 _time.sleep(5)
                 continue
             raise RuntimeError(f"Anthropic API 错误: {msg}")
@@ -575,6 +624,28 @@ def _run_one_turn_anthropic(client: Anthropic, model: str, messages: list) -> No
                 spinner.stop()
             tool_results.append({"type": "tool_result", "tool_use_id": b["id"], "content": result})
         messages.append({"role": "user", "content": tool_results})
+
+    # 迭代预算耗尽：无工具调用强制合成最终回复
+    _converge_anthropic(client, model, messages)
+
+
+def _converge_anthropic(client: Anthropic, model: str, messages: list) -> None:
+    """迭代预算耗尽时收敛：无工具调用，强制生成最终回复（非流式）。"""
+    system = next((m["content"] for m in messages if m["role"] == "system"), "")
+    api_msgs = [m for m in messages if m["role"] != "system" and m.get("content")]
+    try:
+        resp = client.messages.create(
+            model=model, system=system, messages=api_msgs, max_tokens=4096,
+        )
+        text = "".join(b.text for b in resp.content if getattr(b, "type", "") == "text")
+    except Exception:
+        text = ""
+    if text:
+        print_markdown_message("Agent", text)
+    messages.append({
+        "role": "assistant",
+        "content": text or "(已达工具调用上限，未能完成任务。请尝试把任务拆小，或分步询问。)",
+    })
 
 
 def _run_one_turn(client, model: str, messages: list) -> None:

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,82 @@
+"""Tests for Loop phase (Phase 5): iteration budget + retry cap + converge."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import sjtu_agent.agent.runner as runner
+from sjtu_agent.agent.runner import _MAX_TOOL_ITERATIONS, _MAX_NETWORK_RETRIES
+
+
+def _fake_openai_client(create_fn):
+    return SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create_fn)))
+
+
+def test_iteration_budget_constant():
+    assert _MAX_TOOL_ITERATIONS >= 4
+    assert _MAX_NETWORK_RETRIES >= 1
+
+
+def test_openai_loop_converges_when_model_keeps_calling_tools(monkeypatch):
+    """模型持续调工具 → 迭代预算耗尽后收敛（不死循环），且收敛结果入历史。"""
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        # 每个响应都返回一个 tool_call（让模型"永远想调工具"）
+        return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(
+            reasoning_content=None, content=None,
+            tool_calls=[SimpleNamespace(
+                index=0, id="t1",
+                function=SimpleNamespace(name="get_ddls", arguments="{}"))]))])
+
+    client = _fake_openai_client(fake_create)
+
+    def fake_stream_tags(stream, spinner):
+        return "", "", {0: {"id": "t1", "name": "get_ddls", "arguments": "{}"}}
+
+    monkeypatch.setattr(runner, "_stream_with_think_tags", fake_stream_tags)
+    monkeypatch.setattr(runner, "_get_run_tool", lambda: lambda name, args: "{}")
+    monkeypatch.setattr(runner, "print_markdown_message", lambda *a, **k: None)
+
+    msgs = [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}]
+    runner._run_one_turn_openai(client, "deepseek-chat", msgs)
+
+    # _MAX_TOOL_ITERATIONS 次工具迭代 + 1 次收敛 create
+    assert len(calls) == _MAX_TOOL_ITERATIONS + 1
+    # 收敛后最后一条是 assistant（占位文案）
+    assert msgs[-1]["role"] == "assistant"
+    assert "工具调用上限" in msgs[-1]["content"]
+
+
+def test_openai_loop_returns_when_no_tool_calls(monkeypatch):
+    """模型直接给答案（无工具调用）→ 一次调用即返回。"""
+    calls = []
+
+    def fake_create(**kwargs):
+        calls.append(kwargs)
+        return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(
+            reasoning_content=None, content="你好", tool_calls=None))])
+
+    client = _fake_openai_client(fake_create)
+    monkeypatch.setattr(runner, "_stream_with_think_tags",
+                        lambda stream, spinner: ("你好", "", {}))
+    monkeypatch.setattr(runner, "print_markdown_message", lambda *a, **k: None)
+
+    msgs = [{"role": "system", "content": "S"}, {"role": "user", "content": "hi"}]
+    runner._run_one_turn_openai(client, "deepseek-chat", msgs)
+    assert len(calls) == 1
+    assert msgs[-1]["role"] == "assistant"
+    assert msgs[-1]["content"] == "你好"
+
+
+def test_converge_openai_appends_fallback_on_failure(monkeypatch):
+    """收敛时若流式失败，仍补一条占位 assistant，不崩。"""
+    def fake_create(**kwargs):
+        raise RuntimeError("boom")
+
+    client = _fake_openai_client(fake_create)
+    msgs = [{"role": "system", "content": "S"}]
+    runner._converge_openai(client, "deepseek-chat", msgs)
+    assert msgs[-1]["role"] == "assistant"
+    assert "工具调用上限" in msgs[-1]["content"]


### PR DESCRIPTION
## 概述

Loop 单元（设计文档 Phase 5）。375 测试通过。

此前 tool-call 循环是**无界**的（`while True` 无上限），网络重试也无限——模型持续调工具或网络持续失败会死循环。

### 迭代预算
- `_MAX_TOOL_ITERATIONS = 8`：模型持续调工具超过 8 轮 → **收敛**（无工具调用，强制合成最终回复）
- 收敛失败时降级为占位文案（"已达到工具调用上限…请尝试拆小任务"）

### 网络重试上限
- `_MAX_NETWORK_RETRIES = 2`：超时 / 网络 / 过载重试封顶，超过后 raise（不再无限重试）

### 双路径覆盖
- `_converge_openai`（流式，保持 UX）/ `_converge_anthropic`（非流式）
- openai + anthropic 两个 tool 循环都加了迭代预算 + 重试上限

### 测试
- 新增 `tests/test_loop.py`（4 个：持续调工具 → 收敛不死循环、直接作答一次返回、收敛失败降级）
- 全量 **375 passed**

### 相关
- 设计文档：`docs/AGENT_ARCHITECTURE.md`（Phase 5 标记完成）
