### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## v0.10.0 (2026-08-09)
+- ⚡ **uv 迁移**：install 脚本换 uv，安装时间从分钟级降到 ~30 秒（数量级提升）
+- 📦 **依赖按需拆分**：移除死依赖（browser-use / langchain-openai）；语义记忆（chromadb）改为可选 extra `[memory]`
+- 🧭 **setup 向导打磨**：必填/可选分组、完成清单、确定性 y/N 决策
+- 🔧 Python 版本要求 3.10 → 3.11（browser-use 依赖约束）
+
 ## v0.9.0 (2026-08-08)
 - 🏗 **Agent 核心架构升级**（Prompt/Context/Harness/Loop 四层工程）：
   - ⚡ 稳定 system 前缀：动态时间/记忆移出前缀 → 用户消息，命中 DeepSeek 前缀缓存（成本大降）

--- a/README.md
+++ b/README.md
@@ -333,4 +333,4 @@ sjtu-agent install-daemons
 
 ## 版本
 
-当前版本：**v0.9.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。
+当前版本：**v0.10.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -564,7 +564,7 @@ The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on 
 
 ## Version
 
-Current version: **v0.9.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
+Current version: **v0.10.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
 
 ## Release Notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.9.0"
+version = "0.10.0"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.11, <4.0"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"


### PR DESCRIPTION
## v0.10.0

本机安装优化版。版本 bump + 文档同步。

### Changes since v0.9.0（8 commits，PR #126-128）

**安装与依赖**
- ⚡ **uv 迁移**（PR #126）：install 脚本换 uv，安装时间分钟级 → ~30 秒；`requires-python` 3.10 → 3.11（browser-use 约束）
- 📦 **依赖按需拆分**（PR #127）：移除死依赖（browser-use / langchain-openai）；chromadb → 可选 `[memory]` extra，语义记忆需 `pip install -e ".[memory]"`
- 🧭 **setup 向导打磨**（PR #128）：必填/可选分组、完成清单、确定性 y/N 决策

**测试**：375 → 377 passed。

### 相关
- 设计文档：`docs/DEPLOYMENT.md`（本机安装优化路线全完成）
