### PR TITLE
feat: add config export/import for secure server migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Unreleased
 - 🧬 水源 Playwright 登录复用持久化浏览器 profile（`shuiyuan_browser_profile/`），降低 jAccount 风控概率；异地登录二次验证时给出更明确的处理提示
+- 📦 新增 `sjtu-agent export-config / import-config`：核心凭据打包迁移、SSH 管道直传、可选 PBKDF2+ Fernet 加密、导入前自动备份
 
 ## v0.11.0 (2026-08-15)
 - 🔁 后台服务安装清单（`.daemon_manifest.json`）：安装脚本 / `sjtu-agent update` 自动恢复此前安装的 Task Scheduler / psmux / launchd / systemd 服务，重装后无需手动重新配置

--- a/README.md
+++ b/README.md
@@ -254,6 +254,14 @@ sjtu-agent install-parse-backends --backend whisper
 - `.env` — jAccount 账号密码、致远一号 API Key
 - `agent_config.json` — 大模型配置（已有 `ZHIYUAN_API_KEY` 则不需要；模板见 [agent_config.example.json](agent_config.example.json)）
 
+本机配置迁移到服务器：
+
+```bash
+sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
+```
+
+详见 [服务器部署](docs/SERVER_DEPLOYMENT.md)。
+
 ### 安全说明
 
 凭据（API Key、密码、Token）以明文存储在本地文件中。Web UI 需要 `?token=xxx` 访问令牌（首次启动打印在终端）。`execute_python` 工具执行时会自动剥离敏感环境变量。建议保持运行时数据目录为私有（macOS/Linux 已自动设为 `0o600`）。

--- a/README_EN.md
+++ b/README_EN.md
@@ -564,6 +564,14 @@ Runtime files are stored in platform-specific user data directories, not the rep
 
 Legacy files in the repo root are auto-migrated on first import.
 
+To migrate credentials to another machine (e.g. a server):
+
+```bash
+sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
+```
+
+See [Server Deployment](docs/SERVER_DEPLOYMENT.md).
+
 ## Robustness
 
 The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on startup; writes a heartbeat file every 30s for the launcher to monitor (no heartbeat for >90s → unresponsive); and cleans up thread pools and temp files on exit.

--- a/docs/SERVER_DEPLOYMENT.md
+++ b/docs/SERVER_DEPLOYMENT.md
@@ -38,19 +38,29 @@ bash install/install.sh --no-setup --skip-playwright
 - `--no-setup`：服务器上不走交互向导，配置手工写入或从本机复制。
 - `--skip-playwright`：暂时不需要自动登录；之后需要刷新 cookie 时再 `uv run playwright install chromium`（或在有桌面依赖的机器上安装）。
 
-## 2. 准备配置（推荐：从本机复制）
+## 2. 准备配置（推荐：export-config / import-config）
 
-在**你平时使用的电脑**上跑通一次 setup 后，把运行时数据目录整个复制到服务器：
+在**你平时使用的电脑**上跑通一次 setup 后，用专用命令导出核心配置，而不是手工复制整个运行时目录：
 
 ```bash
-# 本机（macOS 示例）
-scp -r ~/Library/Application\ Support/sjtu-agent user@server:.sjtu-agent-local
+# 本机：导出核心凭据（config.json / .env / agent_config.json）
+sjtu-agent export-config --output sjtu-agent-config.tar.gz
 
-# 服务器
-mkdir -p ~/.local/share
-mv ~/.sjtu-agent-local ~/.local/share/sjtu-agent
-chmod 700 ~/.local/share/sjtu-agent
+# 安全传到服务器（scp 走 SSH 加密）
+scp sjtu-agent-config.tar.gz user@server:
+
+# 服务器：导入；同名文件会先自动备份
+sjtu-agent import-config ~/sjtu-agent-config.tar.gz --yes
+sjtu-agent doctor
 ```
