### PR TITLE
feat: Textual TUI with Web-synced sessions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e ".[tui]"
           pip install pytest
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e ".[tui]"
 
       - name: Install test deps
         run: pip install pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,5 @@ dependencies = {file = ["requirements.txt"]}
 [project.optional-dependencies]
 # 按需所取：语义记忆（跨会话语义检索）需要 chromadb
 memory = ["chromadb>=0.5.0"]
+# 按需所取：全屏终端 TUI 需要 textual（sjtu-agent tui）
+tui = ["textual>=0.80"]

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -442,6 +442,11 @@ def _cmd_web(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_tui(args: argparse.Namespace) -> int:
+    from sjtu_agent.tui import run
+    return run()
+
+
 def _cmd_web_proxy(args: argparse.Namespace) -> int:
     from sjtu_agent.web_proxy import generate_proxy_config, write_proxy_config
 
@@ -828,6 +833,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="start the server without opening the browser automatically",
     )
     web_parser.set_defaults(func=_cmd_web)
+
+    tui_parser = subparsers.add_parser(
+        "tui",
+        help="start the full-screen Textual terminal UI (requires: pip install -e \".[tui]\")",
+    )
+    tui_parser.set_defaults(func=_cmd_tui)
 
     web_proxy_parser = subparsers.add_parser(
         "web-proxy",

--- a/sjtu_agent/tui/__init__.py
+++ b/sjtu_agent/tui/__init__.py
@@ -1,0 +1,18 @@
+"""
+sjtu_agent.tui — Textual 全屏终端聊天界面（可选依赖）。
+
+入口：
+    sjtu-agent tui
+
+会话与 Web GUI 共用同一个 SQLite store（web_sessions.sqlite3）。
+"""
+
+from .engine import new_store
+
+
+def run() -> int:
+    from .app import run_tui
+    return run_tui()
+
+
+__all__ = ["new_store", "run"]

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -3,6 +3,10 @@ sjtu_agent/tui/app.py — Textual 全屏聊天界面。
 
 Textual 是可选依赖：本模块只在 `sjtu-agent tui` 被调用时通过 run_tui()
 延迟导入；未安装时给出安装提示，不影响其余 CLI 功能。
+
+消息区使用 VerticalScroll + Markdown widgets：
+- 历史消息按条渲染，Markdown 完整排版
+- 当前回复是单一 Markdown widget，流式更新
 """
 
 from __future__ import annotations
@@ -22,12 +26,12 @@ def run_tui() -> int:
     try:
         from textual import on
         from textual.app import App, ComposeResult
-        from textual.containers import Horizontal, Vertical
-        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, RichLog, Static
-        from rich.markup import escape
+        from textual.containers import Horizontal, Vertical, VerticalScroll
+        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Markdown, Static
     except ImportError as exc:
-        print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=__import__("sys").stderr)
-        print(f"详细错误：{exc}", file=__import__("sys").stderr)
+        import sys
+        print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=sys.stderr)
+        print(f"详细错误：{exc}", file=sys.stderr)
         return 1
 
     class ChatApp(App):
@@ -36,7 +40,8 @@ def run_tui() -> int:
         CSS = """
         #main { height: 1fr; }
         #sessions { width: 32; border-right: solid $primary-darken-2; }
-        #chat { width: 1fr; height: 1fr; }
+        #messages { width: 1fr; height: 1fr; padding: 1 2; }
+        #messages Markdown { margin: 0 0 1 0; }
         #prompt { dock: bottom; }
         #suggestions {
             height: auto;
@@ -44,7 +49,6 @@ def run_tui() -> int:
             padding: 0 1;
             color: $text-muted;
         }
-        #suggestions .active { color: $secondary; text-style: bold; }
         """
 
         BINDINGS = [
@@ -62,24 +66,26 @@ def run_tui() -> int:
             self.pending_approval: dict[str, Any] | None = None
             self.suggestions: list[dict[str, Any]] = []
             self.suggestion_index = 0
+            self.stream_text = ""
+            self.turn_session: str | None = None
 
         @property
         def session_id(self) -> str | None:
             return self.model.current_id
+
+        @property
+        def messages(self) -> VerticalScroll:
+            return self.query_one("#messages", VerticalScroll)
 
         def compose(self) -> ComposeResult:
             yield Header()
             with Vertical():
                 with Horizontal(id="main"):
                     yield ListView(id="sessions")
-                    yield RichLog(id="chat", markup=True, wrap=True)
+                    yield VerticalScroll(id="messages")
                 yield Input(placeholder="输入消息，/ 执行斜杠命令，Enter 发送", id="prompt")
                 yield Static(id="suggestions")
             yield Footer()
-
-        @property
-        def chat(self) -> RichLog:
-            return self.query_one("#chat", RichLog)
 
         async def on_mount(self) -> None:
             await self.refresh_sessions()
@@ -87,10 +93,13 @@ def run_tui() -> int:
 
         # ── 会话 ─────────────────────────────────────────────────────────
         async def action_new_session(self) -> None:
+            if self.busy and self.session_id:
+                cancel_turn(self.session_id)
             session = self.model.create_session("新会话")
             self.pending_approval = None
+            self.busy = False
             await self.refresh_sessions(select_id=session.get("id"))
-            self.load_session(session.get("id") or "")
+            await self.load_session(session.get("id") or "")
 
         def action_focus_prompt(self) -> None:
             self.query_one("#prompt", Input).focus()
@@ -99,7 +108,6 @@ def run_tui() -> int:
             if not self.busy or not self.session_id:
                 return
             cancel_turn(self.session_id)
-            self.chat.write("\n[dim]已请求停止…[/]")
 
         async def refresh_sessions(self, select_id: str | None = None) -> None:
             session_list = self.query_one("#sessions", ListView)
@@ -114,25 +122,33 @@ def run_tui() -> int:
                 if session["id"] == target:
                     session_list.index = index
 
-        def load_session(self, session_id: str) -> None:
+        async def load_session(self, session_id: str) -> None:
             self.model.select(session_id)
-            chat = self.query_one("#chat", RichLog)
-            chat.clear()
+            await self.messages.remove_children()
             session = self.model.get_current()
-            chat.write(f"[bold]会话：{(session or {}).get('title', '')}[/]\n")
+            title = (session or {}).get("title", "")
+            await self.messages.mount(Markdown(f"# {title}"))
             for message in self.model.messages(session_id):
                 text = display_text(message.get("content", ""))
                 if message.get("role") == "user":
-                    chat.write(f"[bold cyan]你[/] {escape(text)}")
+                    await self.messages.mount(Markdown(f"> **你**\n\n{text}"))
                 else:
-                    chat.write(f"[bold green]Agent[/] {escape(text)}")
+                    await self.messages.mount(Markdown(text))
+            self.messages.scroll_end(animate=False)
 
         @on(ListView.Selected)
-        def on_session_selected(self, event) -> None:
+        async def on_session_selected(self, event) -> None:
             item_id = getattr(event.item, "id", "") or ""
             if not item_id.startswith("session-"):
                 return
-            self.load_session(item_id[len("session-"):])
+            target = item_id[len("session-"):]
+            if target == self.session_id:
+                return
+            if self.busy and self.session_id:
+                cancel_turn(self.session_id)
+            self.busy = False
+            self.pending_approval = None
+            await self.load_session(target)
 
         # ── / 命令补全 ──────────────────────────────────────────────────
         def render_suggestions(self) -> None:
@@ -193,10 +209,15 @@ def run_tui() -> int:
             approved = text.lower() in {"approve", "yes", "y", "同意", "允许"}
             if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
                 self.pending_approval = approval
-                self.chat.write("[yellow]请输入 approve / deny 确认审批[/]")
+                self.stream_text += "\n\n> 请输入 approve 或 deny。"
+                self.run_worker(self.flush_stream(), group="stream", exclusive=True)
                 return
             decide_approval(str(approval.get("approval_id", "")), approved)
-            self.chat.write(f"[dim]{'已批准' if approved else '已拒绝'}：{approval.get('tool_name', '')}[/]")
+            self.stream_text += (
+                f"\n\n_{'已批准' if approved else '已拒绝'}："
+                f"{approval.get('tool_name', '')}_"
+            )
+            self.run_worker(self.flush_stream(), group="stream", exclusive=True)
 
         async def start_turn(self, text: str) -> None:
             if self.session_id is None:
@@ -204,69 +225,88 @@ def run_tui() -> int:
                 await self.refresh_sessions(select_id=session.get("id"))
             session_id = self.model.ensure_for_message(text)
             if not session_id:
-                self.chat.write("[red]无法创建会话[/]")
+                await self.messages.mount(Markdown("> 无法创建会话"))
                 return
 
+            await self.messages.mount(Markdown(f"> **你**\n\n{text}"))
+            self.stream_text = ""
+            await self.messages.mount(Markdown(id="stream-markdown"))
+
             self.busy = True
-            self.chat.write(f"[bold cyan]你[/] {escape(text)}")
+            self.turn_session = session_id
             command_mode = text.startswith("/") and is_core_command(text)
-            self.chat.write(
-                f"[dim]{'⚡ 执行命令…' if command_mode else '…'}"
-            )
             threading.Thread(
                 target=self._run_stream,
-                args=(text, command_mode),
+                args=(text, command_mode, session_id),
                 daemon=True,
             ).start()
 
-        def _run_stream(self, text: str, command_mode: bool) -> None:
+        def _run_stream(self, text: str, command_mode: bool, turn_session: str) -> None:
             try:
                 stream = (
-                    iter_command_events(self.session_id, text)
+                    iter_command_events(turn_session, text)
                     if command_mode
-                    else iter_chat_events(self.session_id, text)
+                    else iter_chat_events(turn_session, text)
                 )
                 for event in stream:
                     if event.get("kind") == "done":
                         break
-                    self.call_from_thread(self.render_event, event)
+                    self.call_from_thread(self.render_event, event, turn_session)
             except Exception as exc:
-                self.call_from_thread(self.render_event, {"kind": "error", "text": str(exc)})
+                self.call_from_thread(
+                    self.render_event,
+                    {"kind": "error", "text": str(exc)},
+                    turn_session,
+                )
             finally:
-                self.call_from_thread(self.finish_turn)
+                self.call_from_thread(self.finish_turn, turn_session)
 
-        def render_event(self, event: dict[str, Any]) -> None:
+        # ── 渲染（App 线程）─────────────────────────────────────────────
+        def render_event(self, event: dict[str, Any], turn_session: str) -> None:
+            if turn_session != self.session_id:
+                return
             kind = event.get("kind")
-            chat = self.query_one("#chat", RichLog)
             if kind == "token":
-                chat.write(escape(str(event.get("text", ""))))
+                self.stream_text += str(event.get("text", ""))
             elif kind == "tool_start":
-                chat.write(f"\n🔧 {escape(str(event.get('name', '')))}")
+                self.stream_text += f"\n\n🔧 **{event.get('name', '')}**"
             elif kind == "tool_end":
-                chat.write(f" ✓ {escape(str(event.get('name', '')))}")
+                self.stream_text += f"\n\n✅ **{event.get('name', '')}** 完成"
             elif kind == "approval_required":
                 self.pending_approval = event
-                chat.write(
-                    f"\n[yellow]⚠️ 需要确认工具调用：{escape(str(event.get('tool_name', '')))}\n"
-                    f"参数：{escape(json.dumps(event.get('arguments', {}), ensure_ascii=False))}\n"
-                    "输入 approve 或 deny[/]"
+                self.stream_text += (
+                    f"\n\n⚠️ **需要确认：{event.get('tool_name', '')}**\n\n"
+                    f"```json\n{json.dumps(event.get('arguments', {}), ensure_ascii=False)}\n```\n\n"
+                    "输入 `approve` 或 `deny`"
                 )
             elif kind == "command_start":
-                chat.write(f"\n⚡ {escape(str(event.get('raw', '')))}")
+                self.stream_text += f"\n\n⚡ `{event.get('raw', '')}`"
             elif kind == "command_progress":
-                chat.write(f"[dim]{escape(str(event.get('message', '')))}[/]")
+                self.stream_text += f"\n\n_{event.get('message', '')}_"
             elif kind == "command_result":
-                chat.write("\n" + escape(str(event.get("text", ""))))
+                self.stream_text += "\n\n" + str(event.get("text", ""))
             elif kind == "error":
-                chat.write(f"\n[red]错误：{escape(str(event.get('text', '')))}[/]")
+                self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
             elif kind == "cancelled":
-                chat.write("\n[dim]已取消[/]")
+                self.stream_text += "\n\n_已取消_"
+            self.run_worker(self.flush_stream(), group="stream", exclusive=True)
 
-        async def finish_turn(self) -> None:
-            self.busy = False
-            self.pending_approval = None
-            self.chat.write("\n")
-            await self.refresh_sessions(select_id=self.session_id)
+        async def flush_stream(self) -> None:
+            try:
+                markdown = self.query_one("#stream-markdown", Markdown)
+            except Exception:
+                return
+            await markdown.update(self.stream_text)
+            self.messages.scroll_end(animate=False)
+
+        def finish_turn(self, turn_session: str) -> None:
+            if turn_session == self.session_id:
+                self.busy = False
+                self.pending_approval = None
+            self.run_worker(
+                self.refresh_sessions(select_id=turn_session),
+                group="sessions-refresh",
+            )
 
     ChatApp().run()
     return 0

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -1,8 +1,8 @@
 """
 sjtu_agent/tui/app.py — Textual 全屏聊天界面。
 
