### PR TITLE
feat: reuse persistent browser profile for Shuiyuan auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - 🖥 `install-daemons` / setup 新增 `--no-browser`；未安装 `web` 服务时不再等待或尝试打开浏览器
 - 🐧 systemd 补齐 `web`、`news-digest`、`aihot-push` 服务，并修正早报/午报时间
 - 💧 水源授权优先复用仍有效的 session cookie，登录后校验当前用户，减少异地登录触发
+- 🧬 水源 Playwright 登录复用持久化浏览器 profile（`shuiyuan_browser_profile/`），降低 jAccount 风控概率；异地登录二次验证时给出更明确的处理提示
 - 📚 新增排错手册、服务器部署指南和 GitHub Issue 模板
 
 ## v0.10.0 (2026-08-09)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -159,6 +159,7 @@ loginctl enable-linger "$USER"
 
 - jAccount 把无头浏览器 / 服务器 IP 判定为异地登录，触发交我办 / 邮箱 / 手机验证。
 - 项目会先复用已保存的 `shuiyuan_cookies`，只有在失效时才重新登录；如果你每次都被要求重新登录，说明 cookie 没有保存成功或被风控拦截。
+- Playwright 登录现在会复用运行时数据目录下的 `shuiyuan_browser_profile/`（持久化浏览器 profile，保留 cookie、localStorage 和浏览器指纹），比每次新建无痕窗口更不容易触发风控。
 
 建议按顺序尝试：
 
@@ -166,6 +167,7 @@ loginctl enable-linger "$USER"
 2. 对 Agent 说「配置水源」，让它先复用已有 session；不要从服务器 IP 首次登录。
 3. 本机自动化失败时，手动导出 cookie（见下节）。
 4. 服务器部署时，优先把本机已经配好的 `config.json` 复制到服务器，而不是让服务器去登录 jAccount。