+
+也可以不走中间文件，直接 SSH 管道直传：
+
+```bash
+sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
+```
+
+需要同时迁移提醒/用户画像/食堂偏好时，导出端加 `--with-state`。归档文件本身包含明文凭据，请**只在 SSH/scp 中传输，用后删除**；需要落到共享磁盘时使用 `--encrypt`（PBKDF2 + Fernet 加密，密码可设置 `SJTU_AGENT_CONFIG_PASSWORD`）。
 
 默认路径：
 
@@ -59,7 +69,7 @@ chmod 700 ~/.local/share/sjtu-agent
 | Linux 服务器 | `~/.local/share/sjtu-agent` |
 | 自定义 | 设置 `SJTU_AGENT_HOME=/opt/sjtu-agent` |
 
-如果服务器和本机用同一套路径，`scp` 时注意不要覆盖服务器上已有的配置。也可以只复制三个核心文件：
+导入的三个核心文件：
 
 - `config.json`：平台 Token、Bot 凭据、Cookie
 - `.env`：jAccount、LLM API Key

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -240,6 +240,18 @@ Windows 若下载超时，可以设置代理后重试，或从安装脚本加 `-
 
 运行时数据目录独立于代码仓库，普通重装不会删除。只有手动删除该目录或更换用户才会丢配置。项目目录移动后，Windows 后台服务需要 `sjtu-agent daemons resync`（安装脚本会自动做）。
 
+### 怎么把本机配置搬到服务器？
+
+```bash
+# 本机
+sjtu-agent export-config --output sjtu-agent-config.tar.gz
+
+# 服务器
+sjtu-agent import-config sjtu-agent-config.tar.gz --yes
+```
+
+推荐直接走 SSH 管道：`sjtu-agent export-config --output - | ssh server "sjtu-agent import-config - --yes"`。导入前会备份同名文件到运行时目录 `backups/`。详见 [SERVER_DEPLOYMENT.md](SERVER_DEPLOYMENT.md)。
+
 ### 仍然无法解决？
 
 到 [GitHub Issues](https://github.com/kuan-er/sjtu-agent/issues) 用对应模板提交，附上脱敏后的 `sjtu-agent doctor` 输出和 `logs/` 中相关日志。

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ plyer>=2.1.0
 beautifulsoup4>=4.12.0
 lxml>=5.0.0
 browser-cookie3>=0.19.0
+cryptography>=42.0.0
 playwright>=1.40.0
 python-dotenv>=1.0.0
 rich>=13.7.1

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import runpy
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from sjtu_agent import __version__
@@ -541,6 +542,144 @@ def _cmd_daemons_resync(args: argparse.Namespace) -> int:
     return 0
 
 
+def _prompt_config_password(confirm: bool) -> str:
+    """交互式读取配置归档密码；无 TTY 时从 SJTU_AGENT_CONFIG_PASSWORD 读取。"""
+    from sjtu_agent.config_transfer import password_from_env
+
+    env_password = password_from_env()
+    if env_password:
+        return env_password
+
+    try:
+        import getpass
+        if sys.stdin.isatty():
+            password = getpass.getpass("Config archive password: ")
+            if not confirm:
+                return password
+            again = getpass.getpass("Confirm password: ")
+            if password != again:
+                raise ValueError("两次输入的密码不一致")
+            return password
+    except EOFError as exc:
+        raise ValueError("无法在无 TTY 环境交互输入密码") from exc
+    raise ValueError(
+        "无法交互输入密码。请设置 SJTU_AGENT_CONFIG_PASSWORD，或使用未加密归档 + SSH 管道传输。"
+    )
+
+
+def _cmd_export_config(args: argparse.Namespace) -> int:
+    from sjtu_agent.config_transfer import export_bytes, export_to_path
+
+    encrypt_password: str | None = None
+    if args.encrypt:
+        try:
+            encrypt_password = _prompt_config_password(confirm=True)
+        except ValueError as exc:
+            print(f"[!] {exc}", file=sys.stderr)
+            return 1
+        if not encrypt_password:
+            print("[!] 密码不能为空。", file=sys.stderr)
+            return 1
+
+    if getattr(args, "output", None) == "-":
+        # --output -：二进制写入 stdout，报告写入 stderr
+        try:
+            data = export_bytes(include_state=args.with_state, encrypt_password=encrypt_password)
+            sys.stdout.buffer.write(data)
+            sys.stdout.buffer.flush()
+        except (OSError, RuntimeError, ValueError) as exc:
+            print(f"[!] 导出失败：{exc}", file=sys.stderr)
+            return 1
+        print(f"[i] 已向 stdout 写出 {len(data)} 字节。", file=sys.stderr)
+        return 0
+
+    destination = (
+        Path(args.output)
+        if args.output
+        else Path.cwd() / f"sjtu-agent-config-{datetime.now().strftime('%Y%m%d-%H%M%S')}.tar.gz"
+    )
+    try:
+        payload = export_to_path(
+            destination,
+            include_state=args.with_state,
+            encrypt_password=encrypt_password,
+            force=args.force,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"[!] 导出失败：{exc}", file=sys.stderr)
+        return 1
+    print_json(payload)
+    if not encrypt_password:
+        print(
+            "[i] 这是未加密归档，内含 API Key / 密码 / Token。"
+            "请通过 SSH/scp 传输，用后删除，勿上传公网。",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def _read_import_source(source: str) -> bytes:
+    if source == "-":
+        data = sys.stdin.buffer.read()
+    else:
+        data = Path(source).read_bytes()
+    if not data:
+        raise ValueError("输入为空")
+    return data
+
+
+def _cmd_import_config(args: argparse.Namespace) -> int:
+    from sjtu_agent.config_transfer import is_encrypted, import_bytes, password_from_env
+
+    try:
+        data = _read_import_source(args.archive)
+    except (OSError, ValueError) as exc:
+        print(f"[!] 读取输入失败：{exc}", file=sys.stderr)
+        return 1
+
+    decrypt_password: str | None = None
+    if is_encrypted(data):
+        decrypt_password = password_from_env()
+        if not decrypt_password:
+            try:
+                decrypt_password = _prompt_config_password(confirm=False)
+            except ValueError as exc:
+                print(f"[!] {exc}", file=sys.stderr)
+                return 1
+
+    if not args.dry_run and not args.yes:
+        if args.archive == "-":
+            print(
+                "[!] stdin 模式会覆盖运行时凭据文件，必须显式传 --yes。",
+                file=sys.stderr,
+            )
+            return 1
+        if not sys.stdin.isatty():
+            print(
+                "[!] 非交互环境导入会覆盖运行时凭据文件，必须显式传 --yes（或 --dry-run 预览）。",
+                file=sys.stderr,
+            )
+            return 1
+        answer = input("导入会覆盖同名运行时文件（自动备份），确认继续？[y/N] ").strip().lower()
+        if answer not in {"y", "yes"}:
+            print("已取消。", file=sys.stderr)
+            return 1
+
+    try:
+        payload = import_bytes(
+            data,
+            target_dir=Path(args.target_dir) if args.target_dir else None,
+            decrypt_password=decrypt_password,
+            skip_state=args.skip_state,
+            dry_run=args.dry_run,
+        )
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"[!] 导入失败：{exc}", file=sys.stderr)
+        return 1
+    print_json(payload)
+    return 0
+
+
 def _add_passthrough_parser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
     name: str,
@@ -763,6 +902,59 @@ def build_parser() -> argparse.ArgumentParser:
         help="python executable to use (default: current interpreter)",
     )
     daemons_resync_parser.set_defaults(func=_cmd_daemons_resync)
+
+    export_config_parser = subparsers.add_parser(
+        "export-config",
+        help="export runtime credentials/config as a portable archive (use - for stdout)",
+    )
+    export_config_parser.add_argument(
+        "--output",
+        default=None,
+        help="output file path (default: sjtu-agent-config-<timestamp>.tar.gz; use - for stdout)",
+    )
+    export_config_parser.add_argument(
+        "--with-state",
+        action="store_true",
+        help="also export reminders/user profile/dining history",
+    )
+    export_config_parser.add_argument(
+        "--encrypt",
+        action="store_true",
+        help="encrypt the archive with a passphrase (prompts, or SJTU_AGENT_CONFIG_PASSWORD)",
+    )
+    export_config_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite an existing output file",
+    )
+    export_config_parser.set_defaults(func=_cmd_export_config)
+
+    import_config_parser = subparsers.add_parser(
+        "import-config",
+        help="import a config archive exported by export-config (use - for stdin)",
+    )
+    import_config_parser.add_argument("archive", help="archive path, or - for stdin")
+    import_config_parser.add_argument(
+        "--target-dir",
+        default=None,
+        help="runtime data directory to import into (default: current SJTU_AGENT_HOME)",
+    )
+    import_config_parser.add_argument(
+        "--skip-state",
+        action="store_true",
+        help="do not import optional state files if present in the archive",
+    )
+    import_config_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="validate and print what would be written without writing",
+    )
+    import_config_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="overwrite same-name runtime files without prompting (backs them up first)",
+    )
+    import_config_parser.set_defaults(func=_cmd_import_config)
 
     doctor = subparsers.add_parser("doctor", help="print runtime paths and setup status")
     doctor.set_defaults(func=_cmd_doctor)

--- a/sjtu_agent/config_transfer.py
+++ b/sjtu_agent/config_transfer.py
@@ -1,0 +1,372 @@
+"""
+sjtu_agent/config_transfer.py — 运行时配置的导出 / 导入
+
+目标：把本机配置（config.json / .env / agent_config.json，可选状态文件）
+安全迁移到另一台机器（典型场景是家用电脑 → 服务器）。
+
+安全设计：
+- 导出为 gzip tar，tar 内所有文件权限 0600；默认只导出三个核心凭据文件。
+- 文件路径仅允许固定 basename，导入时拒绝任何路径穿越成员。
+- 导入前先完整解析并校验所有 JSON，全部合法才落盘，避免半截导入。
+- 覆盖已有文件前自动备份到 <data_dir>/backups/<timestamp>/。
+- 可选 --encrypt：PBKDF2-HMAC-SHA256 + Fernet（AES128-CBC + HMAC）加密。
+- 推荐通过 SSH 管道直传，避免在磁盘留下明文归档：
+      sjtu-agent export-config --output - | ssh server "sjtu-agent import-config - --yes"
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import shutil
+import tarfile
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sjtu_agent.paths import (
+    AGENT_CONFIG_PATH,
+    CONFIG_PATH,
+    DATA_DIR,
+    DINING_HISTORY_PATH,
+    ENV_PATH,
+    REMINDERS_PATH,
+    USER_PROFILE_PATH,
+)
+
+_FORMAT_NAME = "sjtu-agent-config"
+_FORMAT_VERSION = 1
+_MAGIC = b"SJTUAGENTCFG\x00\x01"
+_SALT_LENGTH = 16
+_KDF_ITERATIONS = 600_000
+_PASSWORD_ENV = "SJTU_AGENT_CONFIG_PASSWORD"
+
+_CORE_NAMES = ("config.json", ".env", "agent_config.json")
+_STATE_NAMES = ("reminders.json", "user_profile.json", "dining_history.json")
+_ALLOWED_NAMES = set(_CORE_NAMES + _STATE_NAMES)
+
+_PATH_BY_NAME: dict[str, Path] = {
+    "config.json": CONFIG_PATH,
+    ".env": ENV_PATH,
+    "agent_config.json": AGENT_CONFIG_PATH,
+    "reminders.json": REMINDERS_PATH,
+    "user_profile.json": USER_PROFILE_PATH,
+    "dining_history.json": DINING_HISTORY_PATH,
+}
+
+
+def _tar_bytes_entry(tar: tarfile.TarFile, name: str, data: bytes, mode: int = 0o600) -> None:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    info.mode = mode
+    info.mtime = int(datetime.now().timestamp())
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _read_bytes(path: Path) -> bytes:
+    return path.read_bytes()
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    """原子写文件；POSIX 下收紧为 0600，避免凭据暴露给同机其他用户。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=path.name + ".",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        os.replace(tmp_path, path)
+        if os.name != "nt":
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _fernet_encrypt(data: bytes, password: str) -> bytes:
+    try:
+        from cryptography.fernet import Fernet
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    except ImportError as exc:
+        raise RuntimeError(
+            "加密导出需要 cryptography，请先运行: pip install cryptography"
+        ) from exc
+
+    salt = os.urandom(_SALT_LENGTH)
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=_KDF_ITERATIONS,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+    token = Fernet(key).encrypt(data)
+    return _MAGIC + salt + token
+
+
+def _fernet_decrypt(payload: bytes, password: str) -> bytes:
+    try:
+        from cryptography.fernet import Fernet, InvalidToken
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+    except ImportError as exc:
+        raise RuntimeError(
+            "该归档是加密的，导入需要 cryptography，请先运行: pip install cryptography"
+        ) from exc
+
+    salt = payload[len(_MAGIC):len(_MAGIC) + _SALT_LENGTH]
+    token = payload[len(_MAGIC) + _SALT_LENGTH:]
+    if len(salt) != _SALT_LENGTH or not token:
+        raise ValueError("加密归档格式无效")
+
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=_KDF_ITERATIONS,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+    try:
+        return Fernet(key).decrypt(token)
+    except InvalidToken as exc:
+        raise ValueError("密码错误，或加密归档已损坏") from exc
+
+
+def _tar_member_name(name: str) -> str | None:
+    """只允许固定 basename；任何目录成员 / 路径穿越成员一律拒绝。"""
+    if name != Path(name).name:
+        return None
+    if name not in _ALLOWED_NAMES:
+        return None
+    return name
+
+
+def export_bytes(*, include_state: bool = False, encrypt_password: str | None = None) -> bytes:
+    """把运行时配置打包为 tar.gz 字节流。"""
+    names: list[str] = []
+    for name in _CORE_NAMES:
+        path = _PATH_BY_NAME[name]
+        if path.exists():
+            names.append(name)
+
+    if include_state:
+        for name in _STATE_NAMES:
+            if _PATH_BY_NAME[name].exists():
+                names.append(name)
+
+    if not names:
+        raise RuntimeError(
+            "没有可导出的运行时配置。请先运行 sjtu-agent setup 或 sjtu-agent doctor 检查。"
+        )
+
+    manifest = {
+        "format": _FORMAT_NAME,
+        "version": _FORMAT_VERSION,
+        "files": names,
+    }
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+        _tar_bytes_entry(tar, "manifest.json", json.dumps(manifest, ensure_ascii=False).encode("utf-8"))
+        for name in names:
+            _tar_bytes_entry(tar, name, _read_bytes(_PATH_BY_NAME[name]))
+
+    data = buffer.getvalue()
+    if encrypt_password is not None:
+        data = _fernet_encrypt(data, encrypt_password)
+    return data
+
+
+def _parse_archive(data: bytes, *, decrypt_password: str | None = None, skip_state: bool = False) -> dict[str, bytes]:
+    """解密（如需要）、解包并校验归档，返回 name -> bytes。"""
+    if data.startswith(_MAGIC):
+        if not decrypt_password:
+            raise ValueError("这是一个加密归档，请提供密码（或设置 SJTU_AGENT_CONFIG_PASSWORD）")
+        data = _fernet_decrypt(data, decrypt_password)
+
+    try:
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            member_names = set(tar.getnames())
+            if "manifest.json" not in member_names:
+                raise ValueError("归档缺少 manifest.json，不是有效的 sjtu-agent 配置归档")
+
+            manifest_raw = tar.extractfile("manifest.json")
+            if manifest_raw is None:
+                raise ValueError("无法读取归档中的 manifest.json")
+            try:
+                manifest = json.loads(manifest_raw.read().decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise ValueError(f"manifest.json 不是有效 JSON：{exc}") from exc
+
+            if not isinstance(manifest, dict):
+                raise ValueError("归档 manifest.json 必须是 JSON 对象")
+            if manifest.get("format") != _FORMAT_NAME:
+                raise ValueError("归档格式标识不匹配，不是 sjtu-agent 配置归档")
+            try:
+                manifest_version = int(manifest.get("version", 0))
+            except (TypeError, ValueError) as exc:
+                raise ValueError("归档 manifest 中的 version 无效") from exc
+            if manifest_version > _FORMAT_VERSION:
+                raise ValueError(f"归档版本 {manifest.get('version')} 高于当前支持的版本 {_FORMAT_VERSION}")
+
+            files = manifest.get("files", [])
+            if not isinstance(files, list) or not files:
+                raise ValueError("归档 manifest 中没有可导入的文件")
+
+            contents: dict[str, bytes] = {}
+            for raw_name in files:
+                name = _tar_member_name(str(raw_name))
+                if name is None:
+                    raise ValueError(f"归档包含不允许的文件：{raw_name!r}")
+                if skip_state and name in _STATE_NAMES:
+                    continue
+                try:
+                    member = tar.getmember(name)
+                except KeyError as exc:
+                    raise ValueError(f"归档 manifest 声明的文件不在归档中：{name}") from exc
+                if not member.isfile():
+                    raise ValueError(f"归档成员不是普通文件：{name}")
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    raise ValueError(f"无法读取归档成员：{name}")
+                content = extracted.read()
+                if not content and name != ".env":
+                    raise ValueError(f"归档成员为空：{name}")
+                if name.endswith(".json"):
+                    try:
+                        json.loads(content.decode("utf-8"))
+                    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                        raise ValueError(f"{name} 不是有效 JSON：{exc}") from exc
+                contents[name] = content
+
+            if not contents:
+                raise ValueError("归档中没有可导入的文件")
+            return contents
+    except tarfile.TarError as exc:
+        raise ValueError(f"无法读取归档：{exc}") from exc
+
+
+def import_bytes(
+    data: bytes,
+    *,
+    target_dir: Path | None = None,
+    decrypt_password: str | None = None,
+    skip_state: bool = False,
+    dry_run: bool = False,
+    backup: bool = True,
+) -> dict[str, Any]:
+    """把导出归档导入到目标运行时目录。
+
+    返回报告；dry_run 时不写任何文件也不备份。
+    """
+    target = Path(target_dir or DATA_DIR)
+    target.mkdir(parents=True, exist_ok=True)
+    contents = _parse_archive(data, decrypt_password=decrypt_password, skip_state=skip_state)
+
+    report: dict[str, Any] = {
+        "target_dir": str(target),
+        "dry_run": dry_run,
+        "files": [],
+    }
+
+    if dry_run:
+        for name in sorted(contents):
+            dest = target / name
+            report["files"].append({
+                "name": name,
+                "action": "would_write" if not dest.exists() else "would_replace",
+                "backed_up": False,
+            })
+        return report
+
+    # 先统一校验，后统一写；任何校验失败都不会产生半截导入。
+    validated: dict[str, bytes] = {}
+    for name in sorted(contents):
+        content = contents[name]
+        if name.endswith(".json"):
+            json.loads(content.decode("utf-8"))  # _parse_archive 已校验，这里双保险
+        validated[name] = content
+
+    backup_dir: Path | None = None
+    written: list[str] = []
+    for name, content in validated.items():
+        dest = target / name
+        if dest.exists() and dest.read_bytes() == content:
+            report["files"].append({"name": name, "action": "unchanged", "backed_up": False})
+            continue
+
+        if backup and dest.exists():
+            if backup_dir is None:
+                timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+                backup_dir = target / "backups" / timestamp
+                backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_path = backup_dir / name
+            shutil.copy2(dest, backup_path)
+            report["files"].append({
+                "name": name,
+                "action": "written",
+                "backed_up": True,
+                "backup_path": str(backup_path),
+            })
+        else:
+            report["files"].append({"name": name, "action": "written", "backed_up": False})
+
+        _atomic_write_bytes(dest, content)
+        written.append(name)
+
+    report["written"] = written
+    return report
+
+
+def is_encrypted(data: bytes) -> bool:
+    return data.startswith(_MAGIC)
+
+
+def password_from_env() -> str:
+    return os.environ.get(_PASSWORD_ENV, "")
+
+
+def export_to_path(
+    destination: Path,
+    *,
+    include_state: bool = False,
+    encrypt_password: str | None = None,
+    force: bool = False,
+) -> dict[str, Any]:
+    """导出到本地文件，返回报告。"""
+    if destination.exists() and not force:
+        raise FileExistsError(f"目标文件已存在（--force 可覆盖）：{destination}")
+    data = export_bytes(include_state=include_state, encrypt_password=encrypt_password)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_bytes(destination, data)
+    return {
+        "path": str(destination),
+        "size": len(data),
+        "encrypted": encrypt_password is not None,
+        "files": _exported_names(include_state=include_state),
+    }
+
+
+def _exported_names(*, include_state: bool = False) -> list[str]:
+    names = [name for name in _CORE_NAMES if _PATH_BY_NAME[name].exists()]
+    if include_state:
+        names += [name for name in _STATE_NAMES if _PATH_BY_NAME[name].exists()]
+    return names

--- a/tests/test_config_transfer.py
+++ b/tests/test_config_transfer.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+
+import pytest
+
+from sjtu_agent import config_transfer as ct
+
+
+def _patch_sources(monkeypatch, source_dir):
+    for name in ct._CORE_NAMES + ct._STATE_NAMES:
+        monkeypatch.setattr(ct, "_PATH_BY_NAME", dict(ct._PATH_BY_NAME))
+        ct._PATH_BY_NAME[name] = source_dir / name
+    monkeypatch.setattr(ct, "CONFIG_PATH", source_dir / "config.json")
+    monkeypatch.setattr(ct, "ENV_PATH", source_dir / ".env")
+    monkeypatch.setattr(ct, "AGENT_CONFIG_PATH", source_dir / "agent_config.json")
+    monkeypatch.setattr(ct, "REMINDERS_PATH", source_dir / "reminders.json")
+    monkeypatch.setattr(ct, "USER_PROFILE_PATH", source_dir / "user_profile.json")
+    monkeypatch.setattr(ct, "DINING_HISTORY_PATH", source_dir / "dining_history.json")
+
+
+def _make_source(source_dir, with_state=False):
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "config.json").write_text(
+        json.dumps({"feishu_app_id": "cli_test", "feishu_app_secret": "secret"}),
+        encoding="utf-8",
+    )
+    (source_dir / ".env").write_text(
+        "ZHIYUAN_API_KEY=sk-test\nJACCOUNT_USERNAME=zhangsan\nJACCOUNT_PASSWORD=secret\n",
+        encoding="utf-8",
+    )
+    (source_dir / "agent_config.json").write_text(
+        json.dumps({"model": "deepseek-chat", "api_key": "sk-agent"}),
+        encoding="utf-8",
+    )
+    if with_state:
+        (source_dir / "reminders.json").write_text(json.dumps([{"id": 1}]), encoding="utf-8")
+
+
+def test_export_import_roundtrip(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    _make_source(source)
+    _patch_sources(monkeypatch, source)
+
+    data = ct.export_bytes()
+    assert not ct.is_encrypted(data)
+
+    report = ct.import_bytes(data, target_dir=target)
+    assert set(report["written"]) == {"config.json", ".env", "agent_config.json"}
+    assert json.loads((target / "config.json").read_text(encoding="utf-8"))["feishu_app_id"] == "cli_test"
+    assert "ZHIYUAN_API_KEY=sk-test" in (target / ".env").read_text(encoding="utf-8")
+
+
+def test_encrypted_roundtrip_and_wrong_password(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    _make_source(source)
+    _patch_sources(monkeypatch, source)
+
+    data = ct.export_bytes(encrypt_password="hunter2")
+    assert ct.is_encrypted(data)
+
+    with pytest.raises(ValueError):
+        ct.import_bytes(data, target_dir=target, decrypt_password="wrong")
+
+    report = ct.import_bytes(data, target_dir=target, decrypt_password="hunter2")
+    assert report["written"]
+
+
+def test_import_rejects_path_traversal(tmp_path):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        manifest = json.dumps({
+            "format": "sjtu-agent-config",
+            "version": 1,
+            "files": ["../evil.json"],
+        }).encode("utf-8")
+        info = tarfile.TarInfo("manifest.json")
+        info.size = len(manifest)
+        tar.addfile(info, io.BytesIO(manifest))
+
+    with pytest.raises(ValueError, match="不允许"):
+        ct.import_bytes(buffer.getvalue(), target_dir=tmp_path / "target")
+
+
+def test_import_invalid_json_is_rejected(tmp_path):
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        manifest = json.dumps({
+            "format": "sjtu-agent-config",
+            "version": 1,
+            "files": ["config.json"],
+        }).encode("utf-8")
+        for name, payload in (
+            ("manifest.json", manifest),
+            ("config.json", b"{not-json"),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+    with pytest.raises(ValueError, match="JSON"):
+        ct.import_bytes(buffer.getvalue(), target_dir=tmp_path / "target")
+
+
+def test_dry_run_then_import_backs_up_existing(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    target = tmp_path / "target"
+    _make_source(source)
+    _patch_sources(monkeypatch, source)
+
+    target.mkdir()
+    (target / "config.json").write_text(json.dumps({"old": True}), encoding="utf-8")
+    data = ct.export_bytes()
+
+    dry = ct.import_bytes(data, target_dir=target, dry_run=True)
+    assert all(item["action"].startswith("would") for item in dry["files"])
+    assert json.loads((target / "config.json").read_text(encoding="utf-8")) == {"old": True}
+
+    report = ct.import_bytes(data, target_dir=target)
+    assert json.loads((target / "config.json").read_text(encoding="utf-8"))["feishu_app_id"] == "cli_test"
+    written_config = next(item for item in report["files"] if item["name"] == "config.json")
+    assert written_config["backed_up"] is True
+    assert written_config["backup_path"]
+
+
+def test_export_fails_without_any_config(monkeypatch, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    _patch_sources(monkeypatch, empty)
+    with pytest.raises(RuntimeError, match="没有可导出"):
+        ct.export_bytes()

--- a/uv.lock
+++ b/uv.lock
@@ -3131,6 +3131,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "beautifulsoup4" },
     { name = "browser-cookie3" },
+    { name = "cryptography" },
     { name = "fpdf2" },
     { name = "httpx" },
     { name = "lark-oapi" },


### PR DESCRIPTION
## 本机配置 → 服务器迁移

新增两个 CLI：

`ash
# 本机导出（默认只含三个核心凭据文件）
sjtu-agent export-config --output sjtu-agent-config.tar.gz

# 服务器导入（同名文件先自动备份到 backups/<timestamp>/）
sjtu-agent import-config sjtu-agent-config.tar.gz --yes

# 推荐：SSH 管道直传，不在磁盘留明文归档
sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
`

功能与安全设计：

- 默认导出 config.json / .env / gent_config.json；--with-state 可选提醒、用户画像、食堂偏好。
- 归档为 gzip tar，文件权限 0600；导入端严格限制成员名，拒绝路径穿越和非常规文件。
- 导入前完整校验所有 JSON，全部合法才落盘，不会半截导入。
- 覆盖前自动备份到 <data_dir>/backups/<timestamp>/；支持 --dry-run 预览。
- 可选 --encrypt：PBKDF2-HMAC-SHA256 + Fernet 加密；密码交互输入或 SJTU_AGENT_CONFIG_PASSWORD。
- cryptography 加入正式依赖。

文档更新：docs/SERVER_DEPLOYMENT.md、docs/TROUBLESHOOTING.md、README 中英文。