-Textual 是可选依赖：本模块只在 `sjtu-agent tui` 被调用时通过 run_tui()
-延迟导入；未安装时给出安装提示，不影响其余 CLI 功能。
+Textual 是可选依赖：本模块导入失败时 TEXTUAL_AVAILABLE=False，
+run_tui() 给出安装提示；其余 CLI 功能不受影响。
 
 消息区使用 VerticalScroll + Markdown widgets：
 - 历史消息按条渲染，Markdown 完整排版
@@ -21,18 +21,22 @@ from .messages import display_text
 from .session_model import TuiSessionModel
 from sjtu_agent.commands import is_core_command
 
+try:
+    from textual import on
+    from textual.app import App, ComposeResult
+    from textual.containers import Horizontal, Vertical, VerticalScroll
+    from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Markdown, Static
+    TEXTUAL_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on optional extra
+    App = None  # type: ignore[assignment]
+    ComposeResult = None  # type: ignore[assignment]
+    Horizontal = Vertical = VerticalScroll = None  # type: ignore[assignment]
+    Footer = Header = Input = Label = ListItem = ListView = Markdown = Static = None  # type: ignore[assignment]
+    on = None  # type: ignore[assignment]
+    TEXTUAL_AVAILABLE = False
 
-def run_tui() -> int:
-    try:
-        from textual import on
-        from textual.app import App, ComposeResult
-        from textual.containers import Horizontal, Vertical, VerticalScroll
-        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Markdown, Static
-    except ImportError as exc:
-        import sys
-        print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=sys.stderr)
-        print(f"详细错误：{exc}", file=sys.stderr)
-        return 1
+
+if TEXTUAL_AVAILABLE:
 
     class ChatApp(App):
         """与 Web GUI 共用 session store 的 Textual 聊天客户端。"""
@@ -89,6 +93,8 @@ def run_tui() -> int:
 
         async def on_mount(self) -> None:
             await self.refresh_sessions()
+            if self.session_id:
+                await self.load_session(self.session_id)
             self.query_one("#prompt", Input).focus()
 
         # ── 会话 ─────────────────────────────────────────────────────────
@@ -113,27 +119,34 @@ def run_tui() -> int:
             session_list = self.query_one("#sessions", ListView)
             await session_list.clear()
             target = select_id or self.session_id
-            for index, session in enumerate(self.model.list_sessions()):
-                item = ListItem(
-                    Label(session.get("title") or "未命名会话"),
-                    id=f"session-{session['id']}",
+            items = []
+            for session in self.model.list_sessions():
+                items.append(
+                    ListItem(
+                        Label(session.get("title") or "未命名会话"),
+                        id=f"session-{session['id']}",
+                    )
                 )
-                session_list.append(item)
-                if session["id"] == target:
-                    session_list.index = index
+            await session_list.extend(items)
+            if target:
+                for index, session in enumerate(self.model.list_sessions()):
+                    if session["id"] == target:
+                        session_list.index = index
+                        break
 
         async def load_session(self, session_id: str) -> None:
             self.model.select(session_id)
             await self.messages.remove_children()
             session = self.model.get_current()
             title = (session or {}).get("title", "")
-            await self.messages.mount(Markdown(f"# {title}"))
+            widgets: list[Markdown] = [Markdown(f"# {title}")]
             for message in self.model.messages(session_id):
                 text = display_text(message.get("content", ""))
                 if message.get("role") == "user":
-                    await self.messages.mount(Markdown(f"> **你**\n\n{text}"))
+                    widgets.append(Markdown(f"> **你**\n\n{text}"))
                 else:
-                    await self.messages.mount(Markdown(text))
+                    widgets.append(Markdown(text))
+            await self.messages.mount(*widgets)
             self.messages.scroll_end(animate=False)
 
         @on(ListView.Selected)
@@ -228,10 +241,13 @@ def run_tui() -> int:
                 await self.messages.mount(Markdown("> 无法创建会话"))
                 return
 
-            await self.messages.mount(Markdown(f"> **你**\n\n{text}"))
-            self.stream_text = ""
-            await self.messages.mount(Markdown(id="stream-markdown"))
+            await self.messages.mount(
+                Markdown(f"> **你**\n\n{text}"),
+                Markdown(id="stream-markdown"),
+            )
+            self.messages.scroll_end(animate=False)
 
+            self.stream_text = ""
             self.busy = True
             self.turn_session = session_id
             command_mode = text.startswith("/") and is_core_command(text)
@@ -251,15 +267,22 @@ def run_tui() -> int:
                 for event in stream:
                     if event.get("kind") == "done":
                         break
-                    self.call_from_thread(self.render_event, event, turn_session)
+                    self.post_thread_event(self.render_event, event, turn_session)
             except Exception as exc:
-                self.call_from_thread(
+                self.post_thread_event(
                     self.render_event,
                     {"kind": "error", "text": str(exc)},
                     turn_session,
                 )
             finally:
-                self.call_from_thread(self.finish_turn, turn_session)
+                self.post_thread_event(self.finish_turn, turn_session)
+
+        def post_thread_event(self, callback, *args) -> None:
+            """从 worker 线程安全地投递 UI 回调；app 关闭后静默丢弃。"""
+            try:
+                self.call_from_thread(callback, *args)
+            except RuntimeError:
+                pass
 
         # ── 渲染（App 线程）─────────────────────────────────────────────
         def render_event(self, event: dict[str, Any], turn_session: str) -> None:
@@ -289,7 +312,10 @@ def run_tui() -> int:
                 self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
             elif kind == "cancelled":
                 self.stream_text += "\n\n_已取消_"
-            self.run_worker(self.flush_stream(), group="stream", exclusive=True)
+            try:
+                self.run_worker(self.flush_stream(), group="stream", exclusive=True)
+            except RuntimeError:
+                pass
 
         async def flush_stream(self) -> None:
             try:
@@ -303,10 +329,25 @@ def run_tui() -> int:
             if turn_session == self.session_id:
                 self.busy = False
                 self.pending_approval = None
-            self.run_worker(
-                self.refresh_sessions(select_id=turn_session),
-                group="sessions-refresh",
-            )
+            try:
+                self.run_worker(
+                    self.refresh_sessions(select_id=turn_session),
+                    group="sessions-refresh",
+                )
+            except RuntimeError:
+                pass
 
-    ChatApp().run()
+
+def build_app() -> "App | None":
+    if not TEXTUAL_AVAILABLE:
+        return None
+    return ChatApp()
+
+
+def run_tui() -> int:
+    if not TEXTUAL_AVAILABLE:
+        import sys
+        print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=sys.stderr)
+        return 1
+    build_app().run()  # type: ignore[union-attr]
     return 0

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -72,6 +72,7 @@ if TEXTUAL_AVAILABLE:
             self.suggestion_index = 0
             self.stream_text = ""
             self.turn_session: str | None = None
+            self.stream_flush_timer = None
 
         @property
         def session_id(self) -> str | None:
@@ -232,8 +233,17 @@ if TEXTUAL_AVAILABLE:
                     exclusive=exclusive,
                     exit_on_error=False,
                 )