+5. 若怀疑 profile 已损坏或想重置浏览器指纹，可删除 `sjtu-agent doctor` 显示的 `shuiyuan_profile_dir` 后重试。
 
 ### 手动导出水源 cookie（兜底方案）
 

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -32,6 +32,7 @@ from sjtu_agent.paths import (
     PACKAGE_ROOT,
     PROJECT_ROOT,
     REMINDERS_PATH,
+    SHUIYUAN_PROFILE_DIR,
     USER_PROFILE_PATH,
     atomic_write_json,
     read_json_safe,
@@ -1668,7 +1669,11 @@ def tool_setup_shuiyuan() -> dict:
 
 
 def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
-    """降级方案：Playwright 登录水源，保存 session cookie。"""
+    """Playwright 登录水源并保存 session cookie。
+
+    优先复用持久化浏览器 profile（shuiyuan_browser_profile/），profile 失效
+    或不可用时回退到新的浏览器上下文，并把 config 中的 jAccount cookie 合并进去。
+    """
     manual_note = (
         "水源社区没有固定的 API 设置页面；不要去偏好设置里找 API。"
         "如果 User API Key 授权不可用，session cookie 就是当前的降级方案。"
@@ -1695,28 +1700,77 @@ def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
         return _shuiyuan_session_error(f"加载登录模块失败：{e}")
 
     jaccount_cookies = cfg.get("jaccount_cookies", {})
+    try:
+        SHUIYUAN_PROFILE_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        return _shuiyuan_session_error(f"无法创建水源浏览器 profile 目录：{e}")
+    _ManualLoginRequired = getattr(login_module, "ManualLoginRequired", None)
 
     new_session: dict = {}
     with _sync_pw() as pw:
-        browser = pw.chromium.launch(headless=True)
-        ctx = browser.new_context()
-        if jaccount_cookies:
-            ctx.add_cookies([
-                {"name": k, "value": v, "domain": "jaccount.sjtu.edu.cn", "path": "/"}
-                for k, v in jaccount_cookies.items()
-            ])
+        # 优先复用持久化浏览器 profile：保留 localStorage / cookie / 浏览器指纹，
+        # 比每次新建无痕上下文更不容易触发 jAccount 异地登录风控。
+        browser = None
+        profile_reused = False
+        try:
+            try:
+                ctx = pw.chromium.launch_persistent_context(
+                    user_data_dir=str(SHUIYUAN_PROFILE_DIR),
+                    headless=True,
+                    locale="zh-CN",
+                    timezone_id="Asia/Shanghai",
+                    viewport={"width": 1440, "height": 900},
+                )
+                profile_reused = True
+            except Exception:
+                browser = pw.chromium.launch(headless=True)
+                ctx = browser.new_context(
+                    locale="zh-CN",
+                    timezone_id="Asia/Shanghai",
+                    viewport={"width": 1440, "height": 900},
+                )
+
+            # 无论 profile 是否存在，都把 config 里最新的 jAccount cookie 合并进去。
+            if jaccount_cookies:
+                try:
+                    ctx.add_cookies([
+                        {"name": k, "value": v, "domain": "jaccount.sjtu.edu.cn", "path": "/"}
+                        for k, v in jaccount_cookies.items()
+                    ])
+                except Exception:
+                    pass
+        except Exception as e:
+            if browser is not None:
+                try:
+                    browser.close()
+                except Exception:
+                    pass
+            return _shuiyuan_session_error(f"启动浏览器失败：{e}")
+
+        def _close() -> None:
+            try:
+                ctx.close()
+            except Exception:
+                pass
+            if browser is not None:
+                try:
+                    browser.close()
+                except Exception:
+                    pass
+
         page = ctx.new_page()
         try:
             page.goto("https://shuiyuan.sjtu.edu.cn/", wait_until="networkidle", timeout=20_000)
         except Exception:
             pass
+
         if "jaccount" in page.url:
             if not username or not password:
-                browser.close()
+                _close()
                 return {"error": "需要 jAccount 凭据，请先用 save_credentials 配置"}
             try:
                 if not login_module._fill_jaccount(page, username, password):
-                    browser.close()
+                    _close()
                     return _shuiyuan_session_error("jAccount 登录失败，请检查账号密码")
                 try:
                     page.wait_for_url("**/shuiyuan.sjtu.edu.cn/**", timeout=15_000)
@@ -1727,14 +1781,29 @@ def _setup_shuiyuan_session(cfg: dict, username: str, password: str) -> dict:
                 if new_ja:
                     cfg["jaccount_cookies"] = new_ja
             except Exception as e:
-                browser.close()
+                _close()
+                if _ManualLoginRequired is not None and isinstance(e, _ManualLoginRequired):
+                    return _shuiyuan_session_error(
+                        f"{e}。建议先在常用电脑的浏览器里登录水源一次，再重试；"
+                        "也可按排错手册手动导出 shuiyuan cookie。"
+                    )
                 return _shuiyuan_session_error(f"jAccount 登录失败：{e}")
+
         new_session = {c["name"]: c["value"] for c in ctx.cookies()
                        if "shuiyuan.sjtu.edu.cn" in c.get("domain", "")}
-        browser.close()
+        profile_ja = {c["name"]: c["value"] for c in ctx.cookies()
+                      if "jaccount" in c.get("domain", "")}
+        if profile_ja:
+            cfg["jaccount_cookies"] = profile_ja
+        _close()
+
+    if not profile_reused and not new_session:
+        return _shuiyuan_session_error("未能获取水源社区 session，请检查账号")
 
     if not new_session:
-        return _shuiyuan_session_error("未能获取水源社区 session，请检查账号")
+        return _shuiyuan_session_error(
+            "未能从浏览器 profile 中获取水源社区 session，请检查是否已登录。"
+        )
 
     # 不能只看域名 cookie：即使没有登录也可能拿到游客 cookie。
     # 必须通过 Discourse 当前用户接口确认 session 真的已登录。

--- a/sjtu_agent/paths.py
+++ b/sjtu_agent/paths.py
@@ -56,6 +56,7 @@ NEWS_HISTORY_PATH     = DATA_DIR / "news_history.json"
 CONVERSATION_LOG_PATH = DATA_DIR / "conversation_log.jsonl"
 WEB_TOKEN_PATH        = DATA_DIR / ".web_token"
 DAEMON_MANIFEST_PATH  = DATA_DIR / ".daemon_manifest.json"
+SHUIYUAN_PROFILE_DIR  = DATA_DIR / "shuiyuan_browser_profile"
 DINING_HISTORY_PATH   = DATA_DIR / "dining_history.json"
 CANTEEN_KNOWLEDGE_PATH = PACKAGE_ROOT / "data" / "canteen_knowledge.json"
 
@@ -183,6 +184,7 @@ def describe_runtime_paths() -> dict[str, str]:
         "schedule_cache_path": str(SCHEDULE_CACHE_PATH),
         "dining_history_path": str(DINING_HISTORY_PATH),
         "daemon_manifest_path": str(DAEMON_MANIFEST_PATH),
+        "shuiyuan_profile_dir": str(SHUIYUAN_PROFILE_DIR),
         "canteen_knowledge_path": str(CANTEEN_KNOWLEDGE_PATH),
     }
 

--- a/tests/test_shuiyuan_session.py
+++ b/tests/test_shuiyuan_session.py
@@ -50,3 +50,83 @@ def test_setup_shuiyuan_reuses_valid_cookie(monkeypatch, tmp_path):
     result = core.tool_setup_shuiyuan()
     assert result.get("success") is True
     assert "跳过重新登录" in result.get("message", "")
+
+
+class _FakePage:
+    url = "https://shuiyuan.sjtu.edu.cn/"
+
+    def goto(self, *args, **kwargs):
+        return None
+
+    def wait_for_url(self, *args, **kwargs):
+        return None
+
+
+class _FakeContext:
+    def __init__(self):
+        # Playwright 的 cookies() 返回 dict 列表，而不是对象。
+        self._cookies = [
+            {"name": "_forum_session", "value": "profile-session", "domain": ".shuiyuan.sjtu.edu.cn"},
+            {"name": "_jarvis", "value": "profile-ja", "domain": ".jaccount.sjtu.edu.cn"},
+        ]
+
+    def add_cookies(self, cookies):
+        return None
+
+    def cookies(self):
+        return self._cookies
+
+    def new_page(self):
+        return _FakePage()
+
+    def close(self):
+        return None
+
+
+class _FakeChromium:
+    def __init__(self):
+        self.launch_kwargs = None
+
+    def launch_persistent_context(self, **kwargs):
+        self.launch_kwargs = kwargs
+        return _FakeContext()
+
+    def launch(self, **kwargs):
+        raise AssertionError("should use persistent context")
+
+
+class _FakePlaywright:
+    def __init__(self, chromium):
+        self.chromium = chromium
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_setup_shuiyuan_uses_persistent_browser_profile(monkeypatch, tmp_path):
+    import playwright.sync_api as playwright_api
+
+    config_path = tmp_path / "config.json"
+    profile_dir = tmp_path / "shuiyuan_browser_profile"
+    monkeypatch.setattr(core, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(core, "SHUIYUAN_PROFILE_DIR", profile_dir)
+    monkeypatch.setattr(core, "_shuiyuan_session_is_valid", lambda cookies: True)
+
+    chromium = _FakeChromium()
+    monkeypatch.setattr(
+        playwright_api,
+        "sync_playwright",
+        lambda: _FakePlaywright(chromium),
+    )
+
+    result = core._setup_shuiyuan_session({}, "", "")
+    assert result.get("success") is True
+    assert chromium.launch_kwargs is not None
+    assert chromium.launch_kwargs["user_data_dir"] == str(profile_dir)
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["shuiyuan_cookies"]["_forum_session"] == "profile-session"
+    assert saved["jaccount_cookies"]["_jarvis"] == "profile-ja"


### PR DESCRIPTION
## 水源登录态增强

在上一轮“优先复用有效 shuiyuan_cookies”的基础上，进一步降低 jAccount 异地登录风控触发概率：

- Playwright 登录改为**优先复用持久化浏览器 profile**（运行时数据目录 shuiyuan_browser_profile/），保留 cookie、localStorage 与浏览器指纹；profile 不可用时回退到新建上下文，并合并 config 中的 jAccount cookie。
- profile 中的 jAccount cookie 会同步回 config.json，后续仍可跨平台复用。
- 触发 ManualLoginRequired（交我办/邮箱/手机三选一）时，返回更明确的处理提示。
- sjtu-agent doctor 现在会显示 shuiyuan_profile_dir。
- 排错手册与 CHANGELOG 同步更新。

## 验证

- 新增持久化 profile 路径的 Playwright fake 测试。
- 相关可运行测试通过；完整 CI 由本 PR 触发。