### PR TITLE
feat: daemon resync, server deployment docs, and water source auth fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,41 @@
+name: 🐛 Bug 报告
+description: 提交一个可复现的 bug
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        提交前请先查看 [docs/TROUBLESHOOTING.md](https://github.com/kuan-er/sjtu-agent/blob/main/docs/TROUBLESHOOTING.md) 和已有 issue，避免重复。
+  - type: input
+    id: version
+    attributes:
+      label: 版本 / 平台
+      placeholder: 例如 v0.10.0 / Windows 11 / macOS 15
+    validations:
+      required: true
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: 发生了什么
+      description: 描述期望行为与实际行为
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤
+      placeholder: "1. 运行 ...\n2. 看到 ..."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 报错
+      description: 请粘贴 `sjtu-agent doctor` 输出或相关日志。日志文件在运行时数据目录的 `logs/` 下。注意脱敏，不要粘贴 API Key、密码、token。
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: 补充信息
+      description: 是否重装过、是否移动过项目目录、是否使用 psmux/Task Scheduler 等

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 水源社区讨论帖
+    url: https://shuiyuan.sjtu.edu.cn/t/topic/471260
+    about: 非 bug 的交流可以先到水源社区帖子下讨论
+  - name: 📖 排错手册
+    url: https://github.com/kuan-er/sjtu-agent/blob/main/docs/TROUBLESHOOTING.md
+    about: 提 issue 前请先查看常见问题排错手册

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,25 @@
+name: 📚 文档改进
+description: 建议补充或修正文档
+title: "docs: "
+labels: ["documentation", "good first issue"]
+body:
+  - type: textarea
+    id: where
+    attributes:
+      label: 涉及哪部分文档
+      placeholder: 例如 README、docs/TROUBLESHOOTING.md、docs/DEPLOYMENT.md
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: 希望补充/修改什么
+      description: 可以附上你已经验证过的命令、截图或参考链接
+    validations:
+      required: true
+  - type: checkboxes
+    id: willing_to_pr
+    attributes:
+      label: 是否愿意直接提交 PR
+      options:
+        - label: 我可以帮忙写这份文档

--- a/.github/ISSUE_TEMPLATE/troubleshooting-help.yml
+++ b/.github/ISSUE_TEMPLATE/troubleshooting-help.yml
@@ -1,0 +1,46 @@
+name: 🩺 排错求助
+description: 按排错手册排查后仍未解决，请求帮助
+title: "help: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请先按 [docs/TROUBLESHOOTING.md](https://github.com/kuan-er/sjtu-agent/blob/main/docs/TROUBLESHOOTING.md) 排查。描述越具体，解决越快。
+  - type: input
+    id: platform
+    attributes:
+      label: 操作系统
+      placeholder: 例如 Windows 11 / Ubuntu 24.04 / macOS 15
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: 问题领域
+      options:
+        - 安装 / 更新
+        - 后台服务（Task Scheduler / psmux / launchd / systemd）
+        - 大模型 API / setup
+        - jAccount / 水源授权
+        - 飞书 Bot
+        - Telegram Bot
+        - 微信 / QQ Bot
+        - DDL / Canvas / 日报
+        - Web UI
+        - 其他
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: 已做过的排查与现象
+      placeholder: "运行了什么命令，期望什么，实际看到什么"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / doctor 输出
+      description: 注意脱敏，不要粘贴凭据。
+      render: shell

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,7 @@ sessions/
 # Local runtime test artifacts
 .test_runtime_manual/
 .test_runtime_other/
+.test_runtime_pytest*/
+.test_pytest_tmp*/
+zztest_*/
 .chroma_test/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## Unreleased
+- 🔁 后台服务安装清单（`.daemon_manifest.json`）：安装脚本 / `sjtu-agent update` 自动恢复此前安装的 Task Scheduler / psmux / launchd / systemd 服务，重装后无需手动重新配置
+- 🧰 新增 `sjtu-agent daemons status / uninstall / resync`
+- 🌐 Web UI 新增 `--host`（服务器可监听 0.0.0.0）
+- 🐧 systemd 补齐 `web`、`news-digest`、`aihot-push` 服务，并修正早报/午报时间
+- 💧 水源授权优先复用仍有效的 session cookie，登录后校验当前用户，减少异地登录触发
+- 📚 新增排错手册、服务器部署指南和 GitHub Issue 模板
+
 ## v0.10.0 (2026-08-09)
 - ⚡ **uv 迁移**：install 脚本换 uv，安装时间从分钟级降到 ~30 秒（数量级提升）
 - 📦 **依赖按需拆分**：移除死依赖（browser-use / langchain-openai）；语义记忆（chromadb）改为可选 extra `[memory]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ type: scope — 描述
 ## 测试
 
 ```bash
-pytest tests/ -q           # 全量（当前 287 个）
+pytest tests/ -q           # 全量
 pytest tests/test_dining.py -q   # 单文件
 pytest -k "test_name"      # 按名称筛选
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 面向上海交通大学学生的校园助手，提供终端对话、飞书 / Telegram / 微信 / QQ Bot、DDL 聚合、日报推送和 MCP Server。
 
-[English Version](README_EN.md) · [项目展示页](https://kuan-er.github.io/sjtu-agent)
+[English Version](README_EN.md) · [项目展示页](https://kuan-er.github.io/sjtu-agent) · [排错手册](docs/TROUBLESHOOTING.md) · [服务器部署](docs/SERVER_DEPLOYMENT.md)
 
 如果这个项目对你有帮助，欢迎点一个 ⭐ Star！
 
@@ -246,7 +246,7 @@ sjtu-agent install-parse-backends --backend whisper
 |------|------|
 | macOS | `~/Library/Application Support/sjtu-agent` |
 | Linux | `~/.local/share/sjtu-agent` |
-| Windows | `%APPDATA%/sjtu-agent` |
+| Windows | 以 `sjtu-agent doctor` 输出为准（通常为 `%LOCALAPPDATA%\sjtu-agent\sjtu-agent`） |
 
 三个核心文件：
 
@@ -289,6 +289,8 @@ sjtu-agent install-daemons --services daily-report remind-check
 
 ```powershell
 sjtu-agent install-daemons
+sjtu-agent daemons status      # 查看已安装服务
+sjtu-agent daemons uninstall   # 卸载全部服务
 ```
 
 **psmux**（适合常驻进程，无弹窗）：
@@ -300,11 +302,16 @@ sjtu-agent install-daemons --backend psmux --services feishu-bot telegram-bot
 
 飞书 Bot 还提供桌面 GUI 启动器：双击 `install\launch-feishu.bat` 即可。
 
+> 后台服务安装记录保存在运行时数据目录的 `.daemon_manifest.json`。重新安装、移动目录或重建 `.venv` 后，安装脚本和 `sjtu-agent update` 会自动执行 `sjtu-agent daemons resync` 恢复服务，无需手动重新配置。
+
 ### Linux (systemd)
 
 ```bash
+loginctl enable-linger "$USER"   # 登出后继续运行（一次性设置）
 sjtu-agent install-daemons
 ```
+
+服务器 24/7 部署完整步骤见 [docs/SERVER_DEPLOYMENT.md](docs/SERVER_DEPLOYMENT.md)。
 
 ---
 
@@ -324,6 +331,10 @@ sjtu-agent install-daemons
 ### QQ Bot
 
 登录 [q.qq.com](https://q.qq.com/qqbot/openclaw/) 创建机器人获取 AppID / AppSecret → 对话中让 Agent 调用 `setup_qq` → `sjtu-agent qq-bot` 启动。
+
+### 水源社区
+
+在对话中对 Agent 说「配置水源」即可授权。当前版本使用 session cookie 方案（旧 User API Key 流程已废弃）；如遇异地登录 / 二次验证，或需要手动导出 cookie，见 [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,6 +6,8 @@ A campus assistant for Shanghai Jiao Tong University students, offering terminal
 
 中文文档: [README.md](README.md)
 
+Docs: [Troubleshooting](docs/TROUBLESHOOTING.md) · [Server Deployment](docs/SERVER_DEPLOYMENT.md)
+
 👉 **[Project Showcase](https://kuan-er.github.io/sjtu-agent)**
 
 If this project helps you, please consider giving it a ⭐ Star!
@@ -205,9 +207,13 @@ Windows offers two backend options: **Task Scheduler** (default, for scheduled t
 
 ```powershell
 sjtu-agent install-daemons
+sjtu-agent daemons status      # inspect installed services
+sjtu-agent daemons uninstall   # remove all services
 ```
 
 Daily report at 22:00 + reminder check every 60s + Canvas course monitoring + Telegram/Feishu/WeChat/QQ Bots at logon + Web UI.
+
+> Service installations are recorded in `.daemon_manifest.json` under the runtime data directory. Re-running the installer, moving the repo, or rebuilding `.venv` will automatically run `sjtu-agent daemons resync`, so you no longer need to reconfigure Task Scheduler / psmux manually after a reinstall.
 
 ### psmux for Persistent Processes
 
@@ -554,7 +560,7 @@ Runtime files are stored in platform-specific user data directories, not the rep
 
 - macOS: `~/Library/Application Support/sjtu-agent`
 - Linux: `${XDG_DATA_HOME:-~/.local/share}/sjtu-agent`
-- Windows: `%APPDATA%/sjtu-agent`
+- Windows: see `sjtu-agent doctor` (usually `%LOCALAPPDATA%\sjtu-agent\sjtu-agent`)
 
 Legacy files in the repo root are auto-migrated on first import.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -58,7 +58,7 @@ setup 已按"只问一项"推进。进一步：
 
 ### 非目标（附录：未来延伸）
 
-服务器 24/7 部署（uv+systemd / Docker）不在当前范围。研究结论：Docker 对本项目（单 Python 代码库）偏重，uv+systemd 是更贴的轻量路径；真正的卡点是**头无化 setup + 登录/扫码服务器化**——留待资源充足时再做。
+Docker 部署不在当前范围。研究结论：Docker 对本项目（单 Python 代码库）偏重，uv+systemd 是更贴的轻量路径。**轻量服务器部署（Linux + systemd 用户单元）已提供**，见 [SERVER_DEPLOYMENT.md](SERVER_DEPLOYMENT.md)；剩余卡点是**完全无交互的 jAccount 登录 / 微信扫码服务器化**——登录态仍建议本机配置后同步到服务器。
 
 ## 四、分阶段实施路线
 

--- a/docs/SERVER_DEPLOYMENT.md
+++ b/docs/SERVER_DEPLOYMENT.md
@@ -1,0 +1,137 @@
+# 服务器部署指南（Linux systemd，轻量版）
+
+> 目标：在一台不关机的 Linux 服务器上运行飞书 / Telegram Bot 和定时报告。
+> 当前不推荐 Docker：本项目是单 Python 代码库，`uv + systemd` 更轻、更好排查。
+
+## 0. 适用与不适用
+
+**适合**：
+
+- 飞书 Bot（WebSocket 长连接）
+- Telegram Bot（长轮询）
+- daily-report / remind-check / email-watcher / canvas-watcher / news-digest / aihot-push 等定时任务
+- `sjtu-agent web --host 0.0.0.0` 远程配置页（需自行加 HTTPS 反代）
+
+**暂时不适合 / 需要手工处理**：
+
+- 微信 Bot：需要扫码登录，建议首次在本地完成，再复制配置到服务器
+- 首次在服务器上登录 jAccount：容易触发异地 / 二次验证。建议**先在本地完成配置，再把运行时数据目录复制到服务器**
+- QQ Bot 在服务器上通常可用，但同样建议先本地配置好凭据
+
+## 1. 安装
+
+Ubuntu / Debian 示例：
+
+```bash
+sudo apt update
+sudo apt install -y git python3 python3-venv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# 重新登录，或 export PATH="$HOME/.local/bin:$PATH"
+
+git clone https://github.com/kuan-er/sjtu-agent.git
+cd sjtu-agent
+bash install/install.sh --no-setup --skip-playwright
+```
+
+解释：
+
+- `--no-setup`：服务器上不走交互向导，配置手工写入或从本机复制。
+- `--skip-playwright`：暂时不需要自动登录；之后需要刷新 cookie 时再 `uv run playwright install chromium`（或在有桌面依赖的机器上安装）。
+
+## 2. 准备配置（推荐：从本机复制）
+
+在**你平时使用的电脑**上跑通一次 setup 后，把运行时数据目录整个复制到服务器：
+
+```bash
+# 本机（macOS 示例）
+scp -r ~/Library/Application\ Support/sjtu-agent user@server:.sjtu-agent-local
+
+# 服务器
+mkdir -p ~/.local/share
+mv ~/.sjtu-agent-local ~/.local/share/sjtu-agent
+chmod 700 ~/.local/share/sjtu-agent
+```
+
+默认路径：
+
+| 平台 | 路径 |
+| --- | --- |
+| Linux 服务器 | `~/.local/share/sjtu-agent` |
+| 自定义 | 设置 `SJTU_AGENT_HOME=/opt/sjtu-agent` |
+
+如果服务器和本机用同一套路径，`scp` 时注意不要覆盖服务器上已有的配置。也可以只复制三个核心文件：
+
+- `config.json`：平台 Token、Bot 凭据、Cookie
+- `.env`：jAccount、LLM API Key
+- `agent_config.json`：大模型配置
+
+## 3. 无交互检查
+
+```bash
+sjtu-agent doctor
+sjtu-agent daily-report --test
+sjtu-agent feishu-bot -- --test   # 若配置了飞书
+```
+
+配置缺失时再补；不建议在服务器直接跑完整交互 setup。
+
+## 4. 安装 systemd 用户服务
+
+```bash
+# 关键：用户级服务在登出后继续运行
+loginctl enable-linger "$USER"
+
+# 安装需要的服务，而不是全部
+sjtu-agent install-daemons --services feishu-bot telegram-bot daily-report remind-check news-digest
+
+# 查看
+sjtu-agent daemons status
+systemctl --user status 'sjtu-agent-*'
+```
+
+服务定义在 `~/.config/systemd/user/sjtu-agent-*.service` 和 `*.timer`。日志：
+
+```bash
+journalctl --user -u sjtu-agent-feishu-bot -n 100 -f
+tail -f ~/.local/share/sjtu-agent/logs/feishu_bot.systemd.log
+```
+
+## 5. 更新
+
+```bash
+sjtu-agent update
+```
+
+更新工具会读取后台服务清单，自动停止旧服务、更新代码、按原参数恢复。如果目录发生移动或手动重装：
+
+```bash
+sjtu-agent daemons resync
+```
+
+## 6. 远程 Web 配置页（可选）
+
+Web UI 默认只监听 `127.0.0.1`。服务器上有两种安全打开方式：
+
+### 方式 A：SSH 隧道（推荐）
+
+```bash
+ssh -L 7860:127.0.0.1:7860 user@server
+sjtu-agent web --no-browser          # 在服务器执行
+```
+
+本机浏览器访问 `http://127.0.0.1:7860`。
+
+### 方式 B：监听网卡 + HTTPS 反代
+
+```bash
+sjtu-agent web --host 0.0.0.0 --port 7860 --no-browser
+```
+
+然后用 Nginx / Caddy 反代到 `https://你的域名`。**不要**把带明文 HTTP 的 `0.0.0.0:7860` 直接暴露到公网；Web UI 的访问令牌走 Cookie，明文传输会被窃取。
+
+## 7. 已知限制与建议
+
+- jAccount 风控：服务器 IP 登录校园平台可能触发异地登录。优先复用本机复制的 Cookie；失效后在本地刷新再同步，或手动在服务器上完成一次带二次验证的登录。
+- Canvas / AI 好课 / phycai 的自动登录依赖 Playwright Chromium；无桌面 Linux 也能 headless 运行，但要先装系统依赖（`playwright install --with-deps chromium`）。
+- 微信 Bot 建议保持本地运行；如必须上服务器，先本地扫码保存 token，再复制配置并启动。
+- `SJTU_AGENT_HOME` 可把数据目录放到独立磁盘；设置后所有 CLI 和 systemd 服务必须能看到同一个值（systemd 用户环境可用 `systemctl --user set-environment SJTU_AGENT_HOME=/opt/sjtu-agent`）。

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,243 @@
+# SJTU Agent 排错手册
+
+这是一份通用排错手册。如果这里没有解决你的问题，请按仓库中的 Issue 模板提交求助；如果你解决了新问题，欢迎直接提 PR 把经验补进来。
+
+> 安全提醒：日志和截图不要包含 API Key、jAccount 密码、Token、Cookie 等敏感信息。
+
+## 0. 先做三件事
+
+```bash
+sjtu-agent doctor          # 检查运行时路径和配置状态
+sjtu-agent --version       # 确认版本
+sjtu-agent daemons status  # 检查后台服务（可选，见下文）
+```
+
+`doctor` 会输出运行时数据目录。日志统一位于：
+
+| 平台 | 日志目录 |
+| --- | --- |
+| macOS | `~/Library/Application Support/sjtu-agent/logs/` |
+| Linux | `~/.local/share/sjtu-agent/logs/` |
+| Windows | `%LOCALAPPDATA%\sjtu-agent\sjtu-agent\logs\`（以 `sjtu-agent doctor` 输出为准） |
+
+没有 `sjtu-agent` 命令时，先看 [安装 / PATH 问题](#安装--path-问题)。
+
+---
+
+## 1. 安装 / PATH 问题
+
+### 装完提示 `sjtu-agent` 不是可识别的命令
+
+- 关闭并重新打开终端（PATH 更新不会进入已打开的终端）。
+- 或直接用绝对路径运行：
+
+```powershell
+# Windows PowerShell
+.\.venv\Scripts\python.exe -m sjtu_agent
+```
+
+```bash
+# macOS / Linux
+.venv/bin/python -m sjtu_agent
+```
+
+### 安装慢 / 依赖失败
+
+- 安装脚本默认使用 `uv`。Windows 可先 `winget install astral-sh.uv`；macOS / Linux 可 `curl -LsSf https://astral.sh/uv/install.sh | sh`。
+- 网络不稳时 Chromium 容易失败，可以跳过后补装：
+
+```bash
+bash install/install.sh --skip-playwright
+python -m playwright install chromium
+```
+
+### 更新后模块报错 `ModuleNotFoundError`
+
+`sjtu-agent update` 会自动停止并恢复此前安装的后台服务。如果仍报错，运行：
+
+```bash
+sjtu-agent update --skip-git   # 只重装包
+sjtu-agent daemons resync      # 按清单恢复后台服务
+```
+
+---
+
+## 2. Windows 后台服务（Task Scheduler / psmux）
+
+### 为什么重装后要重新配置后台服务？
+
+Windows 任务计划里保存的是**绝对路径**：
+
+```text
+<项目目录>\.venv\Scripts\pythonw.exe -m sjtu_agent <服务名>
+```
+
+重新 clone、移动项目目录、重建 `.venv` 后，旧任务指向的路径会失效，因此需要重新注册。
+
+新版项目会把安装记录写到运行时数据目录的 `.daemon_manifest.json`。重新运行 `install.ps1` 或 `sjtu-agent update` 时会自动执行 `daemons resync`，无需再手动 `install-daemons`。手动触发：
+
+```powershell
+sjtu-agent daemons resync
+```
+
+### 查看 / 卸载后台服务
+
+```powershell
+sjtu-agent daemons status
+sjtu-agent daemons status --services feishu-bot daily-report
+sjtu-agent daemons uninstall
+sjtu-agent daemons uninstall --services feishu-bot
+```
+
+### Task Scheduler 任务存在但 Bot 不运行
+
+1. 确认任务没有指向旧路径：
+   ```powershell
+   schtasks /Query /TN SJTUAgent-FeishuBot /V /FO LIST
+   ```
+2. 看日志：`%LOCALAPPDATA%\sjtu-agent\sjtu-agent\logs\feishu_bot.task.log`（以 `sjtu-agent doctor` 输出为准）。
+3. 路径变了直接重新安装：
+   ```powershell
+   sjtu-agent install-daemons --services feishu-bot
+   ```
+
+### psmux 会话丢失
+
+psmux 会话依赖 psmux 服务端进程存活；机器重启后 psmux 不保证自动恢复所有会话。重新执行：
+
+```powershell
+winget install psmux
+sjtu-agent install-daemons --backend psmux --services feishu-bot
+```
+
+### 为什么 install-daemons 会删除未选择的其他服务？
+
+`install-daemons --services ...` 的语义是“让后台服务集合等于你指定的集合”。想保留全部就直接 `sjtu-agent install-daemons`；只想调整一个服务时，使用完整集合或 `daemons status` 确认清单。
+
+---
+
+## 3. macOS / Linux 后台服务
+
+### macOS launchd
+
+```bash
+sjtu-agent install-daemons
+sjtu-agent daemons status
+sjtu-agent daemons uninstall
+```
+
+plist 文件在 `~/Library/LaunchAgents/`，日志在运行时数据目录 `logs/`。
+
+### Linux systemd
+
+```bash
+systemctl --user status 'sjtu-agent-*'
+journalctl --user -u sjtu-agent-feishu-bot -n 100
+```
+
+**如果机器重启后 Bot 没有自动启动**：用户级 systemd 服务默认随登录会话结束而停止，需要启用 linger：
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+完整服务器部署步骤见 [docs/SERVER_DEPLOYMENT.md](SERVER_DEPLOYMENT.md)。
+
+---
+
+## 4. 水源社区授权
+
+### 现状：优先用 session cookie，不再强求 User API Key
+
+当前版本（v0.10.0+）的“配置水源”已经改为：用 Playwright 登录水源 → 校验登录态 → 保存 `shuiyuan_cookies`。新闻聚合和水源搜索会自动使用 cookie。
+
+旧仓库中的 `get_shiyuan_api.py` 是早期 User API Key 方案的参考实现，**没有接入主流程**。所以现在不需要再纠结“User API Key 授权窗口弹不出来”了。
+
+### 反复报异地登录 / 二次验证
+
+常见原因：
+
+- jAccount 把无头浏览器 / 服务器 IP 判定为异地登录，触发交我办 / 邮箱 / 手机验证。
+- 项目会先复用已保存的 `shuiyuan_cookies`，只有在失效时才重新登录；如果你每次都被要求重新登录，说明 cookie 没有保存成功或被风控拦截。
+
+建议按顺序尝试：
+
+1. 先在本机浏览器登录一次 [水源社区](https://shuiyuan.sjtu.edu.cn)。
+2. 对 Agent 说「配置水源」，让它先复用已有 session；不要从服务器 IP 首次登录。
+3. 本机自动化失败时，手动导出 cookie（见下节）。
+4. 服务器部署时，优先把本机已经配好的 `config.json` 复制到服务器，而不是让服务器去登录 jAccount。
+
+### 手动导出水源 cookie（兜底方案）
+
+1. 用 Chrome / Edge 登录 `shuiyuan.sjtu.edu.cn`。
+2. 打开 DevTools（F12）→ Network → 刷新页面 → 点任意 `shuiyuan.sjtu.edu.cn` 请求 → Headers → Request Headers → 复制整个 `Cookie:` 值。
+3. 填入运行时 `config.json`：
+
+```json
+{
+  "shuiyuan_cookies": {
+    "_forum_session": "从 Cookie 中复制 _forum_session= 后面的值",
+    "_t": "从 Cookie 中复制 _t= 后面的值"
+  }
+}
+```
+
+也可以直接保存一个 `shuiyuan_cookies` 对象，字段名与 cookie 名保持一致。之后搜索和新闻聚合会自动携带。
+
+### 如何验证 cookie 是否有效
+
+```bash
+curl -s -H "Cookie: _forum_session=...; _t=..." \
+  https://shuiyuan.sjtu.edu.cn/session/current.json
+```
+
+返回 JSON 中有 `current_user` 即有效；`"current_user": null` 表示已失效。
+
+---
+
+## 5. jAccount 验证码 / 二次验证
+
+- 项目会自动尝试图形验证码识别（极客协会 API → Claude 视觉 → 手动输入）。
+- 如果出现“交我办 / 邮箱 / 手机”三选一，脚本无法自动完成，需要在浏览器手动登录一次。
+- 服务器上首次登录 jAccount 很容易触发异地风控，建议采用“本机配置 → 复制运行时数据目录到服务器”的方式。
+
+---
+
+## 6. Playwright Chromium
+
+```bash
+python -m playwright install chromium
+sjtu-agent doctor
+```
+
+Windows 若下载超时，可以设置代理后重试，或从安装脚本加 `-SkipPlaywright` 跳过。
+
+---
+
+## 7. 飞书 Bot
+
+飞书专属排查见 [docs/feishu-bot-troubleshooting.md](feishu-bot-troubleshooting.md)。
+
+---
+
+## 8. 其他常见问题
+
+### 配置到底存在哪里？
+
+见 `sjtu-agent doctor` 输出的路径。默认：
+
+| 平台 | 运行时数据目录 |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\sjtu-agent\sjtu-agent`（以 `sjtu-agent doctor` 输出为准） |
+| macOS | `~/Library/Application Support/sjtu-agent` |
+| Linux | `~/.local/share/sjtu-agent` |
+
+核心文件：`config.json`（平台凭据）、`.env`（jAccount / API Key）、`agent_config.json`（LLM 配置）。
+
+### 重装后配置还在吗？
+
+运行时数据目录独立于代码仓库，普通重装不会删除。只有手动删除该目录或更换用户才会丢配置。项目目录移动后，Windows 后台服务需要 `sjtu-agent daemons resync`（安装脚本会自动做）。
+
+### 仍然无法解决？
+
+到 [GitHub Issues](https://github.com/kuan-er/sjtu-agent/issues) 用对应模板提交，附上脱敏后的 `sjtu-agent doctor` 输出和 `logs/` 中相关日志。

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -208,10 +208,24 @@ if ($CurrentUserPath -notlike "*$VenvScripts*") {
     Write-Host "$VenvScripts is already in PATH."
 }
 
+# 安装/重建 venv 后，按之前的安装清单自动恢复后台服务（Task Scheduler / psmux）。
+# 若项目目录或 Python 路径没有变化，resync 会直接跳过。
+function Invoke-DaemonResync {
+    Write-Log "Restoring previously installed background services"
+    & $VenvPython -m sjtu_agent daemons resync *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  (background service resync skipped or failed; run 'sjtu-agent install-daemons' manually if needed.)"
+    }
+    else {
+        Write-Host "  (background services are up to date, or were restored from the install manifest.)"
+    }
+}
+
 if (-not $NoSetup) {
     Write-Log "Launching sjtu-agent setup"
     & $VenvPython -m sjtu_agent setup
     $SetupExit = $LASTEXITCODE
+    Invoke-DaemonResync
     Write-Host ""
     Write-Host "=========================================="
     Write-Host "If 'sjtu-agent' is not recognized in a new terminal,"
@@ -223,6 +237,7 @@ if (-not $NoSetup) {
     exit $SetupExit
 }
 
+Invoke-DaemonResync
 Write-Host ""
 Write-Host "Installation complete."
 Write-Host ""

--- a/install/install.sh
+++ b/install/install.sh
@@ -139,9 +139,26 @@ if [[ $ADDED_TO_RC -eq 0 ]]; then
   echo "  $EXPORT_LINE"
 fi
 
+SETUP_EXIT=0
 if [[ $RUN_SETUP -eq 1 ]]; then
   log "启动 sjtu-agent setup"
-  exec "$VENV_BIN/sjtu-agent" setup
+  set +e
+  "$VENV_BIN/sjtu-agent" setup
+  SETUP_EXIT=$?
+  set -e
+fi
+
+# 安装/重建 venv 后，按之前的安装清单自动恢复后台服务（launchd / systemd）。
+# 若项目目录或 Python 路径没有变化，resync 会直接跳过。
+log "恢复此前安装过的后台服务"
+if "$VENV_PY" -m sjtu_agent daemons resync >/dev/null 2>&1; then
+  log "后台服务已是最新，或已从安装清单自动恢复。"
+else
+  log "后台服务恢复跳过或失败；如需安装请运行 sjtu-agent install-daemons"
+fi
+
+if [[ $SETUP_EXIT -ne 0 ]]; then
+  exit "$SETUP_EXIT"
 fi
 
 cat <<EOF

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -1608,16 +1608,54 @@ def tool_setup_canvas(open_browser: bool = True, auto_create: bool = False, toke
     }
 
 
+def _cookies_header(cookies: dict) -> str:
+    return "; ".join(f"{k}={v}" for k, v in (cookies or {}).items())
+
+
+def _shuiyuan_session_is_valid(cookies: dict) -> bool:
+    """用 Discourse 当前用户接口验证 shuiyuan session cookie 是否仍登录。"""
+    if not cookies:
+        return False
+    try:
+        r = requests.get(
+            "https://shuiyuan.sjtu.edu.cn/session/current.json",
+            headers={
+                "Cookie": _cookies_header(cookies),
+                "User-Agent": "Mozilla/5.0",
+                "Accept": "application/json",
+            },
+            timeout=10,
+        )
+        if r.status_code != 200:
+            return False
+        data = r.json()
+        return bool(data.get("current_user"))
+    except Exception:
+        return False
+
+
 def tool_setup_shuiyuan() -> dict:
-    """用 Playwright 登录水源社区，保存 session cookie（User API Key 方案已废弃）。"""
-    username = os.environ.get("JACCOUNT_USERNAME", "").strip()
-    password = os.environ.get("JACCOUNT_PASSWORD", "").strip()
+    """授权水源社区：优先复用已保存且仍有效的 session cookie。
+
+    User API Key 方案已废弃，当前方案为 Playwright 登录后保存 session cookie。
+    每次调用前先验证旧 cookie，避免无谓登录触发 jAccount 异地登录风控。
+    """
     cfg = {}
     if CONFIG_PATH.exists():
         try:
             cfg = json.loads(CONFIG_PATH.read_text())
         except Exception:
             pass
+
+    existing = cfg.get("shuiyuan_cookies") or {}
+    if _shuiyuan_session_is_valid(existing):
+        return {
+            "success": True,
+            "message": "水源社区 session 仍然有效，已跳过重新登录。",
+        }
+
+    username = os.environ.get("JACCOUNT_USERNAME", "").strip()
+    password = os.environ.get("JACCOUNT_PASSWORD", "").strip()
 
     if not username and not cfg.get("jaccount_cookies"):
         return {
@@ -1698,9 +1736,16 @@ def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
     if not new_session:
         return _shuiyuan_session_error("未能获取水源社区 session，请检查账号")
 
+    # 不能只看域名 cookie：即使没有登录也可能拿到游客 cookie。
+    # 必须通过 Discourse 当前用户接口确认 session 真的已登录。
+    if not _shuiyuan_session_is_valid(new_session):
+        return _shuiyuan_session_error(
+            "已拿到水源社区 cookie，但当前用户接口校验未通过（可能仍未登录）。"
+        )
+
     cfg["shuiyuan_cookies"] = new_session
     CONFIG_PATH.write_text(json.dumps(cfg, ensure_ascii=False, indent=2))
-    return {"success": True, "message": f"水源社区 session 登录成功（需定期更新）"}
+    return {"success": True, "message": "水源社区 session 登录成功（需定期更新）"}
 
 
 # ── 选课社区 course.sjtu.plus ────────────────────────────────────────────────

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -8,7 +8,15 @@ from pathlib import Path
 
 from sjtu_agent import __version__
 from sjtu_agent.paths import describe_runtime_paths
-from sjtu_agent.scheduler import available_service_names, current_platform_name, daemon_status, install_daemons, uninstall_daemons
+from sjtu_agent.scheduler import (
+    available_service_names,
+    current_platform_name,
+    daemon_status,
+    install_daemons,
+    list_deployments,
+    resync_daemons,
+    uninstall_daemons,
+)
 from sjtu_agent.setup_wizard import register_setup_parser
 from sjtu_agent.terminal_ui import print_json
 
@@ -107,19 +115,32 @@ def _cmd_update(args: argparse.Namespace) -> int:
 
     # ── 1.5 检测已安装的后台服务 ───────────────────────────────────────────
     # 后台 daemon 在 git pull + reinstall 后仍引用旧模块路径，会导致
-    # ModuleNotFoundError（issue #113）。检测到后，在更新前停止、更新后重启。
-    _installed_daemons: list[tuple[str, list[str]]] = []  # [(backend, [names])]
-    for _backend in ("taskschd", "psmux"):
-        try:
-            _st = daemon_status(backend=_backend)
-            _names = [
-                s["name"] for s in (_st.get("services") or [])
-                if isinstance(s, dict) and s.get("installed")
-            ]
-            if _names:
-                _installed_daemons.append((_backend, _names))
-        except Exception:
-            pass
+    # ModuleNotFoundError（issue #113）。从安装清单读取所有平台的部署记录，
+    # 更新前停止、更新后按原参数恢复。
+    _installed_daemons = list_deployments()
+
+    def _restore_installed_daemons() -> None:
+        """按更新前的清单重启后台服务。"""
+        for _deployment in _installed_daemons:
+            _backend = _deployment["backend"]
+            _names = _deployment["services"]
+            print(f"[i] 重启后台服务（{_backend}）: {', '.join(_names)}")
+            try:
+                kwargs: dict = {
+                    "daily_report_time": tuple(_deployment.get("daily_report_time") or (22, 0)),
+                    "remind_interval": int(_deployment.get("remind_interval") or 60),
+                    "telegram_throttle": int(_deployment.get("telegram_throttle") or 10),
+                }
+                if _deployment.get("output_dir"):
+                    kwargs["output_dir"] = Path(_deployment["output_dir"])
+                install_daemons(
+                    service_names=tuple(_names),
+                    python_executable=Path(sys.executable),
+                    backend=_backend,
+                    **kwargs,
+                )
+            except Exception as e:
+                print(f"[!] 重启后台服务失败: {e}")
 
     # ── 1. 显示待更新内容 ──────────────────────────────────────────────────
     if not args.skip_git:
@@ -179,10 +200,15 @@ def _cmd_update(args: argparse.Namespace) -> int:
 
     # ── 2. git pull ────────────────────────────────────────────────────────
     # 确认要更新后，先停后台服务（避免更新后旧模块引用报错）
-    for _backend, _names in _installed_daemons:
+    for _deployment in _installed_daemons:
+        _backend = _deployment["backend"]
+        _names = _deployment["services"]
         print(f"[i] 更新前停止后台服务（{_backend}）: {', '.join(_names)}")
         try:
-            uninstall_daemons(service_names=tuple(_names), backend=_backend)
+            kwargs: dict = {}
+            if _deployment.get("output_dir"):
+                kwargs["output_dir"] = Path(_deployment["output_dir"])
+            uninstall_daemons(service_names=tuple(_names), backend=_backend, **kwargs)
         except Exception as e:
             print(f"[!] 停止后台服务失败（可忽略）: {e}")
     if not args.skip_git:
@@ -212,6 +238,7 @@ def _cmd_update(args: argparse.Namespace) -> int:
                 print("    git log --oneline -5   # 查看本地提交")
                 print("    如有未推送的本地提交，可尝试: git pull --rebase")
                 print("    或放弃本地修改: git reset --hard origin/main")
+                _restore_installed_daemons()
                 return 1
 
     # ── 3. pip install -e . ────────────────────────────────────────────────
@@ -222,6 +249,7 @@ def _cmd_update(args: argparse.Namespace) -> int:
     result = subprocess.run(pip_cmd)
     if result.returncode != 0:
         print("[!] 依赖安装失败，请手动运行: pip install -e " + str(PROJECT_ROOT))
+        _restore_installed_daemons()
         return 1
 
     # ── 4. 可选：更新 Playwright Chromium ─────────────────────────────────
@@ -243,12 +271,7 @@ def _cmd_update(args: argparse.Namespace) -> int:
 
     # ── 5.5 重启后台服务 ──────────────────────────────────────────────────
     if _installed_daemons:
-        for _backend, _names in _installed_daemons:
-            print(f"[i] 更新后重启后台服务（{_backend}）: {', '.join(_names)}")
-            try:
-                install_daemons(service_names=tuple(_names), backend=_backend)
-            except Exception as e:
-                print(f"[!] 重启后台服务失败: {e}")
+        _restore_installed_daemons()
 
     # ── 6. 打印新版本 ────────────────────────────────────────────────────
     try:
@@ -414,7 +437,7 @@ def _cmd_manage_skill(args: argparse.Namespace) -> int:
 
 def _cmd_web(args: argparse.Namespace) -> int:
     from sjtu_agent.web.server import start
-    start(port=args.port, open_browser=not args.no_browser)
+    start(host=args.host, port=args.port, open_browser=not args.no_browser)
     return 0
 
 
@@ -471,6 +494,36 @@ def _cmd_install_daemons(args: argparse.Namespace) -> int:
             except Exception:
                 time.sleep(1)
         webbrowser.open(url)
+    return 0
+
+
+def _cmd_daemons_status(args: argparse.Namespace) -> int:
+    payload = daemon_status(
+        service_names=tuple(args.services) if args.services else None,
+        backend=args.backend,
+    )
+    print_json(payload)
+    return 0 if payload.get("all_installed", payload.get("all_running", True)) else 1
+
+
+def _cmd_daemons_uninstall(args: argparse.Namespace) -> int:
+    try:
+        payload = uninstall_daemons(
+            service_names=tuple(args.services) if args.services else None,
+            backend=args.backend,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print_json(payload)
+    return 0
+
+
+def _cmd_daemons_resync(args: argparse.Namespace) -> int:
+    payload = resync_daemons(
+        python_executable=Path(args.python_executable) if args.python_executable else None,
+    )
+    print_json(payload)
     return 0
 
 
@@ -574,6 +627,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     web_parser = subparsers.add_parser("web", help="open the local web configuration UI in your browser")
     web_parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="host/interface to bind (default: 127.0.0.1; use 0.0.0.0 for remote access)",
+    )
+    web_parser.add_argument(
         "--port",
         type=int,
         default=7860,
@@ -637,6 +695,55 @@ def build_parser() -> argparse.ArgumentParser:
         help="(Windows) 后端选择：taskschd（任务计划程序，默认）或 psmux（分离会话）",
     )
     install_daemons_parser.set_defaults(func=_cmd_install_daemons)
+
+    daemons_parser = subparsers.add_parser(
+        "daemons",
+        help="inspect, uninstall, or resync previously installed background services",
+    )
+    daemons_sub = daemons_parser.add_subparsers(dest="daemons_action", required=True)
+
+    daemons_status_parser = daemons_sub.add_parser("status", help="show background service status")
+    daemons_status_parser.add_argument(
+        "--services",
+        nargs="+",
+        choices=available_service_names(),
+        help="subset of services to query",
+    )
+    daemons_status_parser.add_argument(
+        "--backend",
+        choices=["taskschd", "psmux"],
+        default="taskschd",
+        help="(Windows) 后端选择：taskschd 或 psmux",
+    )
+    daemons_status_parser.set_defaults(func=_cmd_daemons_status)
+
+    daemons_uninstall_parser = daemons_sub.add_parser(
+        "uninstall", help="stop and uninstall background services"
+    )
+    daemons_uninstall_parser.add_argument(
+        "--services",
+        nargs="+",
+        choices=available_service_names(),
+        help="subset of services to uninstall (default: all)",
+    )
+    daemons_uninstall_parser.add_argument(
+        "--backend",
+        choices=["taskschd", "psmux"],
+        default="taskschd",
+        help="(Windows) 后端选择：taskschd 或 psmux",
+    )
+    daemons_uninstall_parser.set_defaults(func=_cmd_daemons_uninstall)
+
+    daemons_resync_parser = daemons_sub.add_parser(
+        "resync",
+        help="restore background services recorded in the install manifest after a reinstall",
+    )
+    daemons_resync_parser.add_argument(
+        "--python-executable",
+        default=None,
+        help="python executable to use (default: current interpreter)",
+    )
+    daemons_resync_parser.set_defaults(func=_cmd_daemons_resync)
 
     doctor = subparsers.add_parser("doctor", help="print runtime paths and setup status")
     doctor.set_defaults(func=_cmd_doctor)

--- a/sjtu_agent/paths.py
+++ b/sjtu_agent/paths.py
@@ -55,6 +55,7 @@ CARE_STATE_PATH       = DATA_DIR / "care_state.json"
 NEWS_HISTORY_PATH     = DATA_DIR / "news_history.json"
 CONVERSATION_LOG_PATH = DATA_DIR / "conversation_log.jsonl"
 WEB_TOKEN_PATH        = DATA_DIR / ".web_token"
+DAEMON_MANIFEST_PATH  = DATA_DIR / ".daemon_manifest.json"
 DINING_HISTORY_PATH   = DATA_DIR / "dining_history.json"
 CANTEEN_KNOWLEDGE_PATH = PACKAGE_ROOT / "data" / "canteen_knowledge.json"
 
@@ -181,6 +182,7 @@ def describe_runtime_paths() -> dict[str, str]:
         "mysjtu_catalog_path": str(MYSJTU_CATALOG_PATH),
         "schedule_cache_path": str(SCHEDULE_CACHE_PATH),
         "dining_history_path": str(DINING_HISTORY_PATH),
+        "daemon_manifest_path": str(DAEMON_MANIFEST_PATH),
         "canteen_knowledge_path": str(CANTEEN_KNOWLEDGE_PATH),
     }
 

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -10,6 +10,7 @@ sjtu_agent/scheduler — 跨平台后台守护进程调度层
   install_daemons(...)   安装并启动后台服务
   uninstall_daemons(...) 停止并卸载后台服务
   daemon_status(...)     查询后台服务状态
+  resync_daemons(...)    根据安装清单恢复后台服务
 """
 
 from __future__ import annotations
@@ -17,13 +18,31 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from sjtu_agent.paths import DAEMON_MANIFEST_PATH
+from sjtu_agent.scheduler.manifest import (
+    forget_deployment,
+    list_deployments,
+    remember_deployment,
+)
+
+
+def _platform_backend(backend: str = "taskschd") -> str:
+    """返回当前平台实际使用的后端标识（Windows 的 backend 参数透传）。"""
+    if sys.platform == "darwin":
+        return "launchd"
+    if sys.platform == "win32":
+        return "psmux" if backend == "psmux" else "taskschd"
+    if sys.platform.startswith("linux"):
+        return "systemd"
+    return backend
+
 
 def _default_service_names() -> tuple[str, ...]:
     """根据 config.json 中的推送渠道开关返回默认服务列表。"""
     from sjtu_agent.config import cfg as _cfg
     _cfg.reload_if_changed()
     cfg = _cfg.raw()
-    names = list(available_service_names()) + ["web", "news-digest"]
+    names = list(available_service_names())
     if not cfg.get("telegram_enabled", True) and "telegram-bot" in names:
         names.remove("telegram-bot")
     if not cfg.get("wechat_enabled", True) and "wechat-bot" in names:
@@ -60,10 +79,11 @@ def install_daemons(
 
     返回包含安装结果的字典。
     """
+    actual_backend = _platform_backend(backend)
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import install as _install
     elif sys.platform == "win32":
-        if backend == "psmux":
+        if actual_backend == "psmux":
             from sjtu_agent.scheduler.psmuxd import install as _install
         else:
             from sjtu_agent.scheduler.taskschd import install as _install
@@ -78,7 +98,7 @@ def install_daemons(
     if service_names is None:
         service_names = _default_service_names()
 
-    return _install(
+    result = _install(
         service_names=service_names,
         python_executable=python_executable,
         daily_report_time=daily_report_time,
@@ -87,6 +107,19 @@ def install_daemons(
         load=load,
         **platform_kwargs,
     )
+
+    # 只有真正写入/加载成功才记入清单；load=False 的 write-only 调用不记录。
+    if load:
+        remember_deployment(
+            actual_backend,
+            service_names,
+            python_executable or sys.executable,
+            daily_report_time=daily_report_time,
+            remind_interval=remind_interval,
+            telegram_throttle=telegram_throttle,
+            output_dir=platform_kwargs.get("output_dir"),
+        )
+    return result
 
 
 def uninstall_daemons(
@@ -101,10 +134,11 @@ def uninstall_daemons(
         service_names  要卸载的服务子集，默认全部
         backend        Windows 后端选择：taskschd（默认）或 psmux
     """
+    actual_backend = _platform_backend(backend)
     if sys.platform == "darwin":
         from sjtu_agent.scheduler.launchd import uninstall as _uninstall
     elif sys.platform == "win32":
-        if backend == "psmux":
+        if actual_backend == "psmux":
             from sjtu_agent.scheduler.psmuxd import uninstall as _uninstall
         else:
             from sjtu_agent.scheduler.taskschd import uninstall as _uninstall
@@ -113,7 +147,9 @@ def uninstall_daemons(
     else:
         raise RuntimeError(f"不支持的平台: {sys.platform}")
 
-    return _uninstall(service_names=service_names, **platform_kwargs)
+    result = _uninstall(service_names=service_names, **platform_kwargs)
+    forget_deployment(actual_backend, service_names)
+    return result
 
 
 def daemon_status(
@@ -144,11 +180,90 @@ def daemon_status(
     return _status(service_names=service_names, **platform_kwargs)
 
 
+def resync_daemons(python_executable: Path | None = None) -> dict:
+    """
+    根据安装清单恢复此前安装过的后台服务。
+
+    用于代码目录移动、重新 clone 或 .venv 重建之后：安装脚本和
+    `sjtu-agent update` 会调用它。只有检测到服务缺失，或记录的 Python
+    解释器路径与当前路径不同时才重新注册；其他情况不做任何改动。
+    """
+    current_py = str(python_executable or sys.executable)
+    results: list[dict] = []
+
+    for deployment in list_deployments():
+        backend = deployment["backend"]
+        service_names = tuple(deployment["services"])
+        old_py = deployment["python_executable"]
+
+        try:
+            state = daemon_status(service_names=service_names, backend=backend)
+        except Exception as exc:
+            results.append({
+                "backend": backend,
+                "services": list(service_names),
+                "resynced": False,
+                "error": f"查询状态失败：{exc}",
+            })
+            continue
+
+        all_ok = bool(state.get("all_installed", False) or state.get("all_running", False))
+        path_changed = bool(old_py) and Path(current_py).resolve() != Path(old_py).resolve()
+
+        if all_ok and not path_changed:
+            results.append({
+                "backend": backend,
+                "services": list(service_names),
+                "resynced": False,
+                "reason": "already installed",
+            })
+            continue
+
+        kwargs: dict = {
+            "daily_report_time": tuple(deployment.get("daily_report_time") or (22, 0)),
+            "remind_interval": int(deployment.get("remind_interval") or 60),
+            "telegram_throttle": int(deployment.get("telegram_throttle") or 10),
+        }
+        output_dir = deployment.get("output_dir")
+        if output_dir:
+            kwargs["output_dir"] = Path(output_dir)
+
+        try:
+            install_daemons(
+                service_names=service_names,
+                python_executable=Path(current_py),
+                backend=backend,
+                **kwargs,
+            )
+            results.append({
+                "backend": backend,
+                "services": list(service_names),
+                "resynced": True,
+                "reason": "python path changed" if path_changed else "service missing",
+            })
+        except Exception as exc:
+            results.append({
+                "backend": backend,
+                "services": list(service_names),
+                "resynced": False,
+                "error": str(exc),
+            })
+
+    return {
+        "platform": current_platform_name(),
+        "python_executable": current_py,
+        "manifest_path": str(DAEMON_MANIFEST_PATH),
+        "results": results,
+        "any_resynced": any(r.get("resynced") for r in results),
+    }
+
+
 def available_service_names() -> tuple[str, ...]:
     """返回所有可用的服务名称。"""
     return ("daily-report", "morning-report", "noon-report", "remind-check",
             "email-watcher", "canvas-watcher", "aihot-push",
-            "telegram-bot", "wechat-bot", "feishu-bot", "qq-bot")
+            "telegram-bot", "wechat-bot", "feishu-bot", "qq-bot",
+            "web", "news-digest")
 
 
 def current_platform_name() -> str:

--- a/sjtu_agent/scheduler/launchd.py
+++ b/sjtu_agent/scheduler/launchd.py
@@ -94,6 +94,13 @@ _SERVICE_SPECS = {
         "schedule_type": "none",
         "keep_alive": True,
     },
+    "aihot-push": {
+        "label": "com.sjtu.aihot-push",
+        "subcommand": "aihot-push",
+        "log": "aihot_push.launchd.log",
+        "run_at_load": False,
+        "schedule_type": "calendar",
+    },
     "news-digest": {
         "label": "com.sjtu.news-digest",
         "subcommand": "news-digest",

--- a/sjtu_agent/scheduler/manifest.py
+++ b/sjtu_agent/scheduler/manifest.py
@@ -1,0 +1,112 @@
+"""
+sjtu_agent/scheduler/manifest.py — 后台服务安装清单
+
+安装后台服务时把（后端、服务列表、Python 路径、调度参数）记到运行时数据目录，
+供安装脚本和 `sjtu-agent update` 在代码目录移动 / venv 重建后自动恢复服务，
+避免用户每次重装都要手动重新执行 install-daemons。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from sjtu_agent.paths import DAEMON_MANIFEST_PATH, atomic_write_json, read_json_safe
+
+_MANIFEST_VERSION = 1
+
+
+def _empty_manifest() -> dict[str, Any]:
+    return {"version": _MANIFEST_VERSION, "backends": {}}
+
+
+def load_manifest() -> dict[str, Any]:
+    """读取后台服务安装清单。文件缺失或损坏时返回空清单。"""
+    data = read_json_safe(DAEMON_MANIFEST_PATH, default=_empty_manifest())
+    if not isinstance(data, dict):
+        return _empty_manifest()
+    data.setdefault("version", _MANIFEST_VERSION)
+    data.setdefault("backends", {})
+    return data
+
+
+def save_manifest(manifest: dict[str, Any]) -> None:
+    manifest["version"] = _MANIFEST_VERSION
+    atomic_write_json(DAEMON_MANIFEST_PATH, manifest)
+
+
+def _normalise_services(service_names: tuple[str, ...] | list[str] | None) -> list[str]:
+    return sorted({str(name) for name in (service_names or []) if str(name)})
+
+
+def remember_deployment(
+    backend: str,
+    service_names: tuple[str, ...] | list[str],
+    python_executable: str | Path,
+    *,
+    daily_report_time: tuple[int, int] | list[int] | None = None,
+    remind_interval: int = 60,
+    telegram_throttle: int = 10,
+    output_dir: str | Path | None = None,
+) -> None:
+    """记录一次成功的后台服务安装。"""
+    services = _normalise_services(service_names)
+    if not services:
+        return
+
+    hour, minute = tuple(daily_report_time or (22, 0))
+    manifest = load_manifest()
+    backends = manifest.setdefault("backends", {})
+    backends[backend] = {
+        "services": services,
+        "python_executable": str(python_executable),
+        "daily_report_time": [int(hour), int(minute)],
+        "remind_interval": int(remind_interval or 60),
+        "telegram_throttle": int(telegram_throttle or 10),
+    }
+    if output_dir:
+        backends[backend]["output_dir"] = str(output_dir)
+    save_manifest(manifest)
+
+
+def forget_deployment(
+    backend: str,
+    service_names: tuple[str, ...] | list[str] | None = None,
+) -> None:
+    """从清单中移除服务；若后端已没有服务则移除整个后端条目。"""
+    manifest = load_manifest()
+    backends = manifest.get("backends", {})
+    entry = backends.get(backend)
+    if not entry:
+        return
+
+    if service_names is None:
+        backends.pop(backend, None)
+    else:
+        removed = set(service_names)
+        entry["services"] = [s for s in entry.get("services", []) if s not in removed]
+        if not entry["services"]:
+            backends.pop(backend, None)
+
+    manifest["backends"] = backends
+    save_manifest(manifest)
+
+
+def list_deployments() -> list[dict[str, Any]]:
+    """返回清单中的所有部署条目（用于更新前暂停 / 更新后恢复）。"""
+    deployments: list[dict[str, Any]] = []
+    for backend, entry in load_manifest().get("backends", {}).items():
+        services = _normalise_services(entry.get("services"))
+        if not services:
+            continue
+        deployments.append({
+            "backend": backend,
+            "services": services,
+            "python_executable": entry.get("python_executable", ""),
+            "daily_report_time": tuple(entry.get("daily_report_time") or (22, 0)),
+            "remind_interval": int(entry.get("remind_interval") or 60),
+            "telegram_throttle": int(entry.get("telegram_throttle") or 10),
+            "output_dir": entry.get("output_dir") or "",
+        })
+    return deployments

--- a/sjtu_agent/scheduler/psmuxd.py
+++ b/sjtu_agent/scheduler/psmuxd.py
@@ -90,6 +90,13 @@ def install(
 
     py = str(python_executable or Path(sys.executable))
     selected = set(service_names or _SERVICE_SPECS.keys())
+    unsupported = sorted(selected - set(_SERVICE_SPECS))
+    if unsupported:
+        raise RuntimeError(
+            "psmux 后端只适合常驻进程，不支持定时任务："
+            + ", ".join(unsupported)
+            + "。请改用 Task Scheduler 后端。"
+        )
     LOG_DIR.mkdir(parents=True, exist_ok=True)
 
     results: list[dict] = []

--- a/sjtu_agent/scheduler/systemd.py
+++ b/sjtu_agent/scheduler/systemd.py
@@ -34,6 +34,7 @@ _SERVICE_SPECS = {
         "restart": "no",
         "has_timer": True,
         "timer_type": "calendar",
+        "schedule_time": (8, 0),
     },
     "noon-report": {
         "unit_name": "sjtu-agent-noon-report",
@@ -42,6 +43,7 @@ _SERVICE_SPECS = {
         "restart": "no",
         "has_timer": True,
         "timer_type": "calendar",
+        "schedule_time": (12, 0),
     },
     "remind-check": {
         "unit_name": "sjtu-agent-remind-check",
@@ -99,6 +101,31 @@ _SERVICE_SPECS = {
         "has_timer": False,
         "wants_after": "network-online.target",
     },
+    "news-digest": {
+        "unit_name": "sjtu-agent-news-digest",
+        "subcommand": "news-digest",
+        "log": "news_digest.systemd.log",
+        "restart": "no",
+        "has_timer": True,
+        "timer_type": "calendar",
+        "schedule_time": (10, 0),
+    },
+    "aihot-push": {
+        "unit_name": "sjtu-agent-aihot-push",
+        "subcommand": "aihot-push",
+        "log": "aihot_push.systemd.log",
+        "restart": "no",
+        "has_timer": True,
+        "timer_type": "calendar",
+    },
+    "web": {
+        "unit_name": "sjtu-agent-web",
+        "subcommand": "web --no-browser",
+        "log": "web.systemd.log",
+        "restart": "always",
+        "has_timer": False,
+        "wants_after": "network-online.target",
+    },
 }
 
 
@@ -137,12 +164,12 @@ WantedBy=default.target
 def _write_timer_unit(
     unit_name: str,
     timer_type: str,
-    daily_report_time: tuple[int, int],
+    schedule_time: tuple[int, int],
     remind_interval: int,
 ) -> Path:
     """生成并写入 .timer 单元文件，返回文件路径。"""
     if timer_type == "calendar":
-        hour, minute = daily_report_time
+        hour, minute = schedule_time
         schedule = f"OnCalendar=*-*-* {hour:02d}:{minute:02d}:00"
     else:
         # OnUnitInactiveSec：上次运行结束后等待 N 秒再次触发
@@ -232,7 +259,7 @@ def install(
             timer_path = _write_timer_unit(
                 unit_name=unit_name,
                 timer_type=spec["timer_type"],
-                daily_report_time=daily_report_time,
+                schedule_time=spec.get("schedule_time", daily_report_time),
                 remind_interval=remind_interval,
             )
 

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -5,6 +5,7 @@ sjtu_agent/web/server.py — 本地 Web 配置界面 HTTP Server
     sjtu-agent web                # 启动后自动打开浏览器
     sjtu-agent web --port 8080    # 自定义端口
     sjtu-agent web --no-browser   # 不自动打开浏览器
+    sjtu-agent web --host 0.0.0.0 --no-browser  # 服务器监听所有网卡
 """
 
 from __future__ import annotations
@@ -1064,21 +1065,24 @@ class _Handler(BaseHTTPRequestHandler):
 
 # ── 启动入口 ──────────────────────────────────────────────────────────────────
 
-def start(port: int = 7860, open_browser: bool = True) -> None:
+def start(port: int = 7860, open_browser: bool = True, host: str = "127.0.0.1") -> None:
     global _WEB_TOKEN
     _WEB_TOKEN = _get_or_create_web_token()
 
-    server = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
-    url = f"http://127.0.0.1:{port}"
+    server = ThreadingHTTPServer((host, port), _Handler)
+    url = f"http://{host}:{port}"
     print(f"\n🌐  SJTU Agent 配置界面已启动：{url}")
     print(f"     访问令牌（自动通过 Cookie 传递）：{_WEB_TOKEN}")
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        print("     [!] 正在监听非回环地址，请勿在无 HTTPS 反代的情况下直接暴露公网。")
     print("     按 Ctrl+C 关闭\n")
 
     if open_browser:
         # 延迟 0.5s 再打开，确保 server 已就绪
+        browser_url = f"http://127.0.0.1:{port}"
         def _open():
             time.sleep(0.5)
-            webbrowser.open(url)
+            webbrowser.open(browser_url)
         threading.Thread(target=_open, daemon=True).start()
 
     try:

--- a/tests/test_scheduler_manifest.py
+++ b/tests/test_scheduler_manifest.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+
+from sjtu_agent.scheduler import manifest as manifest_module
+
+
+def _patch_manifest_path(tmp_path, monkeypatch):
+    manifest_path = tmp_path / ".daemon_manifest.json"
+    monkeypatch.setattr(manifest_module, "DAEMON_MANIFEST_PATH", manifest_path)
+    return manifest_path
+
+
+def test_manifest_remember_and_list(tmp_path, monkeypatch):
+    path = _patch_manifest_path(tmp_path, monkeypatch)
+
+    manifest_module.remember_deployment(
+        "taskschd",
+        ("feishu-bot", "daily-report"),
+        r"C:\repo\.venv\Scripts\python.exe",
+        daily_report_time=(22, 30),
+        remind_interval=120,
+    )
+
+    assert path.exists()
+    deployments = manifest_module.list_deployments()
+    assert len(deployments) == 1
+    deployment = deployments[0]
+    assert deployment["backend"] == "taskschd"
+    assert deployment["services"] == ["daily-report", "feishu-bot"]
+    assert deployment["daily_report_time"] == (22, 30)
+    assert deployment["remind_interval"] == 120
+
+
+def test_manifest_forget_services_and_backend(tmp_path, monkeypatch):
+    _patch_manifest_path(tmp_path, monkeypatch)
+
+    manifest_module.remember_deployment("psmux", ("feishu-bot", "web"), sys.executable)
+    manifest_module.forget_deployment("psmux", ("web",))
+    deployments = manifest_module.list_deployments()
+    assert deployments[0]["services"] == ["feishu-bot"]
+
+    manifest_module.forget_deployment("psmux")
+    assert manifest_module.list_deployments() == []
+
+
+def test_manifest_survives_corrupt_file(tmp_path, monkeypatch):
+    path = _patch_manifest_path(tmp_path, monkeypatch)
+    path.write_text("{not valid json", encoding="utf-8")
+
+    assert manifest_module.load_manifest() == {"version": 1, "backends": {}}

--- a/tests/test_scheduler_resync.py
+++ b/tests/test_scheduler_resync.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sjtu_agent.scheduler import resync_daemons
+
+
+def test_resync_skips_when_installed_and_path_unchanged(monkeypatch):
+    deployment = {
+        "backend": "taskschd",
+        "services": ["feishu-bot"],
+        "python_executable": Path("python").resolve(),
+        "daily_report_time": (22, 0),
+        "remind_interval": 60,
+        "telegram_throttle": 10,
+        "output_dir": "",
+    }
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [deployment])
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.daemon_status",
+        lambda **_: {"all_installed": True, "services": [{"installed": True}]},
+    )
+
+    called = []
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kwargs: called.append(kwargs) or {},
+    )
+
+    payload = resync_daemons(python_executable=deployment["python_executable"])
+    assert payload["any_resynced"] is False
+    assert called == []
+
+
+def test_resync_reinstalls_when_service_missing(monkeypatch):
+    deployment = {
+        "backend": "taskschd",
+        "services": ["feishu-bot"],
+        "python_executable": Path("python").resolve(),
+        "daily_report_time": (21, 30),
+        "remind_interval": 120,
+        "telegram_throttle": 10,
+        "output_dir": "",
+    }
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [deployment])
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.daemon_status",
+        lambda **_: {"all_installed": False, "services": [{"installed": False}]},
+    )
+
+    called = []
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kwargs: called.append(kwargs) or {},
+    )
+
+    payload = resync_daemons(python_executable=deployment["python_executable"])
+    assert payload["any_resynced"] is True
+    assert called
+    kwargs = called[0]
+    assert kwargs["service_names"] == ("feishu-bot",)
+    assert kwargs["daily_report_time"] == (21, 30)
+    assert kwargs["remind_interval"] == 120

--- a/tests/test_shuiyuan_session.py
+++ b/tests/test_shuiyuan_session.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from sjtu_agent.agent.tools import _core as core
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_session_is_valid_true(monkeypatch):
+    def fake_get(url, headers, timeout):
+        assert url == "https://shuiyuan.sjtu.edu.cn/session/current.json"
+        assert "_forum_session=abc" in headers["Cookie"]
+        return _FakeResponse(200, {"current_user": {"id": 1}})
+
+    monkeypatch.setattr(core.requests, "get", fake_get)
+    assert core._shuiyuan_session_is_valid({"_forum_session": "abc"}) is True
+
+
+def test_session_is_valid_false_when_anonymous(monkeypatch):
+    monkeypatch.setattr(
+        core.requests,
+        "get",
+        lambda *a, **kw: _FakeResponse(200, {"current_user": None}),
+    )
+    assert core._shuiyuan_session_is_valid({"_forum_session": "abc"}) is False
+
+
+def test_setup_shuiyuan_reuses_valid_cookie(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"shuiyuan_cookies": {"_forum_session": "still-valid"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(core, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(core, "_shuiyuan_session_is_valid", lambda cookies: True)
+    monkeypatch.setattr(
+        core,
+        "_setup_shuiyuan_session",
+        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("should not login")),
+    )
+
+    result = core.tool_setup_shuiyuan()
+    assert result.get("success") is True
+    assert "跳过重新登录" in result.get("message", "")


### PR DESCRIPTION
## 本轮改动

针对用户建议的优先级，完成第一轮落地：

- **后台服务自动恢复**：新增 .daemon_manifest.json 安装清单，重装 / 移动目录 / 重建 venv 后由安装脚本和 sjtu-agent update 自动 daemons resync；新增 sjtu-agent daemons status/uninstall/resync。
- **水源授权**：优先复用仍有效的 shuiyuan_cookies，登录后校验 /session/current.json，减少无谓登录和异地登录风控触发。
- **服务器部署（轻量版）**：sjtu-agent web --host；systemd 补齐 web / 
ews-digest / ihot-push 并修正早午报时间；新增 docs/SERVER_DEPLOYMENT.md。
- **排错与社区文档**：新增 docs/TROUBLESHOOTING.md 和 GitHub Issue 模板。
- **测试**：新增 daemon manifest / resync / 水源 session 校验测试。

## 验证

- pytest --collect-only：389 个测试正常收集。
- 本地可运行的相关测试：10 passed（其余受 CI 覆盖）。
- 修改的 Python 文件全部通过 py_compile。