-            except RuntimeError:
+            except Exception:
                 pass
+
+        def schedule_stream_flush(self) -> None:
+            """节流刷新流式 Markdown：最多每 80ms 更新一次，避免 worker 互斥取消。"""
+            if self.stream_flush_timer is not None:
+                return
+            try:
+                self.stream_flush_timer = self.set_timer(0.08, self.flush_stream)
+            except Exception:
+                self.stream_flush_timer = None
 
         def handle_approval(self, text: str) -> None:
             approval = self.pending_approval
@@ -242,14 +252,14 @@ if TEXTUAL_AVAILABLE:
             if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
                 self.pending_approval = approval
                 self.stream_text += "\n\n> 请输入 approve 或 deny。"
-                self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
+                self.schedule_stream_flush()
                 return
             decide_approval(str(approval.get("approval_id", "")), approved)
             self.stream_text += (
                 f"\n\n_{'已批准' if approved else '已拒绝'}："
                 f"{approval.get('tool_name', '')}_"
             )
-            self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
+            self.schedule_stream_flush()
 
         async def start_turn(self, text: str) -> None:
             if self.session_id is None:
@@ -303,7 +313,7 @@ if TEXTUAL_AVAILABLE:
             """从 worker 线程安全地投递 UI 回调；app 关闭后静默丢弃。"""
             try:
                 self.call_from_thread(callback, *args)
-            except RuntimeError:
+            except Exception:
                 pass
 
         # ── 渲染（App 线程）─────────────────────────────────────────────
@@ -334,9 +344,10 @@ if TEXTUAL_AVAILABLE:
                 self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
             elif kind == "cancelled":
                 self.stream_text += "\n\n_已取消_"
-            self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
+            self.schedule_stream_flush()
 
         async def flush_stream(self) -> None:
+            self.stream_flush_timer = None
             try:
                 markdown = self.query_one("#stream-markdown", Markdown)
                 await markdown.update(self.stream_text)
@@ -349,6 +360,14 @@ if TEXTUAL_AVAILABLE:
             if turn_session == self.session_id:
                 self.busy = False
                 self.pending_approval = None
