### PR TITLE
feat: web proxy generator, archive expiry validation, and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: Run tests
+        run: pytest
+
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Generate release notes from CHANGELOG
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          text = pathlib.Path("CHANGELOG.md").read_text(encoding="utf-8")
+          pattern = re.compile(rf"^## {re.escape(tag)}.*?(?=^## |\Z)", re.MULTILINE | re.DOTALL)
+          match = pattern.search(text)
+          notes = match.group(0).strip() if match else f"See CHANGELOG.md for {tag}."
+          pathlib.Path("release_notes.md").write_text(notes, encoding="utf-8")
+          PY
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release_notes.md \
+            dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## Unreleased
+- 🌐 新增 `sjtu-agent web-proxy`：生成 Nginx / Caddy HTTPS 反向代理配置（SSE 长连接参数、HTTP→HTTPS 跳转）
+- ⏳ 配置归档增加过期与校验策略：默认 24 小时过期、SHA-256 校验、拒绝过期归档（`--allow-expired` 放宽）
+- 🚀 新增 GitHub Actions 自动发布：推送 `v*` tag 后自动测试、构建 wheel/sdist、从 CHANGELOG 生成 Release Notes 并创建 Release
+- 📝 优化 README：目录、常用命令速查、远程 Web UI 与归档安全说明
+
 ## v0.11.2 (2026-08-15)
 - 📦 新增 `sjtu-agent export-config / import-config`：核心凭据打包迁移、SSH 管道直传、可选 PBKDF2+ Fernet 加密、导入前自动备份
 - 🗂 `export-config` / `import-config` 新增 `--state-file`，可按需选择 reminders / user_profile / dining_history 状态文件

