### PR TITLE
fix(install): correct install script paths — PROJECT_DIR = repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 
 ```bash
 # macOS / Linux
-git clone https://github.com/kuan-er/sjtu-agent.git && cd sjtu-agent && bash install.sh
+git clone https://github.com/kuan-er/sjtu-agent.git && cd sjtu-agent && bash install/install.sh
 
 # Windows PowerShell
-git clone https://github.com/kuan-er/sjtu-agent.git; cd sjtu-agent; powershell -ExecutionPolicy Bypass -File .\install.ps1
+git clone https://github.com/kuan-er/sjtu-agent.git; cd sjtu-agent; powershell -ExecutionPolicy Bypass -File .\install\install.ps1
 ```
 
 安装脚本自动创建 `.venv`、安装依赖和 Playwright Chromium，然后启动 `sjtu-agent setup`。setup 向导引导你配置大模型 API，依次保存校园平台凭据、自动创建 Canvas Token、从 Chrome 导入 Cookie。
@@ -25,8 +25,8 @@ git clone https://github.com/kuan-er/sjtu-agent.git; cd sjtu-agent; powershell -
 **安装选项：**
 
 ```bash
-bash install.sh --no-setup          # 只安装，不进入 setup
-bash install.sh --skip-playwright   # 跳过 Chromium
+bash install/install.sh --no-setup          # 只安装，不进入 setup
+bash install/install.sh --skip-playwright   # 跳过 Chromium
 ```
 
 **手动安装：**

--- a/README_EN.md
+++ b/README_EN.md
@@ -15,13 +15,13 @@ If this project helps you, please consider giving it a ⭐ Star!
 macOS / Linux:
 
 ```bash
-git clone https://github.com/kuan-er/sjtu-agent.git && cd sjtu-agent && bash install.sh
+git clone https://github.com/kuan-er/sjtu-agent.git && cd sjtu-agent && bash install/install.sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-git clone https://github.com/kuan-er/sjtu-agent.git; cd sjtu-agent; powershell -ExecutionPolicy Bypass -File .\install.ps1
+git clone https://github.com/kuan-er/sjtu-agent.git; cd sjtu-agent; powershell -ExecutionPolicy Bypass -File .\install\install.ps1
 ```
 
 The install script automatically creates `.venv`, installs dependencies, installs Playwright Chromium, then launches `sjtu-agent setup`.
@@ -34,14 +34,14 @@ Skip setup or Chromium:
 
 ```bash
 # macOS / Linux
-bash install.sh --no-setup
-bash install.sh --skip-playwright
+bash install/install.sh --no-setup
+bash install/install.sh --skip-playwright
 ```
 
 ```powershell
 # Windows
-.\install.ps1 -NoSetup
-.\install.ps1 -SkipPlaywright
+.\install\install.ps1 -NoSetup
+.\install\install.ps1 -SkipPlaywright
 ```
 
 Manual install:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -15,7 +15,7 @@
 
 ## 二、现状诊断（已对照代码核实）
 
-**流程**（`install/install.sh` / `install.ps1`）：
+**流程**（`install/install.sh` / `install/install.ps1`）：
 ```
 创建 .venv → pip install -e .（全量依赖）→ playwright install chromium → 启动 setup 向导
 ```

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -111,7 +111,8 @@ if ($Help) {
 }
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$ProjectDir = $ScriptDir
+# 脚本在 install\ 下，项目根目录是它的父目录
+$ProjectDir = Split-Path -Parent $ScriptDir
 
 if (-not (Test-Path (Join-Path $ProjectDir "pyproject.toml"))) {
     throw "Please run this script from the repository root directory."

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,7 +3,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-PROJECT_DIR="$SCRIPT_DIR"
+# 脚本在 install/ 下，项目根目录是它的父目录
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 PYTHON_CMD="python3"
 INSTALL_PLAYWRIGHT=1
 RUN_SETUP=1

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,27 @@
+"""Regression tests for install script path handling."""
+
+from pathlib import Path
+
+
+def test_install_sh_project_dir_is_parent():
+    """install.sh 的 PROJECT_DIR 应为脚本目录的父目录（仓库根）。
+
+    bug: 曾把 SCRIPT_DIR（install/）当项目根，导致 pyproject.toml 检查失败。
+    """
+    script = Path("install/install.sh").read_text(encoding="utf-8")
+    assert 'PROJECT_DIR="$(dirname "$SCRIPT_DIR")"' in script
+    assert 'PROJECT_DIR="$SCRIPT_DIR"' not in script
+
+
+def test_install_ps1_project_dir_is_parent():
+    script = Path("install/install.ps1").read_text(encoding="utf-8")
+    assert "$ProjectDir = Split-Path -Parent $ScriptDir" in script
+    assert "$ProjectDir = $ScriptDir" not in script
+
+
+def test_readme_uses_install_prefix():
+    """README 安装命令应为 install/install.sh / install\install.ps1。"""
+    readme = Path("README.md").read_text(encoding="utf-8")
+    assert "bash install/install.sh" in readme
+    assert ".\install\install.ps1" in readme
+    assert "bash install.sh" not in readme.replace("bash install/install.sh", "")


### PR DESCRIPTION
## 概述

修复安装脚本路径 bug（发现于 v0.10.0 发布后）。

### Bug
- README 写 `bash install.sh`（仓库根），但脚本实际在 `install/install.sh`
- `install.sh` / `install.ps1` 把脚本所在目录（`install/`）当作项目根 → 从仓库根运行时 `pyproject.toml` 检查失败

### 修复
- `install.sh`：`PROJECT_DIR = dirname(SCRIPT_DIR)`（仓库根）
- `install.ps1`：`ProjectDir = parent of ScriptDir`
- `README` / `README_EN` / `DEPLOYMENT`：命令路径改为 `install/install.sh` / `.\install\install.ps1`

### 测试
- +3 回归（脚本路径逻辑、README 前缀）；全量 **381 passed**
