### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## v0.9.0 (2026-08-08)
+- 🏗 **Agent 核心架构升级**（Prompt/Context/Harness/Loop 四层工程）：
+  - ⚡ 稳定 system 前缀：动态时间/记忆移出前缀 → 用户消息，命中 DeepSeek 前缀缓存（成本大降）
+  - 📊 上下文质量：tool 结果清理 + 64K 质量预算折叠带摘要（抗腐烂、防"念旧账"也防"健忘"）
+  - 🧩 Prompt 审计：SYSTEM_PROMPT 模块化拆分，-20% 体积；近期更新 / Bot 配置引导移出前缀（按需工具读取）
+  - 🛡 Harness：工具参数 schema 校验 + `execute_python` 危险操作拦截 + 工具调用日志（可观测）
+  - 🔁 Loop：工具循环迭代预算（8 轮收敛）+ 网络重试上限（2 次）
+  - 🔧 飞书斜杠命令重构：注册表化、修复 `/news`、统一错误处理、集中帮助文案
+
 ## v0.8.0 (2026-08-07)
 - 🧠 bot 记忆开机自动分析：user-profile 首次会话后台 LLM 重分析，画像注入 system prompt（#113 #4）
 - 🌐 画像在飞书/微信/QQ 跨平台积累（之前只在 telegram）

--- a/README.md
+++ b/README.md
@@ -333,4 +333,4 @@ sjtu-agent install-daemons
 
 ## 版本
 
-当前版本：**v0.8.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。
+当前版本：**v0.9.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -564,7 +564,7 @@ The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on 
 
 ## Version
 
-Current version: **v0.8.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
+Current version: **v0.9.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
 
 ## Release Notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.8.0"
+version = "0.9.0"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
## v0.9.0

Agent 核心架构升级版。版本 bump + 文档同步。

### Changes since v0.8.0（22 commits，PR #120-124）

**Agent 架构（Prompt/Context/Harness/Loop 四层）**
- ⚡ 稳定 system 前缀：动态时间/记忆移出前缀 → 用户消息，命中 DeepSeek 前缀缓存（成本大降）——PR #120
- 📊 上下文质量：tool 结果清理 + 64K 质量预算折叠带摘要（抗腐烂、防"念旧账"也防"健忘"）——PR #120
- 🧩 Prompt 审计：SYSTEM_PROMPT 模块化拆分（-20%）、近期更新移出（CHANGELOG + 工具按需）、Bot 配置引导移出——PR #121
- 🛡 Harness：工具 schema 校验 + execute_python 危险操作拦截 + 工具调用日志——PR #122
- 🔁 Loop：工具循环迭代预算（8 轮收敛）+ 网络重试上限——PR #124
- 🔧 飞书斜杠命令重构：注册表化、修复 /news、统一错误处理——PR #123

**测试**：371 → 375 passed（新增 context/loop/prompt/harness 测试）。

### 相关
- 设计文档：`docs/AGENT_ARCHITECTURE.md`（Phase 1-5 完成）