--- a/README.md
+++ b/README.md
@@ -1,12 +1,25 @@
 # SJTU Agent
 
 [![Test](https://github.com/kuan-er/sjtu-agent/actions/workflows/test.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/test.yml)
+[![Pages](https://github.com/kuan-er/sjtu-agent/actions/workflows/pages.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/pages.yml)
+[![Release](https://github.com/kuan-er/sjtu-agent/actions/workflows/release.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/release.yml)
+[![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.13-blue)](https://www.python.org/)
 
 面向上海交通大学学生的校园助手，提供终端对话、飞书 / Telegram / 微信 / QQ Bot、DDL 聚合、日报推送和 MCP Server。
 
 [English Version](README_EN.md) · [项目展示页](https://kuan-er.github.io/sjtu-agent) · [文档站](https://kuan-er.github.io/sjtu-agent/docs/) · [排错手册](docs/TROUBLESHOOTING.md) · [服务器部署](docs/SERVER_DEPLOYMENT.md)
 
 如果这个项目对你有帮助，欢迎点一个 ⭐ Star！
+
+## 目录
+
+- [快速开始](#快速开始)
+- [常用命令速查](#常用命令速查)
+- [功能](#功能)
+- [配置](#配置)
+- [后台服务](#后台服务)
+- [平台接入](#平台接入)
+- [安全说明](#安全说明)
 
 ---
 
@@ -74,6 +87,22 @@ ZHIYUAN_API_KEY=你的APIKey
    ```
 
 > 视觉模型仅用于识图（一次性调用），不参与对话历史。API Key 仅存本地，输入时不回显、不打印。完整配置模板见 [agent_config.example.json](agent_config.example.json)。
+
+---
+
+## 常用命令速查
+
+| 命令 | 用途 |
+| --- | --- |
+| `sjtu-agent` | 终端对话 |
+| `sjtu-agent doctor` | 检查配置、路径和依赖 |
+| `sjtu-agent update` | 更新代码并自动恢复后台服务 |
+| `sjtu-agent web` | 本地 Web 配置页（`--host 0.0.0.0` 供服务器监听） |
+| `sjtu-agent web-proxy --domain <域名>` | 生成 Nginx / Caddy HTTPS 反代配置 |
+| `sjtu-agent install-daemons` | 安装后台服务；`daemons status/uninstall/resync` 管理服务 |
+| `sjtu-agent export-config / import-config` | 本机配置迁移到服务器（SSH 管道直传） |
+| `sjtu-agent ddl` / `daily-report` / `news-digest` | DDL、日报、校园新闻 |
+| `sjtu-agent feishu-bot` 等 | 启动对应平台 Bot |
 
 ---
 
@@ -260,7 +289,17 @@ sjtu-agent install-parse-backends --backend whisper
 sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
 ```
 
-详见 [服务器部署](docs/SERVER_DEPLOYMENT.md)。
+归档默认 **24 小时过期**（`--expires-hours` 调整，`--no-expiry` 关闭），导入端默认拒绝过期归档（`--allow-expired` 可放宽）；可选 `--encrypt` 加密。详见 [服务器部署](docs/SERVER_DEPLOYMENT.md)。
+
+### 远程访问 Web UI
+
+默认 `sjtu-agent web` 只监听 `127.0.0.1`。服务器上启用远程访问并生成 HTTPS 反代配置：
+
+```bash
+sjtu-agent web --host 0.0.0.0 --port 7860 --no-browser
+sjtu-agent web-proxy --type nginx --domain sjtu-agent.example.com --output sjtu-agent.conf
+# 或 --type caddy 直接放入 Caddyfile
+```
 
 ### 安全说明
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,6 +1,8 @@
 # SJTU Agent
 
 [![Test](https://github.com/kuan-er/sjtu-agent/actions/workflows/test.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/test.yml)
+[![Pages](https://github.com/kuan-er/sjtu-agent/actions/workflows/pages.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/pages.yml)
+[![Release](https://github.com/kuan-er/sjtu-agent/actions/workflows/release.yml/badge.svg)](https://github.com/kuan-er/sjtu-agent/actions/workflows/release.yml)
 
 A campus assistant for Shanghai Jiao Tong University students, offering terminal chat, Telegram / Feishu (Lark) / WeChat / QQ bots, DDL aggregation, daily reports, campus news, canteen recommendations, and an MCP server.
 
@@ -11,6 +13,14 @@ Docs: [Documentation Site](https://kuan-er.github.io/sjtu-agent/docs/) · [Troub
 👉 **[Project Showcase](https://kuan-er.github.io/sjtu-agent)**
 
 If this project helps you, please consider giving it a ⭐ Star!
+
+## Contents
+
+- [Installation](#installation)
+- [Common Commands](#common-commands)
+- [Configuration](#configuration)
+- [Background Services](#background-services)
+- [Runtime Data](#runtime-data)
 
 ## Installation
 
@@ -133,6 +143,10 @@ sjtu-agent mcp --http --port 8765
 sjtu-agent add-mcp-server my-tools --transport stdio --command python --arg D:/path/to/server.py
 sjtu-agent add-skill my-skill --content-file D:/path/to/SKILL.md
 sjtu-agent install-daemons
+sjtu-agent daemons status
+sjtu-agent web --host 0.0.0.0 --no-browser
+sjtu-agent web-proxy --domain sjtu-agent.example.com
+sjtu-agent export-config --output - | ssh server "sjtu-agent import-config - --yes"
 ```
 
 Or run as a module:
@@ -569,6 +583,8 @@ To migrate credentials to another machine (e.g. a server):
 ```bash
 sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
 ```
+
+Archives expire after **24 hours by default** (`--expires-hours` / `--no-expiry`); import rejects expired archives unless `--allow-expired` is passed. For remote Web UI access, use `sjtu-agent web --host 0.0.0.0` and generate an Nginx/Caddy HTTPS config with `sjtu-agent web-proxy --domain <domain>`.
 
 See [Server Deployment](docs/SERVER_DEPLOYMENT.md).
 

--- a/docs/SERVER_DEPLOYMENT.md
+++ b/docs/SERVER_DEPLOYMENT.md
@@ -60,7 +60,7 @@ sjtu-agent doctor
 sjtu-agent export-config --output - | ssh user@server "sjtu-agent import-config - --yes"
 ```
 
-需要同时迁移提醒/用户画像/食堂偏好时，导出端加 `--with-state`；只迁移其中某个时可用 `--state-file reminders.json`（可重复，可选 `reminders.json` / `user_profile.json` / `dining_history.json`）。导入端同样支持 `--state-file` 选择性导入。归档文件本身包含明文凭据，请**只在 SSH/scp 中传输，用后删除**；需要落到共享磁盘时使用 `--encrypt`（PBKDF2 + Fernet 加密，密码可设置 `SJTU_AGENT_CONFIG_PASSWORD`）。
+需要同时迁移提醒/用户画像/食堂偏好时，导出端加 `--with-state`；只迁移其中某个时可用 `--state-file reminders.json`（可重复，可选 `reminders.json` / `user_profile.json` / `dining_history.json`）。导入端同样支持 `--state-file` 选择性导入。归档默认 **24 小时过期**：`--expires-hours` 可调整，`--no-expiry` 关闭；导入端默认拒绝过期归档，确认可信时加 `--allow-expired`。归档文件本身包含明文凭据，请**只在 SSH/scp 中传输，用后删除**；需要落到共享磁盘时使用 `--encrypt`（PBKDF2 + Fernet 加密，密码可设置 `SJTU_AGENT_CONFIG_PASSWORD`）。
 
 默认路径：
 
@@ -135,9 +135,18 @@ sjtu-agent web --no-browser          # 在服务器执行
 
 ```bash
 sjtu-agent web --host 0.0.0.0 --port 7860 --no-browser
+
+# 生成 Nginx 配置（含 certbot 路径、HTTP→HTTPS 跳转、SSE 参数）
+sjtu-agent web-proxy --type nginx --domain sjtu-agent.example.com --output sjtu-agent.conf
+sudo cp sjtu-agent.conf /etc/nginx/conf.d/sjtu-agent.conf
+sudo certbot --nginx -d sjtu-agent.example.com
+sudo nginx -t && sudo systemctl reload nginx
+
+# 或 Caddy（自动 HTTPS）
+sjtu-agent web-proxy --type caddy --domain sjtu-agent.example.com
 ```
 
-然后用 Nginx / Caddy 反代到 `https://你的域名`。**不要**把带明文 HTTP 的 `0.0.0.0:7860` 直接暴露到公网；Web UI 的访问令牌走 Cookie，明文传输会被窃取。
+**不要**把带明文 HTTP 的 `0.0.0.0:7860` 直接暴露到公网；Web UI 的访问令牌走 Cookie，明文传输会被窃取。
 
 ## 7. 已知限制与建议
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -250,7 +250,7 @@ sjtu-agent export-config --output sjtu-agent-config.tar.gz
 sjtu-agent import-config sjtu-agent-config.tar.gz --yes
 ```
 
-推荐直接走 SSH 管道：`sjtu-agent export-config --output - | ssh server "sjtu-agent import-config - --yes"`。导入前会备份同名文件到运行时目录 `backups/`。详见 [SERVER_DEPLOYMENT.md](SERVER_DEPLOYMENT.md)。
+推荐直接走 SSH 管道：`sjtu-agent export-config --output - | ssh server "sjtu-agent import-config - --yes"`。归档默认 24 小时过期；导入前会备份同名文件到运行时目录 `backups/`。远程 Web UI 的 HTTPS 反代配置用 `sjtu-agent web-proxy --domain <域名>` 生成。详见 [SERVER_DEPLOYMENT.md](SERVER_DEPLOYMENT.md)。
 
 ### 仍然无法解决？
 

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -442,6 +442,27 @@ def _cmd_web(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_web_proxy(args: argparse.Namespace) -> int:
+    from sjtu_agent.web_proxy import generate_proxy_config, write_proxy_config
+
+    try:
+        if args.output:
+            destination = write_proxy_config(
+                Path(args.output),
+                kind=args.type,
+                domain=args.domain,
+                backend_port=args.port,
+                force=args.force,
+            )
+            print(f"已生成 HTTPS 反代配置：{destination}")
+        else:
+            sys.stdout.write(generate_proxy_config(args.type, args.domain, args.port))
+    except (OSError, ValueError) as exc:
+        print(f"[!] {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
 def _cmd_wechat_bot(args: argparse.Namespace) -> int:
     return _run_script("wechat_bot", args.script_args)
 
@@ -581,6 +602,8 @@ def _cmd_export_config(args: argparse.Namespace) -> int:
             print("[!] 密码不能为空。", file=sys.stderr)
             return 1
 
+    expires_hours = None if getattr(args, "no_expiry", False) else args.expires_hours
+
     if getattr(args, "output", None) == "-":
         # --output -：二进制写入 stdout，报告写入 stderr
         try:
@@ -588,6 +611,7 @@ def _cmd_export_config(args: argparse.Namespace) -> int:
                 include_state=args.with_state,
                 state_files=args.state_file,
                 encrypt_password=encrypt_password,
+                expires_hours=expires_hours,
             )
             sys.stdout.buffer.write(data)
             sys.stdout.buffer.flush()
@@ -608,6 +632,7 @@ def _cmd_export_config(args: argparse.Namespace) -> int:
             include_state=args.with_state,
             state_files=args.state_file,
             encrypt_password=encrypt_password,
+            expires_hours=expires_hours,
             force=args.force,
         )
     except (OSError, RuntimeError, ValueError) as exc:
@@ -677,6 +702,7 @@ def _cmd_import_config(args: argparse.Namespace) -> int:
             decrypt_password=decrypt_password,
             skip_state=args.skip_state,
             state_files=args.state_file,
+            allow_expired=args.allow_expired,
             dry_run=args.dry_run,
         )
     except (OSError, RuntimeError, ValueError) as exc:
@@ -802,6 +828,39 @@ def build_parser() -> argparse.ArgumentParser:
         help="start the server without opening the browser automatically",
     )
     web_parser.set_defaults(func=_cmd_web)
+
+    web_proxy_parser = subparsers.add_parser(
+        "web-proxy",
+        help="generate an Nginx or Caddy HTTPS reverse-proxy config for the Web UI",
+    )
+    web_proxy_parser.add_argument(
+        "--type",
+        choices=["nginx", "caddy"],
+        default="nginx",
+        help="reverse proxy type (default: nginx)",
+    )
+    web_proxy_parser.add_argument(
+        "--domain",
+        required=True,
+        help="public domain name, e.g. sjtu-agent.example.com",
+    )
+    web_proxy_parser.add_argument(
+        "--port",
+        type=int,
+        default=7860,
+        help="local Web UI port that the proxy should forward to (default: 7860)",
+    )
+    web_proxy_parser.add_argument(
+        "--output",
+        default=None,
+        help="write config to a file instead of stdout",
+    )
+    web_proxy_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite an existing output file",
+    )
+    web_proxy_parser.set_defaults(func=_cmd_web_proxy)
 
     _platform_name = current_platform_name()
     install_daemons_parser = subparsers.add_parser(
@@ -936,6 +995,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="encrypt the archive with a passphrase (prompts, or SJTU_AGENT_CONFIG_PASSWORD)",
     )
     export_config_parser.add_argument(
+        "--expires-hours",
+        type=int,
+        default=24,
+        help="archive validity in hours (default: 24; 1-720)",
+    )
+    export_config_parser.add_argument(
+        "--no-expiry",
+        action="store_true",
+        help="do not set an expiry time (not recommended for plaintext archives)",
+    )
+    export_config_parser.add_argument(
         "--force",
         action="store_true",
         help="overwrite an existing output file",
@@ -963,6 +1033,11 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["reminders.json", "user_profile.json", "dining_history.json"],
         default=[],
         help="select a specific state file to import; repeatable",
+    )
+    import_config_parser.add_argument(
+        "--allow-expired",
+        action="store_true",
+        help="import an archive even after its expires_at timestamp",
     )
     import_config_parser.add_argument(
         "--dry-run",

--- a/sjtu_agent/config_transfer.py
+++ b/sjtu_agent/config_transfer.py
@@ -17,6 +17,7 @@ sjtu_agent/config_transfer.py — 运行时配置的导出 / 导入
 from __future__ import annotations
 
 import base64
+import hashlib
 import io
 import json
 import os
@@ -24,7 +25,7 @@ import shutil
 import tarfile
 import tempfile
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -39,7 +40,9 @@ from sjtu_agent.paths import (
 )
 
 _FORMAT_NAME = "sjtu-agent-config"
-_FORMAT_VERSION = 1
+_FORMAT_VERSION = 2
+_DEFAULT_EXPIRY_HOURS = 24
+_MAX_EXPIRY_HOURS = 720
 _MAGIC = b"SJTUAGENTCFG\x00\x01"
 _SALT_LENGTH = 16
 _KDF_ITERATIONS = 600_000
@@ -171,13 +174,41 @@ def _normalise_state_files(state_files: Iterable[str] | None) -> set[str]:
     return selected
 
 
+def _normalise_expiry(expires_hours: int | None) -> int | None:
+    if expires_hours is None:
+        return None
+    try:
+        value = int(expires_hours)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("--expires-hours 必须是整数小时数，或用 --no-expiry 关闭过期") from exc
+    if value < 1 or value > _MAX_EXPIRY_HOURS:
+        raise ValueError(f"--expires-hours 必须在 1-{_MAX_EXPIRY_HOURS} 之间")
+    return value
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _parse_iso_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def export_bytes(
     *,
     include_state: bool = False,
     state_files: Iterable[str] | None = None,
     encrypt_password: str | None = None,
+    expires_hours: int | None = _DEFAULT_EXPIRY_HOURS,
 ) -> bytes:
-    """把运行时配置打包为 tar.gz 字节流。"""
+    """把运行时配置打包为 tar.gz 字节流。
+
+    expires_hours 默认 24 小时；None 表示不设置过期时间（不推荐用于明文归档）。
+    """
+    expiry = _normalise_expiry(expires_hours)
     selected_state = _normalise_state_files(state_files)
     if include_state:
         selected_state = set(_STATE_NAMES)
@@ -197,17 +228,27 @@ def export_bytes(
             "没有可导出的运行时配置。请先运行 sjtu-agent setup 或 sjtu-agent doctor 检查。"
         )
 
-    manifest = {
+    created_at = datetime.now(timezone.utc)
+    manifest: dict[str, Any] = {
         "format": _FORMAT_NAME,
         "version": _FORMAT_VERSION,
-        "files": names,
+        "created_at": created_at.isoformat(),
+        "files": [],
     }
+    if expiry is not None:
+        manifest["expires_at"] = (created_at + timedelta(hours=expiry)).isoformat()
 
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
-        _tar_bytes_entry(tar, "manifest.json", json.dumps(manifest, ensure_ascii=False).encode("utf-8"))
         for name in names:
-            _tar_bytes_entry(tar, name, _read_bytes(_PATH_BY_NAME[name]))
+            content = _read_bytes(_PATH_BY_NAME[name])
+            manifest["files"].append({"name": name, "sha256": _sha256(content)})
+            _tar_bytes_entry(tar, name, content)
+        _tar_bytes_entry(
+            tar,
+            "manifest.json",
+            json.dumps(manifest, ensure_ascii=False).encode("utf-8"),
+        )
 
     data = buffer.getvalue()
     if encrypt_password is not None:
@@ -221,6 +262,7 @@ def _parse_archive(
     decrypt_password: str | None = None,
     skip_state: bool = False,
     state_files: Iterable[str] | None = None,
+    allow_expired: bool = False,
 ) -> dict[str, bytes]:
     """解密（如需要）、解包并校验归档，返回 name -> bytes。"""
     selected_state = _normalise_state_files(state_files)
@@ -254,13 +296,34 @@ def _parse_archive(
             if manifest_version > _FORMAT_VERSION:
                 raise ValueError(f"归档版本 {manifest.get('version')} 高于当前支持的版本 {_FORMAT_VERSION}")
 
+            expires_at = manifest.get("expires_at")
+            if isinstance(expires_at, str) and not allow_expired:
+                try:
+                    if _parse_iso_utc(expires_at) < datetime.now(timezone.utc):
+                        raise ValueError(
+                            f"配置归档已过期（{expires_at}）。"
+                            "请重新导出；若确认归档可信，可添加 --allow-expired 导入。"
+                        )
+                except ValueError:
+                    raise
+
             files = manifest.get("files", [])
             if not isinstance(files, list) or not files:
                 raise ValueError("归档 manifest 中没有可导入的文件")
 
             contents: dict[str, bytes] = {}
-            for raw_name in files:
-                name = _tar_member_name(str(raw_name))
+            for entry in files:
+                # v2 文件列表为 [{"name": ..., "sha256": ...}]，兼容 v1 的 [文件名]。
+                if isinstance(entry, str):
+                    raw_name = entry
+                    expected_sha256: str | None = None
+                elif isinstance(entry, dict):
+                    raw_name = entry.get("name")
+                    expected_sha256 = entry.get("sha256")
+                else:
+                    raise ValueError(f"归档 manifest 文件条目格式无效：{entry!r}")
+
+                name = _tar_member_name(str(raw_name or ""))
                 if name is None:
                     raise ValueError(f"归档包含不允许的文件：{raw_name!r}")
                 if skip_state and name in _STATE_NAMES:
@@ -284,6 +347,8 @@ def _parse_archive(
                         json.loads(content.decode("utf-8"))
                     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
                         raise ValueError(f"{name} 不是有效 JSON：{exc}") from exc
+                if expected_sha256 and _sha256(content) != expected_sha256:
+                    raise ValueError(f"{name} 的 SHA-256 校验失败，归档可能已损坏或被篡改")
                 contents[name] = content
 
             if not contents:
@@ -300,12 +365,14 @@ def import_bytes(
     decrypt_password: str | None = None,
     skip_state: bool = False,
     state_files: Iterable[str] | None = None,
+    allow_expired: bool = False,
     dry_run: bool = False,
     backup: bool = True,
 ) -> dict[str, Any]:
     """把导出归档导入到目标运行时目录。
 
     state_files 可精确选择要导入的状态文件；skip_state=True 时忽略所有状态文件。
+    allow_expired=True 允许导入已超过 expires_at 的归档（默认拒绝）。
     返回报告；dry_run 时不写任何文件也不备份。
     """
     target = Path(target_dir or DATA_DIR)
@@ -315,6 +382,7 @@ def import_bytes(
         decrypt_password=decrypt_password,
         skip_state=skip_state,
         state_files=state_files,
+        allow_expired=allow_expired,
     )
 
     report: dict[str, Any] = {
@@ -386,6 +454,7 @@ def export_to_path(
     include_state: bool = False,
     state_files: Iterable[str] | None = None,
     encrypt_password: str | None = None,
+    expires_hours: int | None = _DEFAULT_EXPIRY_HOURS,
     force: bool = False,
 ) -> dict[str, Any]:
     """导出到本地文件，返回报告。"""
@@ -395,6 +464,7 @@ def export_to_path(
         include_state=include_state,
         state_files=state_files,
         encrypt_password=encrypt_password,
+        expires_hours=expires_hours,
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write_bytes(destination, data)

--- a/sjtu_agent/web_proxy.py
+++ b/sjtu_agent/web_proxy.py
@@ -1,0 +1,129 @@
+"""
+sjtu_agent/web_proxy.py — 为 `sjtu-agent web` 生成 HTTPS 反向代理配置
+
+本地 Web UI 默认只监听 127.0.0.1；如需远程访问，推荐：
+    sjtu-agent web --host 0.0.0.0 --port 7860 --no-browser
+
+然后由 Nginx / Caddy 提供 HTTPS 反代。这里只生成可直接使用的配置片段。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DOMAIN_RE = re.compile(
+    r"^(?=.{1,253}\.?$)(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.?$"
+)
+
+
+def validate_domain(domain: str) -> str:
+    value = domain.strip().lower().rstrip(".")
+    if not value or not _DOMAIN_RE.match(value):
+        raise ValueError(
+            f"无效的域名：{domain!r}。HTTPS 反代需要一个真实域名（如 sjtu-agent.example.com）。"
+        )
+    return value
+
+
+def validate_port(port: int, label: str = "port") -> int:
+    try:
+        value = int(port)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} 必须是 1-65535 的端口号") from exc
+    if not 1 <= value <= 65535:
+        raise ValueError(f"{label} 必须是 1-65535 的端口号")
+    return value
+
+
+def _nginx_config(domain: str, backend_port: int) -> str:
+    return f"""\
+# SJTU Agent Web UI — Nginx HTTPS 反向代理
+# 放置到 /etc/nginx/conf.d/sjtu-agent.conf 后执行：
+#   nginx -t && systemctl reload nginx
+#
+# 首次申请证书：
+#   apt install -y nginx certbot python3-certbot-nginx
+#   certbot --nginx -d {domain}
+
+server {{
+    listen 443 ssl http2;
+    server_name {domain};
+
+    ssl_certificate     /etc/letsencrypt/live/{domain}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{domain}/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    location / {{
+        proxy_pass http://127.0.0.1:{backend_port};
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+
+        # Web UI 聊天使用 SSE 长连接，必须关闭缓冲并放宽超时。
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+        proxy_connect_timeout 10s;
+    }}
+}}
+
+server {{
+    listen 80;
+    server_name {domain};
+    return 301 https://$host$request_uri;
+}}
+"""
+
+
+def _caddy_config(domain: str, backend_port: int) -> str:
+    return f"""\
+# SJTU Agent Web UI — Caddy 自动 HTTPS 反向代理
+# 放入 Caddyfile（或 /etc/caddy/Caddyfile 对应站点块）后执行：
+#   caddy validate --config Caddyfile
+#   systemctl reload caddy
+
+{domain} {{
+    reverse_proxy 127.0.0.1:{backend_port} {{
+        # SSE 长连接
+        flush_interval -1
+    }}
+}}
+"""
+
+
+def generate_proxy_config(
+    kind: str,
+    domain: str,
+    backend_port: int = 7860,
+) -> str:
+    """生成 Nginx 或 Caddy 的 HTTPS 反向代理配置。"""
+    kind_value = (kind or "nginx").strip().lower()
+    domain_value = validate_domain(domain)
+    backend_port_value = validate_port(backend_port, "backend port")
+
+    if kind_value == "nginx":
+        return _nginx_config(domain_value, backend_port_value)
+    if kind_value == "caddy":
+        return _caddy_config(domain_value, backend_port_value)
+    raise ValueError(f"不支持的反代类型：{kind!r}（可选 nginx / caddy）")
+
+
+def write_proxy_config(
+    destination: Path,
+    kind: str,
+    domain: str,
+    backend_port: int = 7860,
+    force: bool = False,
+) -> Path:
+    destination = Path(destination)
+    if destination.exists() and not force:
+        raise FileExistsError(f"目标文件已存在（--force 可覆盖）：{destination}")
+    content = generate_proxy_config(kind, domain, backend_port)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(content, encoding="utf-8")
+    return destination

--- a/tests/test_config_transfer.py
+++ b/tests/test_config_transfer.py
@@ -167,3 +167,67 @@ def test_invalid_state_file_is_rejected(monkeypatch, tmp_path):
     _patch_sources(monkeypatch, source)
     with pytest.raises(ValueError, match="不支持的状态文件"):
         ct.export_bytes(state_files=["evil.json"])
+
+
+def _make_archive(manifest: dict, files: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        manifest_bytes = json.dumps(manifest).encode("utf-8")
+        for name, payload in [("manifest.json", manifest_bytes), *files.items()]:
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
+def test_expired_archive_is_rejected_by_default(monkeypatch, tmp_path):
+    target = tmp_path / "target"
+    archive = _make_archive(
+        {
+            "format": "sjtu-agent-config",
+            "version": 2,
+            "expires_at": "2000-01-01T00:00:00+00:00",
+            "files": [{"name": "config.json", "sha256": ct._sha256(b"{}")}],
+        },
+        {"config.json": b"{}"},
+    )
+    with pytest.raises(ValueError, match="已过期"):
+        ct.import_bytes(archive, target_dir=target)
+    report = ct.import_bytes(archive, target_dir=target, allow_expired=True)
+    assert report["written"] == ["config.json"]
+
+
+def test_checksum_mismatch_is_rejected(tmp_path):
+    archive = _make_archive(
+        {
+            "format": "sjtu-agent-config",
+            "version": 2,
+            "files": [{"name": "config.json", "sha256": "0" * 64}],
+        },
+        {"config.json": b"{}"},
+    )
+    with pytest.raises(ValueError, match="SHA-256"):
+        ct.import_bytes(archive, target_dir=tmp_path / "target")
+
+
+def test_v1_legacy_archive_without_checksum_is_still_accepted(tmp_path):
+    archive = _make_archive(
+        {"format": "sjtu-agent-config", "version": 1, "files": ["config.json"]},
+        {"config.json": b"{}"},
+    )
+    report = ct.import_bytes(archive, target_dir=tmp_path / "target")
+    assert report["written"] == ["config.json"]
+
+
+def test_export_manifest_contains_expiry_and_checksums(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    _make_source(source)
+    _patch_sources(monkeypatch, source)
+
+    data = ct.export_bytes(expires_hours=6)
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        manifest = json.loads(tar.extractfile("manifest.json").read().decode("utf-8"))
+    assert manifest["version"] == 2
+    assert manifest["created_at"]
+    assert manifest["expires_at"]
+    assert manifest["files"][0]["sha256"]

--- a/tests/test_web_proxy.py
+++ b/tests/test_web_proxy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from sjtu_agent.web_proxy import generate_proxy_config, validate_domain, write_proxy_config
+
+
+def test_validate_domain():
+    assert validate_domain("sjtu-agent.example.com") == "sjtu-agent.example.com"
+    assert validate_domain("SJTU-Agent.Example.COM.") == "sjtu-agent.example.com"
+    with pytest.raises(ValueError):
+        validate_domain("https://sjtu-agent.example.com")
+    with pytest.raises(ValueError):
+        validate_domain("not a domain")
+
+
+def test_generate_nginx_config():
+    config = generate_proxy_config("nginx", "sjtu-agent.example.com", 7860)
+    assert "server_name sjtu-agent.example.com;" in config
+    assert "proxy_pass http://127.0.0.1:7860;" in config
+    assert "proxy_buffering off;" in config
+    assert "listen 443 ssl" in config
+    assert "return 301 https://$host$request_uri;" in config
+
+
+def test_generate_caddy_config():
+    config = generate_proxy_config("caddy", "sjtu-agent.example.com", 8080)
+    assert "sjtu-agent.example.com {" in config
+    assert "reverse_proxy 127.0.0.1:8080" in config
+    assert "flush_interval -1" in config
+
+
+def test_unknown_proxy_type():
+    with pytest.raises(ValueError, match="不支持"):
+        generate_proxy_config("apache", "sjtu-agent.example.com")
+
+
+def test_write_proxy_config(tmp_path):
+    target = tmp_path / "nginx.conf"
+    written = write_proxy_config(target, "nginx", "sjtu-agent.example.com")
+    assert written == target
+    assert "proxy_pass" in target.read_text(encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        write_proxy_config(target, "nginx", "sjtu-agent.example.com")
+
+    write_proxy_config(target, "nginx", "sjtu-agent.example.com", force=True)


### PR DESCRIPTION
## 本轮内容

### 1. Web UI HTTPS 反代配置生成器
- 新增 `sjtu-agent web-proxy`
- 支持 `--type nginx` / `--type caddy`、`--domain`、`--port`、`--output`
- Nginx 配置包含 certbot 路径、HTTP→HTTPS 跳转、SSE 长连接所需参数；Caddy 自动 HTTPS

### 2. 配置归档过期与校验
- 导出归档默认 **24 小时过期**：`--expires-hours` / `--no-expiry`
- 导入端默认拒绝过期归档：`--allow-expired` 放宽
- 归档 manifest v2 增加 `created_at` / `expires_at` 和每个文件的 SHA-256
- 校验失败拒绝导入；兼容 v1 旧归档

### 3. GitHub Actions 自动发布
- 新增 `.github/workflows/release.yml`
- 推送 `v*` tag 后：Python 3.11/3.13 测试 → 构建 wheel/sdist → 从 CHANGELOG 生成 Release Notes → 自动创建 GitHub Release 并上传构建产物

### 4. README 优化
- 增加目录、常用命令速查表、Pages/Release badges
- 补充远程 Web UI、HTTPS 反代和归档过期说明（中英文）
- 服务器部署与排错文档同步更新

### 测试
- 新增 `web-proxy` 测试 5 个、归档过期/校验/兼容性测试 5 个