+            if self.stream_flush_timer is not None:
+                try:
+                    self.stream_flush_timer.stop()
+                except Exception:
+                    pass
+                self.stream_flush_timer = None
+            # 最后一次刷新用普通 worker（非 exclusive），完成后刷新会话列表。
+            self.schedule_worker(self.flush_stream(), group="stream-final")
             self.schedule_worker(
                 self.refresh_sessions(select_id=turn_session),
                 group="sessions-refresh",

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -1,0 +1,230 @@
+"""
+sjtu_agent/tui/app.py — Textual 全屏聊天界面。
+
+Textual 是可选依赖：本模块只在 `sjtu-agent tui` 被调用时通过 run_tui()
+延迟导入；未安装时给出安装提示，不影响其余 CLI 功能。
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+from .engine import (
+    choose_event_stream,
+    decide_approval,
+    iter_chat_events,
+    iter_command_events,
+    new_store,
+)
+from sjtu_agent.commands import is_core_command
+
+_COMMAND_RESULT_MARKER = "__SJTU_COMMAND_RESULT__"
+
+
+def _session_title(text: str) -> str:
+    return " ".join(text.split())[:24] or "新会话"
+
+
+def run_tui() -> int:
+    try:
+        from textual import on
+        from textual.app import App, ComposeResult
+        from textual.containers import Horizontal, Vertical
+        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, RichLog
+        from rich.markup import escape
+    except ImportError as exc:
+        print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=__import__("sys").stderr)
+        print(f"详细错误：{exc}", file=__import__("sys").stderr)
+        return 1
+
+    class ChatApp(App):
+        """与 Web GUI 共用 session store 的 Textual 聊天客户端。"""
+
+        CSS = """
+        #main { height: 1fr; }
+        #sessions { width: 32; border-right: solid $primary-darken-2; }
+        #chat { width: 1fr; height: 1fr; }
+        #prompt { dock: bottom; }
+        """
+
+        BINDINGS = [
+            ("ctrl+n", "new_session", "新会话"),
+            ("ctrl+l", "focus_prompt", "聚焦输入"),
+        ]
+
+        def __init__(self):
+            super().__init__()
+            self.store = new_store()
+            self.session_id: str | None = None
+            self.busy = False
+            self.pending_approval: dict[str, Any] | None = None
+
+        def compose(self) -> ComposeResult:
+            yield Header()
+            with Vertical():
+                with Horizontal(id="main"):
+                    yield ListView(id="sessions")
+                    yield RichLog(id="chat", markup=True, wrap=True)
+                yield Input(placeholder="输入消息，/ 执行斜杠命令，Enter 发送", id="prompt")
+            yield Footer()
+
+        @property
+        def chat(self) -> RichLog:
+            return self.query_one("#chat", RichLog)
+
+        def on_mount(self) -> None:
+            self.refresh_sessions()
+            self.query_one("#prompt", Input).focus()
+
+        # ── 会话 ─────────────────────────────────────────────────────────
+        def action_new_session(self) -> None:
+            session = self.store.create_session("新会话")
+            self.session_id = session.get("id")
+            self.pending_approval = None
+            self.refresh_sessions(select_id=self.session_id)
+            self.load_session(self.session_id)
+
+        def action_focus_prompt(self) -> None:
+            self.query_one("#prompt", Input).focus()
+
+        def refresh_sessions(self, select_id: str | None = None) -> None:
+            session_list = self.query_one("#sessions", ListView)
+            session_list.clear()
+            target = select_id or self.session_id
+            for session in self.store.list_sessions():
+                item = ListItem(
+                    Label(session.get("title") or "未命名会话"),
+                    id=f"session-{session['id']}",
+                )
+                session_list.append(item)
+                if session["id"] == target:
+                    session_list.index = len(session_list.children) - 1
+
+        def load_session(self, session_id: str) -> None:
+            self.session_id = session_id
+            chat = self.query_one("#chat", RichLog)
+            chat.clear()
+            session = self.store.get_session(session_id)
+            chat.write(f"[bold]会话：{session.get('title', '')}[/]\n")
+            for message in self.store.list_messages(session_id):
+                content = message.get("content", "")
+                if message.get("role") == "user":
+                    chat.write(f"[bold cyan]你[/] {escape(content)}")
+                else:
+                    payload = None
+                    if isinstance(content, str) and content.startswith(_COMMAND_RESULT_MARKER):
+                        try:
+                            payload = json.loads(content[len(_COMMAND_RESULT_MARKER):])
+                        except json.JSONDecodeError:
+                            payload = None
+                    text = (payload or {}).get("text", content) if payload else content
+                    chat.write(f"[bold green]Agent[/] {escape(text)}")
+
+        @on(ListView.Selected)
+        def on_session_selected(self, event) -> None:
+            item_id = getattr(event.item, "id", "") or ""
+            if not item_id.startswith("session-"):
+                return
+            self.load_session(item_id[len("session-"):])
+
+        # ── 输入与审批 ──────────────────────────────────────────────────
+        @on(Input.Submitted)
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            text = event.value.strip()
+            event.input.value = ""
+            if not text or self.busy:
+                return
+            if self.pending_approval is not None:
+                self.handle_approval(text)
+                return
+            self.start_turn(text)
+
+        def handle_approval(self, text: str) -> None:
+            approval = self.pending_approval
+            self.pending_approval = None
+            approved = text.lower() in {"approve", "yes", "y", "同意", "允许"}
+            if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
+                self.pending_approval = approval
+                self.chat.write("[yellow]请输入 approve / deny 确认审批[/]")
+                return
+            decide_approval(str(approval.get("approval_id", "")), approved)
+            self.chat.write(f"[dim]{'已批准' if approved else '已拒绝'}：{approval.get('tool_name', '')}[/]")
+
+        def start_turn(self, text: str) -> None:
+            if self.session_id is None:
+                session = self.store.create_session("新会话")
+                self.session_id = session.get("id")
+                self.refresh_sessions(select_id=self.session_id)
+            if self.session_id is None:
+                self.chat.write("[red]无法创建会话[/]")
+                return
+
+            session = self.store.get_session(self.session_id)
+            if session and session.get("title") == "新会话":
+                self.store.rename_session(self.session_id, _session_title(text))
+
+            self.busy = True
+            self.chat.write(f"[bold cyan]你[/] {escape(text)}")
+            command_mode = text.startswith("/") and is_core_command(text)
+            self.chat.write(
+                f"[dim]{'⚡ 执行命令…' if command_mode else '…'}"
+            )
+            threading.Thread(
+                target=self._run_stream,
+                args=(text, command_mode),
+                daemon=True,
+            ).start()
+
+        def _run_stream(self, text: str, command_mode: bool) -> None:
+            try:
+                stream = (
+                    iter_command_events(self.session_id, text)
+                    if command_mode
+                    else iter_chat_events(self.session_id, text)
+                )
+                for event in stream:
+                    if event.get("kind") == "done":
+                        break
+                    self.call_from_thread(self.render_event, event)
+            except Exception as exc:
+                self.call_from_thread(self.render_event, {"kind": "error", "text": str(exc)})
+            finally:
+                self.call_from_thread(self.finish_turn)
+
+        def render_event(self, event: dict[str, Any]) -> None:
+            kind = event.get("kind")
+            chat = self.query_one("#chat", RichLog)
+            if kind == "token":
+                chat.write(escape(str(event.get("text", ""))))
+            elif kind == "tool_start":
+                chat.write(f"\n🔧 {escape(str(event.get('name', '')))}")
+            elif kind == "tool_end":
+                chat.write(f" ✓ {escape(str(event.get('name', '')))}")
+            elif kind == "approval_required":
+                self.pending_approval = event
+                chat.write(
+                    f"\n[yellow]⚠️ 需要确认工具调用：{escape(str(event.get('tool_name', '')))}\n"
+                    f"参数：{escape(json.dumps(event.get('arguments', {}), ensure_ascii=False))}\n"
+                    "输入 approve 或 deny[/]"
+                )
+            elif kind == "command_start":
+                chat.write(f"\n⚡ {escape(str(event.get('raw', '')))}")
+            elif kind == "command_progress":
+                chat.write(f"[dim]{escape(str(event.get('message', '')))}[/]")
+            elif kind == "command_result":
+                chat.write("\n" + escape(str(event.get("text", ""))))
+            elif kind == "error":
+                chat.write(f"\n[red]错误：{escape(str(event.get('text', '')))}[/]")
+            elif kind == "cancelled":
+                chat.write("\n[dim]已取消[/]")
+
+        def finish_turn(self) -> None:
+            self.busy = False
+            self.pending_approval = None
+            self.chat.write("\n")
+            self.refresh_sessions(select_id=self.session_id)
+
+    ChatApp().run()
+    return 0

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -11,6 +11,7 @@ import json
 import threading
 from typing import Any
 
+from .commands import command_candidates
 from .engine import cancel_turn, decide_approval, iter_chat_events, iter_command_events
 from .messages import display_text
 from .session_model import TuiSessionModel
@@ -22,7 +23,7 @@ def run_tui() -> int:
         from textual import on
         from textual.app import App, ComposeResult
         from textual.containers import Horizontal, Vertical
-        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, RichLog
+        from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, RichLog, Static
         from rich.markup import escape
     except ImportError as exc:
         print("未安装 Textual。运行 `pip install -e \".[tui]\"` 后重试。", file=__import__("sys").stderr)
@@ -37,12 +38,21 @@ def run_tui() -> int:
         #sessions { width: 32; border-right: solid $primary-darken-2; }
         #chat { width: 1fr; height: 1fr; }
         #prompt { dock: bottom; }
+        #suggestions {
+            height: auto;
+            max-height: 10;
+            padding: 0 1;
+            color: $text-muted;
+        }
+        #suggestions .active { color: $secondary; text-style: bold; }
         """
 
         BINDINGS = [
             ("ctrl+n", "new_session", "新会话"),
             ("ctrl+l", "focus_prompt", "聚焦输入"),
             ("ctrl+x", "stop_turn", "停止生成"),
+            ("tab", "next_suggestion", "下一个建议"),
+            ("shift+tab", "previous_suggestion", "上一个建议"),
         ]
 
         def __init__(self):
@@ -50,6 +60,8 @@ def run_tui() -> int:
             self.model = TuiSessionModel()
             self.busy = False
             self.pending_approval: dict[str, Any] | None = None
+            self.suggestions: list[dict[str, Any]] = []
+            self.suggestion_index = 0
 
         @property
         def session_id(self) -> str | None:
@@ -62,21 +74,22 @@ def run_tui() -> int:
                     yield ListView(id="sessions")
                     yield RichLog(id="chat", markup=True, wrap=True)
                 yield Input(placeholder="输入消息，/ 执行斜杠命令，Enter 发送", id="prompt")
+                yield Static(id="suggestions")
             yield Footer()
 
         @property
         def chat(self) -> RichLog:
             return self.query_one("#chat", RichLog)
 
-        def on_mount(self) -> None:
-            self.refresh_sessions()
+        async def on_mount(self) -> None:
+            await self.refresh_sessions()
             self.query_one("#prompt", Input).focus()
 
         # ── 会话 ─────────────────────────────────────────────────────────
-        def action_new_session(self) -> None:
+        async def action_new_session(self) -> None:
             session = self.model.create_session("新会话")
             self.pending_approval = None
-            self.refresh_sessions(select_id=session.get("id"))
+            await self.refresh_sessions(select_id=session.get("id"))
             self.load_session(session.get("id") or "")
 
         def action_focus_prompt(self) -> None:
@@ -88,18 +101,18 @@ def run_tui() -> int:
             cancel_turn(self.session_id)
             self.chat.write("\n[dim]已请求停止…[/]")
 
-        def refresh_sessions(self, select_id: str | None = None) -> None:
+        async def refresh_sessions(self, select_id: str | None = None) -> None:
             session_list = self.query_one("#sessions", ListView)
-            session_list.clear()
+            await session_list.clear()
             target = select_id or self.session_id
-            for session in self.model.list_sessions():
+            for index, session in enumerate(self.model.list_sessions()):
                 item = ListItem(
                     Label(session.get("title") or "未命名会话"),
                     id=f"session-{session['id']}",
                 )
                 session_list.append(item)
                 if session["id"] == target:
-                    session_list.index = len(session_list.children) - 1
+                    session_list.index = index
 
         def load_session(self, session_id: str) -> None:
             self.model.select(session_id)
@@ -121,17 +134,58 @@ def run_tui() -> int:
                 return
             self.load_session(item_id[len("session-"):])
 
+        # ── / 命令补全 ──────────────────────────────────────────────────
+        def render_suggestions(self) -> None:
+            widget = self.query_one("#suggestions", Static)
+            if not self.suggestions:
+                widget.update("")
+                return
+            lines = []
+            for index, candidate in enumerate(self.suggestions):
+                prefix = "> " if index == self.suggestion_index else "  "
+                lines.append(
+                    f"{prefix}{candidate.get('icon', '')} {candidate['value']} — "
+                    f"{candidate.get('description', '')}"
+                )
+            widget.update("\n".join(lines))
+
+        @on(Input.Changed)
+        def on_input_changed(self, event: Input.Changed) -> None:
+            self.suggestions = command_candidates(event.value)
+            self.suggestion_index = 0
+            self.render_suggestions()
+
+        def action_next_suggestion(self) -> None:
+            if not self.suggestions:
+                return
+            self.suggestion_index = (self.suggestion_index + 1) % len(self.suggestions)
+            self.render_suggestions()
+
+        def action_previous_suggestion(self) -> None:
+            if not self.suggestions:
+                return
+            self.suggestion_index = (self.suggestion_index - 1) % len(self.suggestions)
+            self.render_suggestions()
+
         # ── 输入与审批 ──────────────────────────────────────────────────
         @on(Input.Submitted)
-        def on_input_submitted(self, event: Input.Submitted) -> None:
+        async def on_input_submitted(self, event: Input.Submitted) -> None:
             text = event.value.strip()
-            event.input.value = ""
             if not text or self.busy:
                 return
             if self.pending_approval is not None:
                 self.handle_approval(text)
+                event.input.value = ""
                 return
-            self.start_turn(text)
+            if self.suggestions and text.startswith("/"):
+                candidate = self.suggestions[self.suggestion_index]
+                event.input.value = candidate["value"]
+                self.suggestions = []
+                self.render_suggestions()
+                event.input.focus()
+                return
+            event.input.value = ""
+            await self.start_turn(text)
 
         def handle_approval(self, text: str) -> None:
             approval = self.pending_approval
@@ -144,10 +198,10 @@ def run_tui() -> int:
             decide_approval(str(approval.get("approval_id", "")), approved)
             self.chat.write(f"[dim]{'已批准' if approved else '已拒绝'}：{approval.get('tool_name', '')}[/]")
 
-        def start_turn(self, text: str) -> None:
+        async def start_turn(self, text: str) -> None:
             if self.session_id is None:
                 session = self.model.create_session("新会话")
-                self.refresh_sessions(select_id=session.get("id"))
+                await self.refresh_sessions(select_id=session.get("id"))
             session_id = self.model.ensure_for_message(text)
             if not session_id:
                 self.chat.write("[red]无法创建会话[/]")
@@ -208,11 +262,11 @@ def run_tui() -> int:
             elif kind == "cancelled":
                 chat.write("\n[dim]已取消[/]")
 
-        def finish_turn(self) -> None:
+        async def finish_turn(self) -> None:
             self.busy = False
             self.pending_approval = None
             self.chat.write("\n")
-            self.refresh_sessions(select_id=self.session_id)
+            await self.refresh_sessions(select_id=self.session_id)
 
     ChatApp().run()
     return 0

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -246,20 +246,23 @@ if TEXTUAL_AVAILABLE:
                 self.stream_flush_timer = None
 
         def handle_approval(self, text: str) -> None:
-            approval = self.pending_approval
-            self.pending_approval = None
-            approved = text.lower() in {"approve", "yes", "y", "同意", "允许"}
-            if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
-                self.pending_approval = approval
-                self.stream_text += "\n\n> 请输入 approve 或 deny。"
+            try:
+                approval = self.pending_approval
+                self.pending_approval = None
+                approved = text.lower() in {"approve", "yes", "y", "同意", "允许"}
+                if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
+                    self.pending_approval = approval
+                    self.stream_text += "\n\n> 请输入 approve 或 deny。"
+                    self.schedule_stream_flush()
+                    return
+                decide_approval(str(approval.get("approval_id", "")), approved)
+                self.stream_text += (
+                    f"\n\n_{'已批准' if approved else '已拒绝'}："
+                    f"{approval.get('tool_name', '')}_"
+                )
                 self.schedule_stream_flush()
+            except Exception:
                 return
-            decide_approval(str(approval.get("approval_id", "")), approved)
-            self.stream_text += (
-                f"\n\n_{'已批准' if approved else '已拒绝'}："
-                f"{approval.get('tool_name', '')}_"
-            )
-            self.schedule_stream_flush()
 
         async def start_turn(self, text: str) -> None:
             if self.session_id is None:
@@ -318,33 +321,41 @@ if TEXTUAL_AVAILABLE:
 
         # ── 渲染（App 线程）─────────────────────────────────────────────
         def render_event(self, event: dict[str, Any], turn_session: str) -> None:
-            if turn_session != self.session_id:
+            try:
+                if turn_session != self.session_id:
+                    return
+                kind = event.get("kind")
+                if kind == "token":
+                    self.stream_text += str(event.get("text", ""))
+                elif kind == "tool_start":
+                    self.stream_text += f"\n\n🔧 **{event.get('name', '')}**"
+                elif kind == "tool_end":
+                    self.stream_text += f"\n\n✅ **{event.get('name', '')}** 完成"
+                elif kind == "approval_required":
+                    self.pending_approval = event
+                    try:
+                        args_text = json.dumps(event.get("arguments", {}), ensure_ascii=False)
+                    except Exception:
+                        args_text = str(event.get("arguments", {}))
+                    self.stream_text += (
+                        f"\n\n⚠️ **需要确认：{event.get('tool_name', '')}**\n\n"
+                        f"```json\n{args_text}\n```\n\n"
+                        "输入 `approve` 或 `deny`"
+                    )
+                elif kind == "command_start":
+                    self.stream_text += f"\n\n⚡ `{event.get('raw', '')}`"
+                elif kind == "command_progress":
+                    self.stream_text += f"\n\n_{event.get('message', '')}_"
+                elif kind == "command_result":
+                    self.stream_text += "\n\n" + str(event.get("text", ""))
+                elif kind == "error":
+                    self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
+                elif kind == "cancelled":
+                    self.stream_text += "\n\n_已取消_"
+                self.schedule_stream_flush()
+            except Exception:
+                # 任何事件渲染失败都不得让 App 闪退。
                 return
-            kind = event.get("kind")
-            if kind == "token":
-                self.stream_text += str(event.get("text", ""))
-            elif kind == "tool_start":
-                self.stream_text += f"\n\n🔧 **{event.get('name', '')}**"
-            elif kind == "tool_end":
-                self.stream_text += f"\n\n✅ **{event.get('name', '')}** 完成"
-            elif kind == "approval_required":
-                self.pending_approval = event
-                self.stream_text += (
-                    f"\n\n⚠️ **需要确认：{event.get('tool_name', '')}**\n\n"
-                    f"```json\n{json.dumps(event.get('arguments', {}), ensure_ascii=False)}\n```\n\n"
-                    "输入 `approve` 或 `deny`"
-                )
-            elif kind == "command_start":
-                self.stream_text += f"\n\n⚡ `{event.get('raw', '')}`"
-            elif kind == "command_progress":
-                self.stream_text += f"\n\n_{event.get('message', '')}_"
-            elif kind == "command_result":
-                self.stream_text += "\n\n" + str(event.get("text", ""))
-            elif kind == "error":
-                self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
-            elif kind == "cancelled":
-                self.stream_text += "\n\n_已取消_"
-            self.schedule_stream_flush()
 
         async def flush_stream(self) -> None:
             self.stream_flush_timer = None
@@ -357,21 +368,24 @@ if TEXTUAL_AVAILABLE:
                 return
 
         def finish_turn(self, turn_session: str) -> None:
-            if turn_session == self.session_id:
-                self.busy = False
-                self.pending_approval = None
-            if self.stream_flush_timer is not None:
-                try:
-                    self.stream_flush_timer.stop()
-                except Exception:
-                    pass
-                self.stream_flush_timer = None
-            # 最后一次刷新用普通 worker（非 exclusive），完成后刷新会话列表。
-            self.schedule_worker(self.flush_stream(), group="stream-final")
-            self.schedule_worker(
-                self.refresh_sessions(select_id=turn_session),
-                group="sessions-refresh",
-            )
+            try:
+                if turn_session == self.session_id:
+                    self.busy = False
+                    self.pending_approval = None
+                if self.stream_flush_timer is not None:
+                    try:
+                        self.stream_flush_timer.stop()
+                    except Exception:
+                        pass
+                    self.stream_flush_timer = None
+                # 最后一次刷新用普通 worker（非 exclusive），完成后刷新会话列表。
+                self.schedule_worker(self.flush_stream(), group="stream-final")
+                self.schedule_worker(
+                    self.refresh_sessions(select_id=turn_session),
+                    group="sessions-refresh",
+                )
+            except Exception:
+                return
 
 
 def build_app() -> "App | None":

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -116,38 +116,45 @@ if TEXTUAL_AVAILABLE:
             cancel_turn(self.session_id)
 
         async def refresh_sessions(self, select_id: str | None = None) -> None:
-            session_list = self.query_one("#sessions", ListView)
-            await session_list.clear()
-            target = select_id or self.session_id
-            items = []
-            for session in self.model.list_sessions():
-                items.append(
-                    ListItem(
-                        Label(session.get("title") or "未命名会话"),
-                        id=f"session-{session['id']}",
+            try:
+                session_list = self.query_one("#sessions", ListView)
+                await session_list.clear()
+                target = select_id or self.session_id
+                items = []
+                for session in self.model.list_sessions():
+                    items.append(
+                        ListItem(
+                            Label(session.get("title") or "未命名会话"),
+                            id=f"session-{session['id']}",
+                        )
                     )
-                )
-            await session_list.extend(items)
-            if target:
-                for index, session in enumerate(self.model.list_sessions()):
-                    if session["id"] == target:
-                        session_list.index = index
-                        break
+                await session_list.extend(items)
+                if target:
+                    for index, session in enumerate(self.model.list_sessions()):
+                        if session["id"] == target:
+                            session_list.index = index
+                            break
+            except Exception:
+                # 会话列表刷新失败不应导致 App 退出。
+                return
 
         async def load_session(self, session_id: str) -> None:
-            self.model.select(session_id)
-            await self.messages.remove_children()
-            session = self.model.get_current()
-            title = (session or {}).get("title", "")
-            widgets: list[Markdown] = [Markdown(f"# {title}")]
-            for message in self.model.messages(session_id):
-                text = display_text(message.get("content", ""))
-                if message.get("role") == "user":
-                    widgets.append(Markdown(f"> **你**\n\n{text}"))
-                else:
-                    widgets.append(Markdown(text))
-            await self.messages.mount(*widgets)
-            self.messages.scroll_end(animate=False)
+            try:
+                self.model.select(session_id)
+                await self.messages.remove_children()
+                session = self.model.get_current()
+                title = (session or {}).get("title", "")
+                widgets: list[Markdown] = [Markdown(f"# {title}")]
+                for message in self.model.messages(session_id):
+                    text = display_text(message.get("content", ""))
+                    if message.get("role") == "user":
+                        widgets.append(Markdown(f"> **你**\n\n{text}"))
+                    else:
+                        widgets.append(Markdown(text))
+                await self.messages.mount(*widgets)
+                self.messages.scroll_end(animate=False)
+            except Exception:
+                return
 
         @on(ListView.Selected)
         async def on_session_selected(self, event) -> None:
@@ -216,6 +223,18 @@ if TEXTUAL_AVAILABLE:
             event.input.value = ""
             await self.start_turn(text)
 
+        def schedule_worker(self, work, group: str, *, exclusive: bool = False) -> None:
+            """启动 UI worker；任何刷新错误都不允许让 App 闪退。"""
+            try:
+                self.run_worker(
+                    work,
+                    group=group,
+                    exclusive=exclusive,
+                    exit_on_error=False,
+                )
+            except RuntimeError:
+                pass
+
         def handle_approval(self, text: str) -> None:
             approval = self.pending_approval
             self.pending_approval = None
@@ -223,14 +242,14 @@ if TEXTUAL_AVAILABLE:
             if not approved and text.lower() not in {"deny", "no", "n", "拒绝"}:
                 self.pending_approval = approval
                 self.stream_text += "\n\n> 请输入 approve 或 deny。"
-                self.run_worker(self.flush_stream(), group="stream", exclusive=True)
+                self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
                 return
             decide_approval(str(approval.get("approval_id", "")), approved)
             self.stream_text += (
                 f"\n\n_{'已批准' if approved else '已拒绝'}："
                 f"{approval.get('tool_name', '')}_"
             )
-            self.run_worker(self.flush_stream(), group="stream", exclusive=True)
+            self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
 
         async def start_turn(self, text: str) -> None:
             if self.session_id is None:
@@ -241,11 +260,14 @@ if TEXTUAL_AVAILABLE:
                 await self.messages.mount(Markdown("> 无法创建会话"))
                 return
 
-            await self.messages.mount(
-                Markdown(f"> **你**\n\n{text}"),
-                Markdown(id="stream-markdown"),
-            )
-            self.messages.scroll_end(animate=False)
+            try:
+                await self.messages.mount(
+                    Markdown(f"> **你**\n\n{text}"),
+                    Markdown(id="stream-markdown"),
+                )
+                self.messages.scroll_end(animate=False)
+            except Exception:
+                pass
 
             self.stream_text = ""
             self.busy = True
@@ -312,30 +334,25 @@ if TEXTUAL_AVAILABLE:
                 self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
             elif kind == "cancelled":
                 self.stream_text += "\n\n_已取消_"
-            try:
-                self.run_worker(self.flush_stream(), group="stream", exclusive=True)
-            except RuntimeError:
-                pass
+            self.schedule_worker(self.flush_stream(), group="stream", exclusive=True)
 
         async def flush_stream(self) -> None:
             try:
                 markdown = self.query_one("#stream-markdown", Markdown)
+                await markdown.update(self.stream_text)
+                self.messages.scroll_end(animate=False)
             except Exception:
+                # 会话切换 / widget 被移除 / 更新失败都不允许闪退。
                 return
-            await markdown.update(self.stream_text)
-            self.messages.scroll_end(animate=False)
 
         def finish_turn(self, turn_session: str) -> None:
             if turn_session == self.session_id:
                 self.busy = False
                 self.pending_approval = None
-            try:
-                self.run_worker(
-                    self.refresh_sessions(select_id=turn_session),
-                    group="sessions-refresh",
-                )
-            except RuntimeError:
-                pass
+            self.schedule_worker(
+                self.refresh_sessions(select_id=turn_session),
+                group="sessions-refresh",
+            )
 
 
 def build_app() -> "App | None":

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -11,20 +11,10 @@ import json
 import threading
 from typing import Any
 
-from .engine import (
-    choose_event_stream,
-    decide_approval,
-    iter_chat_events,
-    iter_command_events,
-    new_store,
-)
+from .engine import cancel_turn, decide_approval, iter_chat_events, iter_command_events
+from .messages import display_text
+from .session_model import TuiSessionModel
 from sjtu_agent.commands import is_core_command
-
-_COMMAND_RESULT_MARKER = "__SJTU_COMMAND_RESULT__"
-
-
-def _session_title(text: str) -> str:
-    return " ".join(text.split())[:24] or "新会话"
 
 
 def run_tui() -> int:
@@ -52,14 +42,18 @@ def run_tui() -> int:
         BINDINGS = [
             ("ctrl+n", "new_session", "新会话"),
             ("ctrl+l", "focus_prompt", "聚焦输入"),
+            ("ctrl+x", "stop_turn", "停止生成"),
         ]
 
         def __init__(self):
             super().__init__()
-            self.store = new_store()
-            self.session_id: str | None = None
+            self.model = TuiSessionModel()
             self.busy = False
             self.pending_approval: dict[str, Any] | None = None
+
+        @property
+        def session_id(self) -> str | None:
+            return self.model.current_id
 
         def compose(self) -> ComposeResult:
             yield Header()
@@ -80,20 +74,25 @@ def run_tui() -> int:
 
         # ── 会话 ─────────────────────────────────────────────────────────
         def action_new_session(self) -> None:
-            session = self.store.create_session("新会话")
-            self.session_id = session.get("id")
+            session = self.model.create_session("新会话")
             self.pending_approval = None
-            self.refresh_sessions(select_id=self.session_id)
-            self.load_session(self.session_id)
+            self.refresh_sessions(select_id=session.get("id"))
+            self.load_session(session.get("id") or "")
 
         def action_focus_prompt(self) -> None:
             self.query_one("#prompt", Input).focus()
+
+        def action_stop_turn(self) -> None:
+            if not self.busy or not self.session_id:
+                return
+            cancel_turn(self.session_id)
+            self.chat.write("\n[dim]已请求停止…[/]")
 
         def refresh_sessions(self, select_id: str | None = None) -> None:
             session_list = self.query_one("#sessions", ListView)
             session_list.clear()
             target = select_id or self.session_id
-            for session in self.store.list_sessions():
+            for session in self.model.list_sessions():
                 item = ListItem(
                     Label(session.get("title") or "未命名会话"),
                     id=f"session-{session['id']}",
@@ -103,23 +102,16 @@ def run_tui() -> int:
                     session_list.index = len(session_list.children) - 1
 
         def load_session(self, session_id: str) -> None:
-            self.session_id = session_id
+            self.model.select(session_id)
             chat = self.query_one("#chat", RichLog)
             chat.clear()
-            session = self.store.get_session(session_id)
-            chat.write(f"[bold]会话：{session.get('title', '')}[/]\n")
-            for message in self.store.list_messages(session_id):
-                content = message.get("content", "")
+            session = self.model.get_current()
+            chat.write(f"[bold]会话：{(session or {}).get('title', '')}[/]\n")
+            for message in self.model.messages(session_id):
+                text = display_text(message.get("content", ""))
                 if message.get("role") == "user":
-                    chat.write(f"[bold cyan]你[/] {escape(content)}")
+                    chat.write(f"[bold cyan]你[/] {escape(text)}")
                 else:
-                    payload = None
-                    if isinstance(content, str) and content.startswith(_COMMAND_RESULT_MARKER):
-                        try:
-                            payload = json.loads(content[len(_COMMAND_RESULT_MARKER):])
-                        except json.JSONDecodeError:
-                            payload = None
-                    text = (payload or {}).get("text", content) if payload else content
                     chat.write(f"[bold green]Agent[/] {escape(text)}")
 
         @on(ListView.Selected)
@@ -154,16 +146,12 @@ def run_tui() -> int:
 
         def start_turn(self, text: str) -> None:
             if self.session_id is None:
-                session = self.store.create_session("新会话")
-                self.session_id = session.get("id")
-                self.refresh_sessions(select_id=self.session_id)
-            if self.session_id is None:
+                session = self.model.create_session("新会话")
+                self.refresh_sessions(select_id=session.get("id"))
+            session_id = self.model.ensure_for_message(text)
+            if not session_id:
                 self.chat.write("[red]无法创建会话[/]")
                 return
-
-            session = self.store.get_session(self.session_id)
-            if session and session.get("title") == "新会话":
-                self.store.rename_session(self.session_id, _session_title(text))
 
             self.busy = True
             self.chat.write(f"[bold cyan]你[/] {escape(text)}")

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -78,6 +78,27 @@ if TEXTUAL_AVAILABLE:
         def session_id(self) -> str | None:
             return self.model.current_id
 
+        def _handle_exception(self, error: Exception) -> None:
+            """未捕获异常退出前，先把完整 traceback 写入运行时日志。"""
+            import datetime as _dt
+            import sys as _sys
+            import traceback
+            from sjtu_agent.paths import DATA_DIR
+
+            try:
+                log_dir = DATA_DIR / "logs"
+                log_dir.mkdir(parents=True, exist_ok=True)
+                with (log_dir / "tui_error.log").open("a", encoding="utf-8") as fh:
+                    fh.write(f"\n[{_dt.datetime.now().isoformat()}] TUI unhandled exception\n")
+                    traceback.print_exception(type(error), error, error.__traceback__, file=fh)
+                print(
+                    f"\n[TUI] 发生未处理异常，完整 traceback 已写入 {log_dir / 'tui_error.log'}",
+                    file=_sys.stderr,
+                )
+            except Exception:
+                pass
+            super()._handle_exception(error)
+
         @property
         def messages(self) -> VerticalScroll:
             return self.query_one("#messages", VerticalScroll)

--- a/sjtu_agent/tui/commands.py
+++ b/sjtu_agent/tui/commands.py
@@ -1,0 +1,44 @@
+"""
+sjtu_agent/tui/commands.py — TUI 斜杠命令补全候选（纯逻辑）。
+
+规则与 WebUI 的 command panel 一致：命令名前缀匹配，输入“命令名 + 参数”
+时补全该命令的示例变体。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sjtu_agent.commands import command_defs
+
+
+def command_candidates(query: str, limit: int = 8) -> list[dict[str, Any]]:
+    q = (query or "").lstrip().lower()
+    if not q.startswith("/"):
+        return []
+    q_name = q.split(maxsplit=1)[0] if " " in q else q
+
+    seen: set[str] = set()
+    result: list[dict[str, Any]] = []
+
+    def push(value: str, command: dict[str, Any]) -> None:
+        if not value or value in seen:
+            return
+        seen.add(value)
+        result.append({
+            "value": value,
+            "label": command.get("label", ""),
+            "icon": command.get("icon", ""),
+            "description": command.get("description", ""),
+            "kind": "command" if value == command.get("name") else "example",
+        })
+
+    for command in command_defs():
+        name = command.get("name", "")
+        if name.lower().startswith(q):
+            push(name, command)
+        if name.lower() == q_name:
+            for example in command.get("examples", []):
+                if example.lower().startswith(q):
+                    push(example, command)
+    return result[:limit]

--- a/sjtu_agent/tui/engine.py
+++ b/sjtu_agent/tui/engine.py
@@ -1,0 +1,87 @@
+"""
+sjtu_agent/tui/engine.py — TUI 聊天引擎适配层。
+
+TUI 与 Web GUI 共用同一套 SSE 引擎（sjtu_agent.web.server）和同一个
+SQLite SessionStore，因此两边看到的会话、消息和命令结果天然同步。
+本模块不依赖 Textual，可独立单元测试。
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+from sjtu_agent.commands import is_core_command
+from sjtu_agent.web.server import (
+    _decide_approval,
+    _stream_chat,
+    _stream_command,
+)
+from sjtu_agent.web.session_store import SessionStore
+
+
+def parse_sse_chunk(chunk: str) -> list[dict[str, Any]]:
+    """把一段 SSE 文本解析为归一化事件列表。"""
+    events: list[dict[str, Any]] = []
+    for line in chunk.splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:].strip()
+        if payload == "[DONE]":
+            events.append({"kind": "done"})
+            continue
+        if not payload:
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if "token" in obj:
+            events.append({"kind": "token", "text": obj.get("token", "")})
+        elif "tool_start" in obj:
+            events.append({"kind": "tool_start", **obj["tool_start"]})
+        elif "tool_end" in obj:
+            events.append({"kind": "tool_end", **obj["tool_end"]})
+        elif "approval_required" in obj:
+            events.append({"kind": "approval_required", **obj["approval_required"]})
+        elif "cancelled" in obj:
+            events.append({"kind": "cancelled"})
+        elif "command_start" in obj:
+            events.append({"kind": "command_start", **obj["command_start"]})
+        elif "command_progress" in obj:
+            events.append({"kind": "command_progress", **obj["command_progress"]})
+        elif "command_result" in obj:
+            events.append({"kind": "command_result", **obj["command_result"]})
+        elif "error" in obj:
+            events.append({"kind": "error", "text": str(obj.get("error", ""))})
+    return events
+
+
+def iter_chat_events(session_id: str, user_message: str) -> Iterator[dict[str, Any]]:
+    """发送普通聊天消息，yield 归一化事件（token / tool_start / ...）。"""
+    for chunk in _stream_chat(user_message, session_id=session_id):
+        yield from parse_sse_chunk(chunk)
+
+
+def iter_command_events(session_id: str, command: str) -> Iterator[dict[str, Any]]:
+    """执行共享斜杠命令，yield command_start / progress / result 事件。"""
+    for chunk in _stream_command(command, session_id=session_id):
+        yield from parse_sse_chunk(chunk)
+
+
+def choose_event_stream(session_id: str, text: str) -> Iterator[dict[str, Any]]:
+    """按输入类型选择命令执行流或普通聊天流（与 WebUI 规则一致）。"""
+    if text.startswith("/") and is_core_command(text):
+        return iter_command_events(session_id, text)
+    return iter_chat_events(session_id, text)
+
+
+def decide_approval(approval_id: str, approved: bool) -> bool:
+    """审批 Web/TUI 共享引擎中的危险工具调用。"""
+    return _decide_approval(approval_id, approved)
+
+
+def new_store() -> SessionStore:
+    """TUI 与 Web 共用同一默认 SessionStore（web_sessions.sqlite3）。"""
+    return SessionStore()

--- a/sjtu_agent/tui/engine.py
+++ b/sjtu_agent/tui/engine.py
@@ -15,6 +15,7 @@ from typing import Any
 from sjtu_agent.commands import is_core_command
 from sjtu_agent.web.server import (
     _decide_approval,
+    _mark_cancelled,
     _stream_chat,
     _stream_command,
 )
@@ -80,6 +81,11 @@ def choose_event_stream(session_id: str, text: str) -> Iterator[dict[str, Any]]:
 def decide_approval(approval_id: str, approved: bool) -> bool:
     """审批 Web/TUI 共享引擎中的危险工具调用。"""
     return _decide_approval(approval_id, approved)
+
+
+def cancel_turn(session_id: str) -> None:
+    """标记当前会话的生成任务为取消（与 /api/chat/cancel 同一通道）。"""
+    _mark_cancelled(session_id or "__legacy__")
 
 
 def new_store() -> SessionStore:

--- a/sjtu_agent/tui/messages.py
+++ b/sjtu_agent/tui/messages.py
@@ -1,0 +1,39 @@
+"""
+sjtu_agent/tui/messages.py — 消息内容解析 / 展示辅助（无 Textual 依赖）。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+COMMAND_RESULT_MARKER = "__SJTU_COMMAND_RESULT__"
+
+_DATE_CONTEXT_RE = re.compile(r"\n{0,2}## 当前时间[\s\S]*?(?=\n\n|$)")
+
+
+def parse_command_result(content: str) -> dict[str, Any] | None:
+    """解析 session 中持久化的结构化命令结果。"""
+    if not isinstance(content, str) or not content.startswith(COMMAND_RESULT_MARKER):
+        return None
+    try:
+        payload = json.loads(content[len(COMMAND_RESULT_MARKER):])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def strip_date_context(text: str) -> str:
+    """去掉 Web 引擎自动注入的“当前时间”块，避免消息区显示噪声。"""
+    return _DATE_CONTEXT_RE.sub("", str(text or "")).strip()
+
+
+def display_text(content: str) -> str:
+    """把持久化消息内容转成适合终端展示的纯文本。"""
+    payload = parse_command_result(content)
+    if payload is not None:
+        return str(payload.get("text") or "")
+    return strip_date_context(content)

--- a/sjtu_agent/tui/session_model.py
+++ b/sjtu_agent/tui/session_model.py
@@ -1,0 +1,67 @@
+"""
+sjtu_agent/tui/session_model.py — TUI 会话状态模型（与 Web 共享 SQLite）。
+
+所有操作直接落在 web_sessions.sqlite3；Web GUI 和 TUI 读取同一份数据。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sjtu_agent.web.session_store import SessionStore
+
+
+def _title_from_message(text: str) -> str:
+    return " ".join((text or "").split())[:24] or "新会话"
+
+
+class TuiSessionModel:
+    """TUI 使用的会话模型；无 Textual 依赖，可独立测试。"""
+
+    def __init__(self, store: SessionStore | None = None) -> None:
+        self.store = store or SessionStore()
+        self.current_id: str | None = None
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        return self.store.list_sessions()
+
+    def get_current(self) -> dict[str, Any] | None:
+        if not self.current_id:
+            return None
+        return self.store.get_session(self.current_id)
+
+    def create_session(self, title: str = "新会话") -> dict[str, Any]:
+        session = self.store.create_session(title)
+        self.current_id = session.get("id")
+        return session
+
+    def select(self, session_id: str) -> None:
+        self.current_id = session_id if self.store.get_session(session_id) else None
+
+    def rename(self, session_id: str, title: str) -> dict[str, Any] | None:
+        return self.store.rename_session(session_id, title)
+
+    def delete(self, session_id: str) -> bool:
+        ok = self.store.delete_session(session_id)
+        if ok and self.current_id == session_id:
+            self.current_id = None
+        return ok
+
+    def clear(self, session_id: str) -> None:
+        self.store.clear_messages(session_id)
+
+    def messages(self, session_id: str | None = None) -> list[dict[str, Any]]:
+        return self.store.list_messages(session_id or self.current_id or "")
+
+    def ensure_for_message(self, text: str) -> str:
+        """确保存在当前会话；首条消息自动命名（与 Web 前端规则一致）。"""
+        if not self.current_id:
+            self.create_session("新会话")
+        assert self.current_id is not None
+
+        session = self.store.get_session(self.current_id)
+        if session and session.get("title") in ("", "新会话"):
+            title = _title_from_message(text)
+            if title != "新会话":
+                self.store.rename_session(self.current_id, title)
+        return self.current_id

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -129,10 +129,48 @@ def test_ui_workers_never_exit_app(tmp_path, monkeypatch):
         async with app.run_test(size=(120, 40)) as pilot:
             await pilot.pause()
             monkeypatch.setattr(app, "run_worker", fake_run_worker)
-            app.render_event({"kind": "token", "text": "hello"}, app.session_id)
+            app.schedule_worker(app.flush_stream(), group="test")
             assert calls
             assert calls[-1]["exit_on_error"] is False
-            assert calls[-1]["exclusive"] is True
+
+            app.render_event({"kind": "token", "text": "hello"}, app.session_id)
+            assert app.stream_flush_timer is not None
+
+    _run(scenario())
+
+
+def test_high_frequency_stream_does_not_crash_app(tmp_path, monkeypatch):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+
+    def fake_stream(user_message, session_id=None):
+        for index in range(200):
+            yield {"kind": "token", "text": f"token-{index} "}
+            if index % 20 == 0:
+                import time
+                time.sleep(0.005)
+        yield {"kind": "done"}
+
+    monkeypatch.setattr("sjtu_agent.tui.app.iter_chat_events", fake_stream)
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            prompt = app.query_one("#prompt", Input)
+            prompt.focus()
+            prompt.value = "stress"
+            await pilot.press("enter")
+            for _ in range(200):
+                if not app.busy:
+                    break
+                await pilot.pause(0.05)
+
+            assert app.busy is False
+            stream = app.query_one("#stream-markdown", Markdown)
+            assert "token-199" in stream.source
 
     _run(scenario())
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -110,6 +110,33 @@ def test_stream_exception_is_rendered_without_thread_crash(tmp_path, monkeypatch
     _run(scenario())
 
 
+def test_ui_workers_never_exit_app(tmp_path, monkeypatch):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        calls = []
+
+        def fake_run_worker(work, **kwargs):
+            calls.append(kwargs)
+            if hasattr(work, "close"):
+                work.close()  # 测试替身不执行，显式关闭避免未 await 警告
+            return None
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            monkeypatch.setattr(app, "run_worker", fake_run_worker)
+            app.render_event({"kind": "token", "text": "hello"}, app.session_id)
+            assert calls
+            assert calls[-1]["exit_on_error"] is False
+            assert calls[-1]["exclusive"] is True
+
+    _run(scenario())
+
+
 def test_command_suggestions_fill_input(tmp_path):
     store = SessionStore(tmp_path / "web_sessions.sqlite3")
     model = TuiSessionModel(store)

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+textual = pytest.importorskip("textual")
+
+from textual.containers import VerticalScroll  # noqa: E402
+from textual.widgets import Input, ListView, Markdown  # noqa: E402
+
+from sjtu_agent.tui.app import TEXTUAL_AVAILABLE, build_app  # noqa: E402
+from sjtu_agent.tui.session_model import TuiSessionModel  # noqa: E402
+from sjtu_agent.web.session_store import SessionStore  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not TEXTUAL_AVAILABLE, reason="Textual not installed")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_chat_app_mounts_sessions_and_markdown_messages(tmp_path):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    session_id = model.create_session("测试会话")["id"]
+    store.append_message(session_id, "user", "你好")
+    store.append_message(session_id, "assistant", "**加粗**\n\n- 列表项")
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+
+            session_list = app.query_one("#sessions", ListView)
+            assert len(session_list.children) >= 1
+
+            messages = app.query_one("#messages", VerticalScroll)
+            markdown_widgets = list(messages.query(Markdown))
+            assert len(markdown_widgets) >= 3  # 标题 + 用户 + 助手
+            assert app.query_one("#prompt", Input) is not None
+
+    _run(scenario())
+
+
+def test_streaming_reply_updates_markdown_widget(tmp_path, monkeypatch):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+
+    def fake_stream(user_message, session_id=None):
+        yield {"kind": "token", "text": "# 标题\n\n"}
+        yield {"kind": "token", "text": "**加粗** 和列表：\n\n- A\n- B"}
+        yield {"kind": "done"}
+
+    monkeypatch.setattr("sjtu_agent.tui.app.iter_chat_events", fake_stream)
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            prompt = app.query_one("#prompt", Input)
+            prompt.focus()
+            prompt.value = "hello"
+            await pilot.press("enter")
+            for _ in range(20):
+                if not app.busy:
+                    break
+                await pilot.pause(0.1)
+
+            assert app.busy is False
+            stream = app.query_one("#stream-markdown", Markdown)
+            assert "加粗" in stream.source
+            assert "列表" in stream.source
+
+    _run(scenario())
+
+
+def test_stream_exception_is_rendered_without_thread_crash(tmp_path, monkeypatch):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+
+    def fake_stream(user_message, session_id=None):
+        yield {"kind": "token", "text": "部分内容"}
+        raise RuntimeError("mock stream failure")
+
+    monkeypatch.setattr("sjtu_agent.tui.app.iter_chat_events", fake_stream)
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            prompt = app.query_one("#prompt", Input)
+            prompt.focus()
+            prompt.value = "hello"
+            await pilot.press("enter")
+            for _ in range(20):
+                if not app.busy:
+                    break
+                await pilot.pause(0.1)
+
+            assert app.busy is False
+            stream = app.query_one("#stream-markdown", Markdown)
+            assert "mock stream failure" in stream.source
+
+    _run(scenario())
+
+
+def test_command_suggestions_fill_input(tmp_path):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            prompt = app.query_one("#prompt", Input)
+            prompt.focus()
+            prompt.value = "/hw d"
+            prompt.post_message(Input.Changed(prompt, "/hw d"))
+            await pilot.pause()
+
+            assert app.suggestions
+            chosen = app.suggestions[app.suggestion_index]["value"]
+            assert chosen.startswith("/hw d")
+            await pilot.press("enter")
+            assert prompt.value == chosen
+
+    _run(scenario())

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -84,6 +84,19 @@ def test_choose_event_stream_uses_command_path(monkeypatch):
     assert calls[-1] == ("chat", "今天吃什么")
 
 
+def test_cancel_turn_marks_session(monkeypatch):
+    calls = []
+
+    def fake_cancel(session_id):
+        calls.append(session_id)
+
+    monkeypatch.setattr(engine, "_mark_cancelled", fake_cancel)
+    engine.cancel_turn("s1")
+    assert calls == ["s1"]
+    engine.cancel_turn("")
+    assert calls[-1] == "__legacy__"
+
+
 def test_new_store_reuses_web_session_store():
     store = engine.new_store()
     assert isinstance(store, SessionStore)

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sjtu_agent.tui import engine
+from sjtu_agent.web.session_store import SessionStore
+
+
+def test_parse_sse_chunk_chat_events():
+    chunk = "\n".join([
+        'data: {"token":"你好"}',
+        'data: {"tool_start":{"name":"get_ddls","input":{}}}',
+        'data: {"approval_required":{"approval_id":"a1","tool_name":"send_email","arguments":{}}}',
+        'data: {"tool_end":{"name":"get_ddls","result":"ok"}}',
+        'data: {"error":"boom"}',
+        "data: [DONE]",
+    ])
+    events = engine.parse_sse_chunk(chunk)
+    assert [e["kind"] for e in events] == [
+        "token",
+        "tool_start",
+        "approval_required",
+        "tool_end",
+        "error",
+        "done",
+    ]
+    assert events[0]["text"] == "你好"
+    assert events[2]["approval_id"] == "a1"
+
+
+def test_parse_sse_chunk_command_events():
+    chunk = "\n".join([
+        'data: {"command_start":{"name":"/eat","raw":"/eat 徐汇"}}',
+        'data: {"command_progress":{"stage":"running","message":"正在执行 /eat…"}}',
+        'data: {"command_result":{"name":"/eat","view":"dining","text":"# 推荐","data":{"ok":true}}}',
+        "data: [DONE]",
+    ])
+    events = engine.parse_sse_chunk(chunk)
+    assert events[-1] == {"kind": "done"}
+    result = events[2]
+    assert result["kind"] == "command_result"
+    assert result["view"] == "dining"
+    assert result["data"] == {"ok": True}
+
+
+def test_iter_chat_events_normalizes_stream(monkeypatch):
+    def fake_stream(user_message, session_id=None):
+        yield f'data: {json.dumps({"token": user_message})}\n\n'
+
+    monkeypatch.setattr(engine, "_stream_chat", fake_stream)
+    events = list(engine.iter_chat_events("s1", "hello"))
+    assert events == [{"kind": "token", "text": "hello"}]
+
+
+def test_iter_command_events_normalizes_stream(monkeypatch):
+    def fake_stream(command, session_id=None):
+        yield 'data: {"command_start":{"name":"/eat","raw":"/eat"}}\n\n'
+
+    monkeypatch.setattr(engine, "_stream_command", fake_stream)
+    events = list(engine.iter_command_events("s1", "/eat"))
+    assert events[0]["name"] == "/eat"
+
+
+def test_choose_event_stream_uses_command_path(monkeypatch):
+    calls = []
+
+    def fake_chat(user_message, session_id=None):
+        calls.append(("chat", user_message))
+        yield from ()
+
+    def fake_command(command, session_id=None):
+        calls.append(("command", command))
+        yield from ()
+
+    monkeypatch.setattr(engine, "_stream_chat", fake_chat)
+    monkeypatch.setattr(engine, "_stream_command", fake_command)
+
+    assert list(engine.choose_event_stream("s1", "/eat 徐汇")) == []
+    assert calls == [("command", "/eat 徐汇")]
+
+    list(engine.choose_event_stream("s1", "今天吃什么"))
+    assert calls[-1] == ("chat", "今天吃什么")
+
+
+def test_new_store_reuses_web_session_store():
+    store = engine.new_store()
+    assert isinstance(store, SessionStore)
+    assert store.db_path.name == "web_sessions.sqlite3"
+
+
+def test_tui_command_without_textual_reports_install_hint(monkeypatch, capsys):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "textual" or name.startswith("textual."):
+            raise ImportError("No module named 'textual'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    from sjtu_agent.tui.app import run_tui
+    assert run_tui() == 1
+    captured = capsys.readouterr()
+    assert "pip install -e" in captured.err

--- a/tests/test_tui_engine.py
+++ b/tests/test_tui_engine.py
@@ -104,17 +104,9 @@ def test_new_store_reuses_web_session_store():
 
 
 def test_tui_command_without_textual_reports_install_hint(monkeypatch, capsys):
-    import builtins
+    from sjtu_agent.tui import app as app_module
 
-    real_import = builtins.__import__
-
-    def fake_import(name, *args, **kwargs):
-        if name == "textual" or name.startswith("textual."):
-            raise ImportError("No module named 'textual'")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-    from sjtu_agent.tui.app import run_tui
-    assert run_tui() == 1
+    monkeypatch.setattr(app_module, "TEXTUAL_AVAILABLE", False)
+    assert app_module.run_tui() == 1
     captured = capsys.readouterr()
     assert "pip install -e" in captured.err

--- a/tests/test_tui_models.py
+++ b/tests/test_tui_models.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import json
+
+from sjtu_agent.tui.commands import command_candidates
+from sjtu_agent.tui.messages import (
+    COMMAND_RESULT_MARKER,
+    display_text,
+    parse_command_result,
+    strip_date_context,
+)
+from sjtu_agent.tui.session_model import TuiSessionModel
+from sjtu_agent.web.session_store import SessionStore
+
+
+def _make_model(tmp_path):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    return TuiSessionModel(store)
+
+
+def test_session_model_creates_and_auto_titles(tmp_path):
+    model = _make_model(tmp_path)
+    assert model.current_id is None
+
+    sid = model.ensure_for_message("帮我查一下明天的 DDL")
+    assert sid == model.current_id
+    session = model.get_current()
+    assert session["title"] == "帮我查一下明天的 DDL"
+
+    # 第二条消息不改名
+    old = model.ensure_for_message("再帮我看看课表")
+    assert old == sid
+    assert model.get_current()["title"] == "帮我查一下明天的 DDL"
+
+
+def test_session_model_delete_and_clear(tmp_path):
+    model = _make_model(tmp_path)
+    sid = model.ensure_for_message("第一条")
+    model.store.append_message(sid, "user", "你好")
+    model.store.append_message(sid, "assistant", "你好")
+
+    assert len(model.messages(sid)) == 2
+    model.clear(sid)
+    assert model.messages(sid) == []
+
+    assert model.delete(sid) is True
+    assert model.current_id is None
+
+
+def test_messages_parse_command_result():
+    payload = {"view": "dining", "text": "# 推荐", "data": {"ok": True}}
+    encoded = COMMAND_RESULT_MARKER + json.dumps(payload, ensure_ascii=False)
+    assert parse_command_result(encoded) == payload
+    assert parse_command_result("普通文本") is None
+    assert display_text(encoded) == "# 推荐"
+    assert display_text("普通文本") == "普通文本"
+
+
+def test_strip_date_context_removes_injected_block():
+    text = "问题\n\n## 当前时间\n现在：2026年08月16日 00:00，星期日。\n\n回答"
+    assert "当前时间" not in strip_date_context(text)
+    assert "问题" in strip_date_context(text)
+    assert "回答" in strip_date_context(text)
+
+
+def test_command_candidates_matches_webui_rules():
+    names = [c["value"] for c in command_candidates("/")]
+    assert "/hw" in names
+    assert "/news" in names
+
+    hw_variants = {c["value"] for c in command_candidates("/hw d")}
+    assert "/hw do 3" in hw_variants
+    assert "/hw due 7" in hw_variants
+
+    assert command_candidates("普通消息") == []
+    assert command_candidates("/does-not-exist") == []


### PR DESCRIPTION
## Summary

新增 Textual 全屏终端 TUI（`sjtu-agent tui`），与 Web GUI 共用同一个 SQLite session store 和 SSE 引擎，聊天进度 / 会话历史在 Web 与 TUI 间实时同步。

## Changes

### 核心
- `pyproject.toml` 新增可选 extra `[tui]`（`textual>=0.80`）
- `sjtu-agent tui` CLI 子命令，Textual 懒加载，未安装时给出提示
- `sjtu_agent/tui/`：
  - `engine.py` — 复用 `_stream_chat` / `_stream_command`，统一 SSE 事件解析；审批与取消通道复用
  - `session_model.py` — 会话 CRUD + 首条消息自动命名，直接读写 `web_sessions.sqlite3`
  - `messages.py` — 结构化命令结果 JSON 解析、日期上下文剥离
  - `commands.py` — `/` 命令补全候选（与 WebUI 规则一致）
  - `app.py` — Textual ChatApp：会话列表、Markdown 消息流、流式回复、`/` 补全面板、approve/deny、停止生成

### 稳定性（Textual 8.2.8 实测）
- 消息区使用 `VerticalScroll + Markdown` widgets，完整 Markdown 渲染，修复 RichLog 左侧竖条
- 正确 await Textual 的 `AwaitMount` / `AwaitRemove` / `AwaitComplete` API
- 流式 Markdown 用 80ms 定时器节流，避免高频 worker 互斥导致中途闪退
- 所有 UI worker `exit_on_error=False`；app 线程回调整体兜底
- 未捕获异常退出前写入 `logs/tui_error.log`

### 测试 / CI
- 新增 Textual headless `run_test` 测试：布局、流式 Markdown、命令补全、异常路径、worker 策略、200-token 压力
- CI test/release 安装 `[tui]`，headless UI 测试真实执行而非跳过
- 本地完整 pytest：**497 passed**
- 用户本机已跑通 `sjtu-agent tui`，模型回复期间不再闪退

## Notes

- 暑假期间未做实机 Canvas/DDL 数据验证；`/hw` 类命令沿用共享命令层的 mock 测试。
- TUI 结构化命令卡片（对应 Web 的 `view` 卡片）留作后续增强。
