### PR TITLE
feat: TUI command cards, session actions, and attachment safety

### DIFF
--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -405,15 +405,97 @@ if TEXTUAL_AVAILABLE:
 
             event.input.value = ""
             attachment_items = self.staged_attachment_items()
-            attachment_note = build_attachment_note(attachment_items)
-            message = (text or "请查看我上传的附件") + attachment_note
-            command_mode = (
-                not attachment_items
-                and text.startswith("/")
-                and is_core_command(text)
-            )
+            if not attachment_items:
+                await self.start_turn(
+                    text,
+                    command_mode=text.startswith("/") and is_core_command(text),
+                )
+                return
+
+            # 有附件：解析在后台线程执行，UI 先显示进度，避免视觉模型 / OCR 阻塞。
+            base_message = text or "请查看我上传的附件"
+            if self.session_id is None:
+                session = self.model.create_session("新会话")
+                await self.refresh_sessions(select_id=session.get("id"))
+            turn_session = self.model.ensure_for_message(base_message)
             self.staged_attachment_ids = []
-            await self.start_turn(message, command_mode=command_mode)
+            self.busy = True
+            try:
+                await self.messages.mount(
+                    Markdown(
+                        f"> 📎 正在解析附件（{len(attachment_items)} 个）…",
+                        id="attach-progress",
+                    )
+                )
+                self.messages.scroll_end(animate=False)
+            except Exception:
+                pass
+            threading.Thread(
+                target=self._prepare_attachment_message,
+                args=(base_message, attachment_items, turn_session),
+                daemon=True,
+            ).start()
+
+        def _prepare_attachment_message(
+            self,
+            base_message: str,
+            attachment_items: list[dict[str, Any]],
+            turn_session: str,
+        ) -> None:
+            try:
+                note = build_attachment_note(attachment_items)
+                error = None
+            except Exception as exc:
+                note = ""
+                error = str(exc)
+            self.post_thread_event(
+                self.attachment_prepare_done,
+                base_message,
+                note,
+                error,
+                turn_session,
+            )
+
+        def attachment_prepare_done(
+            self,
+            base_message: str,
+            note: str,
+            error: str | None,
+            turn_session: str,
+        ) -> None:
+            if turn_session != self.session_id:
+                return
+            if error:
+                self.schedule_worker(
+                    self.attachment_prepare_failed(error),
+                    group="attachment-send",
+                )
+                return
+            self.schedule_worker(
+                self.send_after_attachment(base_message + note, turn_session),
+                group="attachment-send",
+            )
+
+        async def attachment_prepare_failed(self, error: str) -> None:
+            try:
+                progress = self.query_one("#attach-progress", Markdown)
+                await progress.remove()
+            except Exception:
+                pass
+            await self.messages.mount(Markdown(f"> ❌ 附件解析失败：{error}"))
+            self.messages.scroll_end(animate=False)
+            self.busy = False
+
+        async def send_after_attachment(self, message: str, turn_session: str) -> None:
+            if turn_session != self.session_id:
+                return
+            try:
+                progress = self.query_one("#attach-progress", Markdown)
+                await progress.remove()
+            except Exception:
+                pass
+            self.busy = False
+            await self.start_turn(message, command_mode=False)
 
         def schedule_worker(self, work, group: str, *, exclusive: bool = False) -> None:
             """启动 UI worker；任何刷新错误都不允许让 App 闪退。"""

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -15,28 +15,81 @@ import json
 import threading
 from typing import Any
 
+from .cards import render_command_result
 from .commands import command_candidates
 from .engine import cancel_turn, decide_approval, iter_chat_events, iter_command_events
-from .messages import display_text
+from .messages import display_text, parse_command_result
 from .session_model import TuiSessionModel
 from sjtu_agent.commands import is_core_command
 
 try:
     from textual import on
     from textual.app import App, ComposeResult
+    from textual.binding import Binding
     from textual.containers import Horizontal, Vertical, VerticalScroll
+    from textual.screen import ModalScreen
     from textual.widgets import Footer, Header, Input, Label, ListItem, ListView, Markdown, Static
     TEXTUAL_AVAILABLE = True
 except ImportError:  # pragma: no cover - depends on optional extra
     App = None  # type: ignore[assignment]
+    Binding = None  # type: ignore[assignment]
     ComposeResult = None  # type: ignore[assignment]
     Horizontal = Vertical = VerticalScroll = None  # type: ignore[assignment]
+    ModalScreen = None  # type: ignore[assignment]
     Footer = Header = Input = Label = ListItem = ListView = Markdown = Static = None  # type: ignore[assignment]
     on = None  # type: ignore[assignment]
     TEXTUAL_AVAILABLE = False
 
 
 if TEXTUAL_AVAILABLE:
+
+    class RenameModal(ModalScreen[str | None]):
+        """重命名当前会话的输入弹窗。"""
+
+        CSS = """
+        #rename-input { width: 60; }
+        """
+
+        BINDINGS = [("escape", "cancel", "取消")]
+
+        def __init__(self, current_title: str):
+            super().__init__()
+            self.current_title = current_title
+
+        def compose(self) -> ComposeResult:
+            yield Label(f"重命名会话（当前：{self.current_title}）")
+            yield Input(value=self.current_title, id="rename-input")
+
+        def on_mount(self) -> None:
+            prompt = self.query_one("#rename-input", Input)
+            prompt.focus()
+            prompt.cursor_position = len(prompt.value)
+
+        @on(Input.Submitted)
+        def on_input_submitted(self, event: Input.Submitted) -> None:
+            self.dismiss(event.value.strip() or self.current_title)
+
+        def action_cancel(self) -> None:
+            self.dismiss(None)
+
+    class ConfirmDeleteModal(ModalScreen[bool]):
+        """删除会话二次确认。"""
+
+        BINDINGS = [
+            ("y", "confirm", "确认删除"),
+            ("n", "cancel", "取消"),
+            ("escape", "cancel", "取消"),
+        ]
+
+        def compose(self) -> ComposeResult:
+            yield Label("⚠️ 删除当前会话？消息会从本地 SQLite 中永久移除。")
+            yield Label("[y] 确认    [n/esc] 取消")
+
+        def action_confirm(self) -> None:
+            self.dismiss(True)
+
+        def action_cancel(self) -> None:
+            self.dismiss(False)
 
     class ChatApp(App):
         """与 Web GUI 共用 session store 的 Textual 聊天客户端。"""
@@ -56,7 +109,9 @@ if TEXTUAL_AVAILABLE:
         """
 
         BINDINGS = [
+            Binding("ctrl+d", "delete_session", "删除会话", priority=True),
             ("ctrl+n", "new_session", "新会话"),
+            ("ctrl+r", "rename_session", "重命名"),
             ("ctrl+l", "focus_prompt", "聚焦输入"),
             ("ctrl+x", "stop_turn", "停止生成"),
             ("tab", "next_suggestion", "下一个建议"),
@@ -132,6 +187,52 @@ if TEXTUAL_AVAILABLE:
         def action_focus_prompt(self) -> None:
             self.query_one("#prompt", Input).focus()
 
+        def action_rename_session(self) -> None:
+            session = self.model.get_current()
+            if not session:
+                return
+            session_id = session["id"]
+            old_title = session.get("title", "新会话")
+
+            def on_result(new_title: str | None) -> None:
+                if not new_title or new_title == old_title:
+                    return
+                self.model.rename(session_id, new_title)
+                self.schedule_worker(self.after_rename(session_id), group="session-op")
+
+            self.push_screen(RenameModal(old_title), callback=on_result)
+
+        async def after_rename(self, session_id: str) -> None:
+            await self.refresh_sessions(select_id=session_id)
+            await self.load_session(session_id)
+
+        def action_delete_session(self) -> None:
+            session_id = self.session_id
+            if not session_id:
+                return
+
+            def on_result(confirmed: bool) -> None:
+                if not confirmed:
+                    return
+                if self.busy:
+                    cancel_turn(session_id)
+                self.busy = False
+                self.pending_approval = None
+                self.schedule_worker(self.after_delete(session_id), group="session-op")
+
+            self.push_screen(ConfirmDeleteModal(), callback=on_result)
+
+        async def after_delete(self, session_id: str) -> None:
+            self.model.delete(session_id)
+            remaining = self.model.list_sessions()
+            await self.refresh_sessions()
+            if remaining:
+                await self.load_session(remaining[0]["id"])
+            else:
+                session = self.model.create_session("新会话")
+                await self.refresh_sessions(select_id=session.get("id"))
+                await self.load_session(session.get("id") or "")
+
         def action_stop_turn(self) -> None:
             if not self.busy or not self.session_id:
                 return
@@ -168,11 +269,15 @@ if TEXTUAL_AVAILABLE:
                 title = (session or {}).get("title", "")
                 widgets: list[Markdown] = [Markdown(f"# {title}")]
                 for message in self.model.messages(session_id):
-                    text = display_text(message.get("content", ""))
+                    content = message.get("content", "")
                     if message.get("role") == "user":
-                        widgets.append(Markdown(f"> **你**\n\n{text}"))
+                        widgets.append(Markdown(f"> **你**\n\n{display_text(content)}"))
+                        continue
+                    payload = parse_command_result(content)
+                    if payload is not None:
+                        widgets.append(Markdown(render_command_result(payload)))
                     else:
-                        widgets.append(Markdown(text))
+                        widgets.append(Markdown(display_text(content)))
                 await self.messages.mount(*widgets)
                 self.messages.scroll_end(animate=False)
             except Exception:
@@ -335,6 +440,8 @@ if TEXTUAL_AVAILABLE:
 
         def post_thread_event(self, callback, *args) -> None:
             """从 worker 线程安全地投递 UI 回调；app 关闭后静默丢弃。"""
+            if not getattr(self, "is_running", False):
+                return
             try:
                 self.call_from_thread(callback, *args)
             except Exception:
@@ -368,7 +475,12 @@ if TEXTUAL_AVAILABLE:
                 elif kind == "command_progress":
                     self.stream_text += f"\n\n_{event.get('message', '')}_"
                 elif kind == "command_result":
-                    self.stream_text += "\n\n" + str(event.get("text", ""))
+                    payload = {
+                        "view": event.get("view", "markdown"),
+                        "text": event.get("text", ""),
+                        "data": event.get("data", {}),
+                    }
+                    self.stream_text += "\n\n" + render_command_result(payload)
                 elif kind == "error":
                     self.stream_text += f"\n\n❌ **错误：{event.get('text', '')}**"
                 elif kind == "cancelled":

--- a/sjtu_agent/tui/app.py
+++ b/sjtu_agent/tui/app.py
@@ -15,6 +15,7 @@ import json
 import threading
 from typing import Any
 
+from .attachments import TuiAttachments, build_attachment_note
 from .cards import render_command_result
 from .commands import command_candidates
 from .engine import cancel_turn, decide_approval, iter_chat_events, iter_command_events
@@ -121,6 +122,8 @@ if TEXTUAL_AVAILABLE:
         def __init__(self):
             super().__init__()
             self.model = TuiSessionModel()
+            self.attachments = TuiAttachments()
+            self.staged_attachment_ids: list[str] = []
             self.busy = False
             self.pending_approval: dict[str, Any] | None = None
             self.suggestions: list[dict[str, Any]] = []
@@ -181,6 +184,7 @@ if TEXTUAL_AVAILABLE:
             session = self.model.create_session("新会话")
             self.pending_approval = None
             self.busy = False
+            self.staged_attachment_ids = []
             await self.refresh_sessions(select_id=session.get("id"))
             await self.load_session(session.get("id") or "")
 
@@ -295,6 +299,7 @@ if TEXTUAL_AVAILABLE:
                 cancel_turn(self.session_id)
             self.busy = False
             self.pending_approval = None
+            self.staged_attachment_ids = []
             await self.load_session(target)
 
         # ── / 命令补全 ──────────────────────────────────────────────────
@@ -331,6 +336,52 @@ if TEXTUAL_AVAILABLE:
             self.render_suggestions()
 
         # ── 输入与审批 ──────────────────────────────────────────────────
+        def staged_attachment_items(self) -> list[dict[str, Any]]:
+            items = []
+            for attachment_id in self.staged_attachment_ids:
+                item = self.attachments.store.get(attachment_id)
+                if item:
+                    items.append(item)
+            return items
+
+        async def handle_attach_command(self, text: str) -> None:
+            parts = text.split(maxsplit=1)
+            path_arg = parts[1].strip() if len(parts) > 1 else ""
+
+            if not self.session_id:
+                session = self.model.create_session("新会话")
+                await self.refresh_sessions(select_id=session.get("id"))
+
+            if path_arg == "clear":
+                for attachment_id in self.staged_attachment_ids:
+                    self.attachments.remove(attachment_id)
+                self.staged_attachment_ids = []
+                await self.messages.mount(Markdown("> 🧹 已清空暂存附件"))
+                self.messages.scroll_end(animate=False)
+                return
+
+            if not path_arg:
+                items = self.staged_attachment_items()
+                if not items:
+                    await self.messages.mount(Markdown("> 没有暂存附件。用法：`/attach <本地文件路径>`"))
+                else:
+                    lines = ["> 📎 当前暂存附件："]
+                    for item in items:
+                        lines.append(f"> - `{item['filename']}`（{item.get('size', 0)}B）")
+                    await self.messages.mount(Markdown("\n".join(lines)))
+                self.messages.scroll_end(animate=False)
+                return
+
+            item, error = self.attachments.add(self.session_id, path_arg)
+            if error or not item:
+                await self.messages.mount(Markdown(f"> ❌ {error or '附件添加失败'}"))
+            else:
+                self.staged_attachment_ids.append(item["id"])
+                await self.messages.mount(
+                    Markdown(f"> 📎 已暂存附件：`{item['filename']}`（发送下一条消息时自动解析并附加）")
+                )
+            self.messages.scroll_end(animate=False)
+
         @on(Input.Submitted)
         async def on_input_submitted(self, event: Input.Submitted) -> None:
             text = event.value.strip()
@@ -340,6 +391,10 @@ if TEXTUAL_AVAILABLE:
                 self.handle_approval(text)
                 event.input.value = ""
                 return
+            if text.startswith("/attach"):
+                event.input.value = ""
+                await self.handle_attach_command(text)
+                return
             if self.suggestions and text.startswith("/"):
                 candidate = self.suggestions[self.suggestion_index]
                 event.input.value = candidate["value"]
@@ -347,8 +402,18 @@ if TEXTUAL_AVAILABLE:
                 self.render_suggestions()
                 event.input.focus()
                 return
+
             event.input.value = ""
-            await self.start_turn(text)
+            attachment_items = self.staged_attachment_items()
+            attachment_note = build_attachment_note(attachment_items)
+            message = (text or "请查看我上传的附件") + attachment_note
+            command_mode = (
+                not attachment_items
+                and text.startswith("/")
+                and is_core_command(text)
+            )
+            self.staged_attachment_ids = []
+            await self.start_turn(message, command_mode=command_mode)
 
         def schedule_worker(self, work, group: str, *, exclusive: bool = False) -> None:
             """启动 UI worker；任何刷新错误都不允许让 App 闪退。"""
@@ -390,7 +455,7 @@ if TEXTUAL_AVAILABLE:
             except Exception:
                 return
 
-        async def start_turn(self, text: str) -> None:
+        async def start_turn(self, text: str, command_mode: bool | None = None) -> None:
             if self.session_id is None:
                 session = self.model.create_session("新会话")
                 await self.refresh_sessions(select_id=session.get("id"))
@@ -398,6 +463,9 @@ if TEXTUAL_AVAILABLE:
             if not session_id:
                 await self.messages.mount(Markdown("> 无法创建会话"))
                 return
+
+            if command_mode is None:
+                command_mode = text.startswith("/") and is_core_command(text)
 
             try:
                 await self.messages.mount(
@@ -411,7 +479,6 @@ if TEXTUAL_AVAILABLE:
             self.stream_text = ""
             self.busy = True
             self.turn_session = session_id
-            command_mode = text.startswith("/") and is_core_command(text)
             threading.Thread(
                 target=self._run_stream,
                 args=(text, command_mode, session_id),

--- a/sjtu_agent/tui/attachments.py
+++ b/sjtu_agent/tui/attachments.py
@@ -1,0 +1,62 @@
+"""
+sjtu_agent/tui/attachments.py — TUI 附件暂存（复用 Web 白名单存储）。
+
+用户用 `/attach <本地路径>` 添加附件后，文件被复制到运行时
+web_attachments/ 目录并登记到 AttachmentStore；发送消息时只把预解析
+文本注入上下文，原始路径不会交给 Agent，和 WebUI 的越权修复一致。
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from pathlib import Path
+from typing import Any
+
+from sjtu_agent.web.attachment_context import attachment_note_for_chat
+from sjtu_agent.web.attachment_store import AttachmentStore
+
+MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
+
+class TuiAttachments:
+    """TUI 当前会话的暂存附件管理。"""
+
+    def __init__(self, store: AttachmentStore | None = None) -> None:
+        self.store = store or AttachmentStore()
+
+    def add(self, session_id: str, raw_path: str) -> tuple[dict[str, Any] | None, str | None]:
+        path = Path(raw_path or "").expanduser()
+        if not path.exists():
+            return None, f"文件不存在：{raw_path}"
+        if not path.is_file():
+            return None, f"不是文件：{raw_path}"
+        try:
+            size = path.stat().st_size
+        except OSError as exc:
+            return None, f"无法读取文件：{exc}"
+        if size > MAX_ATTACHMENT_BYTES:
+            return None, f"附件超过 20MB 限制：{raw_path}"
+
+        try:
+            data = path.read_bytes()
+        except OSError as exc:
+            return None, f"读取文件失败：{exc}"
+
+        mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        item = self.store.save(session_id, path.name, data, mime_type)
+        return item, None
+
+    def staged(self, session_id: str) -> list[dict[str, Any]]:
+        return self.store.list_for_session(session_id)
+
+    def remove(self, attachment_id: str) -> bool:
+        return self.store.delete(attachment_id)
+
+    def clear_session(self, session_id: str) -> None:
+        for item in self.staged(session_id):
+            self.store.delete(item["id"])
+
+
+def build_attachment_note(items: list[dict[str, Any]]) -> str:
+    """把暂存附件预解析后拼进用户消息（Web / TUI 同一实现）。"""
+    return attachment_note_for_chat(items)

--- a/sjtu_agent/tui/cards.py
+++ b/sjtu_agent/tui/cards.py
@@ -1,0 +1,159 @@
+"""
+sjtu_agent/tui/cards.py — 把共享命令结果渲染成终端 Markdown 卡片。
+
+Web GUI 用 HTML 卡片渲染 {view, text, data}；TUI 用同一份数据生成
+适合 Textual Markdown widget 的 Markdown 布局。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _dining(result: dict[str, Any]) -> str:
+    data = result.get("data") or {}
+    text = result.get("text") or ""
+    if not data.get("ok"):
+        return text
+
+    mode = data.get("mode", "recommendation")
+    campus = data.get("campus", "")
+    if mode == "crowd":
+        lines = [f"## 🍽️ 食堂拥挤度 · {campus} 校区", ""]
+        for canteen in data.get("canteens", []):
+            lines.append(
+                f"- **{canteen.get('name', '')}** — "
+                f"{canteen.get('overall_label', '')}（{canteen.get('overall_rate', '')}%）"
+            )
+        return "\n".join(lines)
+
+    lines = [
+        f"## 🍽️ {data.get('meal_type', '')}推荐 · {campus} 校区",
+        "",
+        str(data.get("summary", "")).strip(),
+        "",
+    ]
+    for rank, rec in enumerate(data.get("recommendations", []), start=1):
+        lines.append(
+            f"### {rank}. {rec.get('canteen_name', '')} "
+            f"{rec.get('overall_label', '')}（{rec.get('overall_rate', '')}%）"
+        )
+        for reason in rec.get("reasons", []):
+            lines.append(f"- {reason}")
+        areas = rec.get("recommended_sub_areas") or []
+        if areas:
+            lines.append(f"- 推荐窗口：{'、'.join(areas[:3])}")
+        lines.append("")
+
+    if data.get("has_history"):
+        lines.append(f"_基于 {data.get('history_count', 0)} 条历史记录，推荐会越来越准_")
+    return "\n".join(lines).strip()
+
+
+def _news(result: dict[str, Any]) -> str:
+    data = result.get("data") or {}
+    items = data.get("items") or []
+    if not items:
+        return result.get("text") or ""
+
+    source_labels = {"jwc": "教务处", "shuiyuan": "水源社区", "official": "交大新闻网", "canvas": "Canvas"}
+    lines = [f"## 📰 校园新闻 · {len(items)} 条", ""]
+    for item in items:
+        title = item.get("title", "未命名")
+        url = item.get("url", "")
+        heading = f"[{title}]({url})" if url else title
+        lines.append(f"### {heading}")
+        source = source_labels.get(item.get("source", ""), item.get("source", ""))
+        meta = source
+        if item.get("category"):
+            meta += f" · {item['category']}"
+        if item.get("reason"):
+            meta += f" · {item['reason']}"
+        if meta:
+            lines.append(f"**{meta}**")
+        if item.get("summary"):
+            lines.append(str(item["summary"]))
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def _homework(result: dict[str, Any]) -> str:
+    data = result.get("data") or {}
+    assignments = data.get("assignments") or []
+    kind = data.get("kind", "list")
+    if not assignments:
+        return result.get("text") or ""
+
+    lines = [f"## 📝 作业列表 · {len(assignments)} 项", ""]
+    for item in assignments:
+        due = item.get("due") or "未知"
+        status = "已提交" if item.get("submitted") else "未提交"
+        days = item.get("days_left")
+        if days is not None:
+            if days > 0:
+                due += f"（{days} 天后）"
+            elif days == 0:
+                due += "（今天）"
+            else:
+                due += "（已截止）"
+        lines.append(
+            f"### [{item.get('index')}] {item.get('course', '')} — {item.get('name', '')}"
+        )
+        lines.append(f"- 截止：{due} · {status}")
+        lines.append("")
+
+    command = "/hw past do N" if kind in {"past", "all"} else "/hw do N"
+    lines.append(f"_在输入框输入 `{command}`（把 N 换成序号）即可分析对应作业_")
+    return "\n".join(lines).strip()
+
+
+def _template_list(data: dict[str, Any], text: str) -> str:
+    templates = data.get("templates") or []
+    if not templates:
+        return text
+    lines = ["## 📚 可用 LaTeX 模板", ""]
+    for template in templates:
+        source = "📦 内置" if template.get("source") == "builtin" else "📥 用户"
+        lines.append(f"- **{template.get('name', '')}** {source}")
+        lines.append(f"  {template.get('description', '')}")
+    lines.extend(["", "_输入 `/template <名称>` 套用模板_"])
+    return "\n".join(lines)
+
+
+def render_command_result(result: dict[str, Any]) -> str:
+    """把 {view,text,data} 渲染为终端 Markdown。"""
+    view = result.get("view") or "markdown"
+    data = result.get("data") or {}
+    text = result.get("text") or ""
+
+    if view == "dining":
+        return _dining(result)
+    if view == "news":
+        return _news(result)
+    if view == "homework":
+        return _homework(result)
+    if view == "template_list":
+        return _template_list(data, text)
+    if view == "template_compile":
+        if data.get("ok"):
+            return f"## ✅ LaTeX 编译成功\n\nPDF：`{data.get('pdf', '')}`（{data.get('size_kb', 0)} KB）"
+        return text
+    if view == "template_clone":
+        if data.get("ok"):
+            return f"## ✅ 模板已克隆\n\n名称：`{data.get('name', '')}`\n\n`/template {data.get('name', '')}` 即可套用。"
+        return text
+    if view == "template_apply":
+        if data.get("ok"):
+            return f"## ✅ 已套用模板\n\n`{data.get('name', '')}`\n\n把你的文档放进去，然后 `/template compile` 编译。"
+        return text
+    if view == "template_push":
+        if data.get("ok"):
+            return f"## ✅ 已推送到 Overleaf\n\n{data.get('message', '')}"
+        return text
+    if view == "news_preference":
+        if data.get("ok"):
+            if data.get("category"):
+                return f"## ✅ 已屏蔽新闻分类\n\n`{data.get('category')}`"
+            return f"## ✅ 新闻偏好已更新\n\n{text}"
+        return text
+    return text

--- a/sjtu_agent/web/attachment_context.py
+++ b/sjtu_agent/web/attachment_context.py
@@ -1,0 +1,59 @@
+"""
+sjtu_agent/web/attachment_context.py — 附件预解析与上下文注入（Web / TUI 共享）。
+
+附件必须先复制进 web_attachments/ 目录再使用；这里只负责把已保存附件
+预解析成文本并拼进用户消息，避免主 Agent 调用 parse_local_file 触发越权或
+OCR 安装询问。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def attachment_content(item: dict) -> str:
+    """复用飞书 Bot 的媒体解析能力，提前提取附件内容。
+
+    图片优先走独立视觉模型，其次走 OCR；其他文件走 parse_file 统一解析。
+    避免让主 Agent 再调用 parse_local_file 并触发 OCR 安装询问。
+    """
+    path = Path(item["path"])
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        return f"（附件读取失败：{exc}）"
+
+    mime_type = str(item.get("mime_type") or "")
+    if mime_type.startswith("image/"):
+        try:
+            from sjtu_agent.vision import analyze_image, load_vision_config
+            if load_vision_config() is not None:
+                return analyze_image(data, "请描述这张图片并提取其中的文字。")
+        except Exception:
+            pass
+
+    try:
+        from sjtu_agent.parsing import parse_file
+        parsed = parse_file(str(path), max_chars=8000, strategy="auto")
+        if parsed.get("ok") and str(parsed.get("content") or "").strip():
+            return str(parsed.get("content"))
+        return "（未能自动提取该附件内容）"
+    except Exception as exc:
+        return f"（附件解析失败：{exc}）"
+
+
+def attachment_note_for_chat(items: list[dict]) -> str:
+    if not items:
+        return ""
+    lines = ["\n\n[用户通过 Web 上传了附件，内容已预解析]"]
+    for item in items:
+        lines.append(
+            f"\n附件：{item['filename']}（type={item.get('mime_type')}, size={item.get('size')}B）"
+            f"\n解析结果：{attachment_content(item)}"
+        )
+    return "\n".join(lines)
+
+
+# 兼容旧调用点与测试的私有别名
+_attachment_content = attachment_content
+_attachment_note_for_chat = attachment_note_for_chat

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from sjtu_agent.paths import ENV_PATH, CONFIG_PATH, AGENT_CONFIG_PATH, _get_or_create_web_token
+from sjtu_agent.web.attachment_context import _attachment_content, _attachment_note_for_chat
 from sjtu_agent.web.attachment_store import AttachmentStore
 from sjtu_agent.web.session_store import SessionStore
 
@@ -403,47 +404,7 @@ def _build_history(_agent, session_id: str | None) -> list[dict]:
     return history
 
 
-def _attachment_content(item: dict) -> str:
-    """复用飞书 Bot 的媒体解析能力，提前提取附件内容。
-
-    图片优先走独立视觉模型，其次走 OCR；其他文件走 parse_file 统一解析。
-    避免让主 Agent 再调用 parse_local_file 并触发 OCR 安装询问。
-    """
-    path = Path(item["path"])
-    try:
-        data = path.read_bytes()
-    except OSError as exc:
-        return f"（附件读取失败：{exc}）"
-
-    mime_type = str(item.get("mime_type") or "")
-    if mime_type.startswith("image/"):
-        try:
-            from sjtu_agent.vision import analyze_image, load_vision_config
-            if load_vision_config() is not None:
-                return analyze_image(data, "请描述这张图片并提取其中的文字。")
-        except Exception:
-            pass
-
-    try:
-        from sjtu_agent.parsing import parse_file
-        parsed = parse_file(str(path), max_chars=8000, strategy="auto")
-        if parsed.get("ok") and str(parsed.get("content") or "").strip():
-            return str(parsed.get("content"))
-        return "（未能自动提取该附件内容）"
-    except Exception as exc:
-        return f"（附件解析失败：{exc}）"
-
-
-def _attachment_note_for_chat(items: list[dict]) -> str:
-    if not items:
-        return ""
-    lines = ["\n\n[用户通过 Web 上传了附件，内容已预解析]"]
-    for item in items:
-        lines.append(
-            f"\n附件：{item['filename']}（type={item.get('mime_type')}, size={item.get('size')}B）"
-            f"\n解析结果：{_attachment_content(item)}"
-        )
-    return "\n".join(lines)
+# 附件预解析与上下文注入逻辑见 sjtu_agent/web/attachment_context.py（Web / TUI 共享）。
 
 
 def _get_chat_client():

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
 
 import pytest
@@ -276,6 +277,69 @@ def test_attach_command_uses_whitelisted_store_and_preparses(tmp_path, monkeypat
             assert sent_messages
             assert "预解析出的作业内容" in sent_messages[-1]
             assert str(source) not in sent_messages[-1]
+
+    _run(scenario())
+
+
+def test_attachment_parsing_runs_off_the_ui_thread(tmp_path, monkeypatch):
+    from sjtu_agent.tui.attachments import TuiAttachments
+    from sjtu_agent.web.attachment_store import AttachmentStore
+
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+    source = tmp_path / "image.png"
+    source.write_bytes(b"fake-image")
+
+    started = threading.Event()
+    release = threading.Event()
+    sent_messages = []
+
+    def fake_parse(path, **kwargs):
+        started.set()
+        release.wait(timeout=10)
+        return {"ok": True, "content": "图片解析内容"}
+
+    def fake_stream(session_id, user_message):
+        sent_messages.append(user_message)
+        yield {"kind": "done"}
+
+    monkeypatch.setattr("sjtu_agent.parsing.parse_file", fake_parse)
+    monkeypatch.setattr("sjtu_agent.tui.app.iter_chat_events", fake_stream)
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        app.attachments = TuiAttachments(AttachmentStore(tmp_path / "web_attachments"))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            prompt = app.query_one("#prompt", Input)
+
+            prompt.focus()
+            prompt.value = f"/attach {source}"
+            await pilot.press("enter")
+            await pilot.pause()
+
+            prompt.focus()
+            prompt.value = "看图"
+            await pilot.press("enter")
+            for _ in range(50):
+                if started.is_set():
+                    break
+                await pilot.pause(0.05)
+
+            assert started.is_set()
+            assert app.busy is True
+            assert app.query_one("#attach-progress", Markdown) is not None
+
+            release.set()
+            for _ in range(50):
+                if not app.busy:
+                    break
+                await pilot.pause(0.05)
+
+            assert sent_messages
+            assert "图片解析内容" in sent_messages[-1]
 
     _run(scenario())
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import pytest
 
@@ -222,6 +223,59 @@ def test_delete_session_modal_creates_replacement(tmp_path):
             assert model.store.get_session(old_id) is None
             assert model.list_sessions()
             assert app.session_id == model.list_sessions()[0]["id"]
+
+    _run(scenario())
+
+
+def test_attach_command_uses_whitelisted_store_and_preparses(tmp_path, monkeypatch):
+    from sjtu_agent.tui.attachments import TuiAttachments
+    from sjtu_agent.web.attachment_store import AttachmentStore
+
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    model.create_session("新会话")
+    source = tmp_path / "作业.pdf"
+    source.write_bytes(b"%PDF fake")
+
+    sent_messages = []
+
+    def fake_stream(session_id, user_message):
+        sent_messages.append(user_message)
+        yield {"kind": "done"}
+
+    monkeypatch.setattr("sjtu_agent.tui.app.iter_chat_events", fake_stream)
+    monkeypatch.setattr(
+        "sjtu_agent.parsing.parse_file",
+        lambda path, **kwargs: {"ok": True, "content": "预解析出的作业内容"},
+    )
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        app.attachments = TuiAttachments(AttachmentStore(tmp_path / "web_attachments"))
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+
+            prompt = app.query_one("#prompt", Input)
+            prompt.focus()
+            prompt.value = f"/attach {source}"
+            await pilot.press("enter")
+            await pilot.pause()
+            assert len(app.staged_attachment_ids) == 1
+            item = app.attachments.store.get(app.staged_attachment_ids[0])
+            assert Path(item["path"]).is_relative_to(tmp_path / "web_attachments")
+
+            prompt.focus()
+            prompt.value = "帮我看看附件"
+            await pilot.press("enter")
+            for _ in range(20):
+                if not app.busy:
+                    break
+                await pilot.pause(0.05)
+
+            assert sent_messages
+            assert "预解析出的作业内容" in sent_messages[-1]
+            assert str(source) not in sent_messages[-1]
 
     _run(scenario())
 

--- a/tests/test_tui_app.py
+++ b/tests/test_tui_app.py
@@ -175,6 +175,57 @@ def test_high_frequency_stream_does_not_crash_app(tmp_path, monkeypatch):
     _run(scenario())
 
 
+def test_rename_session_modal(tmp_path):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    session_id = model.create_session("旧名字")["id"]
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            rename_input = app.screen.query_one("#rename-input", Input)
+            rename_input.value = "新名字"
+            await pilot.press("enter")
+            for _ in range(20):
+                if model.get_current()["title"] == "新名字":
+                    break
+                await pilot.pause(0.05)
+
+            assert model.get_current()["title"] == "新名字"
+            assert model.get_current()["id"] == session_id
+
+    _run(scenario())
+
+
+def test_delete_session_modal_creates_replacement(tmp_path):
+    store = SessionStore(tmp_path / "web_sessions.sqlite3")
+    model = TuiSessionModel(store)
+    old_id = model.create_session("待删除")["id"]
+
+    async def scenario():
+        app = build_app()
+        app.model = model
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+d")
+            await pilot.pause()
+            await pilot.press("y")
+            for _ in range(20):
+                if model.store.get_session(old_id) is None:
+                    break
+                await pilot.pause(0.05)
+
+            assert model.store.get_session(old_id) is None
+            assert model.list_sessions()
+            assert app.session_id == model.list_sessions()[0]["id"]
+
+    _run(scenario())
+
+
 def test_command_suggestions_fill_input(tmp_path):
     store = SessionStore(tmp_path / "web_sessions.sqlite3")
     model = TuiSessionModel(store)

--- a/tests/test_tui_attachments.py
+++ b/tests/test_tui_attachments.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from sjtu_agent.tui.attachments import TuiAttachments, build_attachment_note
+from sjtu_agent.web.attachment_store import AttachmentStore
+
+
+def _make_manager(tmp_path):
+    store = AttachmentStore(tmp_path / "web_attachments")
+    return TuiAttachments(store)
+
+
+def test_attach_copies_file_into_whitelisted_store(tmp_path):
+    source = tmp_path / "notes.txt"
+    source.write_text("本地文件内容", encoding="utf-8")
+    manager = _make_manager(tmp_path)
+
+    item, error = manager.add("session-1", str(source))
+    assert error is None
+    assert item is not None
+    assert item["filename"] == "notes.txt"
+    assert Path(item["path"]).is_relative_to(tmp_path / "web_attachments")
+    assert Path(item["path"]).read_text(encoding="utf-8") == "本地文件内容"
+
+
+def test_attach_rejects_missing_and_oversized(tmp_path):
+    manager = _make_manager(tmp_path)
+    _, error = manager.add("session-1", str(tmp_path / "missing.png"))
+    assert "不存在" in error
+
+    big = tmp_path / "big.bin"
+    big.write_bytes(b"0" * (21 * 1024 * 1024))
+    _, error = manager.add("session-1", str(big))
+    assert "20MB" in error
+
+
+def test_build_attachment_note_preparses_content(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "sjtu_agent.parsing.parse_file",
+        lambda path, **kwargs: {"ok": True, "content": "预解析内容"},
+    )
+    doc = tmp_path / "notes.pdf"
+    doc.write_bytes(b"%PDF fake")
+    item = {
+        "filename": "notes.pdf",
+        "mime_type": "application/pdf",
+        "size": 10,
+        "path": str(doc),
+    }
+    note = build_attachment_note([item])
+    assert "预解析内容" in note
+    assert "已预解析" in note
+    assert "parse_local_file" not in note
+
+
+def test_remove_and_clear(tmp_path):
+    source = tmp_path / "a.txt"
+    source.write_text("x", encoding="utf-8")
+    manager = _make_manager(tmp_path)
+    item, _ = manager.add("s1", str(source))
+    assert len(manager.staged("s1")) == 1
+
+    assert manager.remove(item["id"]) is True
+    assert manager.staged("s1") == []
+
+    manager.add("s2", str(source))
+    manager.clear_session("s2")
+    assert manager.staged("s2") == []

--- a/tests/test_tui_cards.py
+++ b/tests/test_tui_cards.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from sjtu_agent.tui.cards import render_command_result
+
+
+def test_dining_card_renders_recommendations():
+    result = {
+        "view": "dining",
+        "text": "fallback",
+        "data": {
+            "ok": True,
+            "mode": "recommendation",
+            "campus": "闵行",
+            "meal_type": "午餐",
+            "summary": "今天适合清淡",
+            "has_history": True,
+            "history_count": 3,
+            "recommendations": [
+                {
+                    "canteen_name": "第一餐饮大楼",
+                    "overall_label": "空闲",
+                    "overall_rate": 20,
+                    "reasons": ["人少"],
+                    "recommended_sub_areas": ["面馆", "自选"],
+                }
+            ],
+        },
+    }
+    markdown = render_command_result(result)
+    assert "第一餐饮大楼" in markdown
+    assert "面馆" in markdown
+    assert "历史记录" in markdown
+    assert "fallback" not in markdown
+
+
+def test_news_card_renders_links_and_meta():
+    result = {
+        "view": "news",
+        "text": "fallback",
+        "data": {
+            "items": [
+                {
+                    "title": "教务通知",
+                    "url": "https://example.com",
+                    "source": "jwc",
+                    "category": "选课",
+                    "reason": "与你相关",
+                    "summary": "摘要内容",
+                }
+            ]
+        },
+    }
+    markdown = render_command_result(result)
+    assert "[教务通知](https://example.com)" in markdown
+    assert "教务处" in markdown
+    assert "选课" in markdown
+    assert "与你相关" in markdown
+
+
+def test_homework_card_uses_past_command_for_past_list():
+    result = {
+        "view": "homework",
+        "text": "fallback",
+        "data": {
+            "ok": True,
+            "kind": "past",
+            "assignments": [
+                {"index": 1, "course": "数学分析", "name": "作业一", "due": "2026-08-01", "submitted": True}
+            ],
+        },
+    }
+    markdown = render_command_result(result)
+    assert "数学分析" in markdown
+    assert "/hw past do N" in markdown
+
+
+def test_template_list_card():
+    result = {
+        "view": "template_list",
+        "text": "fallback",
+        "data": {"templates": [{"name": "bachelor-thesis", "description": "毕业论文", "source": "builtin"}]},
+    }
+    markdown = render_command_result(result)
+    assert "bachelor-thesis" in markdown
+    assert "📦" in markdown
+
+
+def test_unknown_view_falls_back_to_text():
+    assert render_command_result({"view": "markdown", "text": "**hello**"}) == "**hello**"


### PR DESCRIPTION
## Summary

TUI 增强批次：

- 结构化命令卡片（复用 Web 的 `{view, text, data}`）
- 会话重命名 / 删除快捷键
- 附件上传走 Web 白名单存储，修复越权路径问题
- 附件解析移出 UI 线程，视觉模型 / OCR 不再冻结 TUI

## Changes

### Structured command cards
- `sjtu_agent/tui/cards.py`：把 dining / news / homework / template / news_preference 结果渲染为终端 Markdown 卡片
- 实时 command_result 和历史会话加载共用同一 renderer

### Session management
- `ctrl+r` 重命名弹窗
- `ctrl+d` 删除确认弹窗（priority binding，避免与输入框删除键冲突）
- 删除后自动切换到剩余会话或新建会话

### Attachments（越权修复）
- 抽取 `sjtu_agent/web/attachment_context.py`，Web / TUI 共用附件预解析逻辑
- TUI `/attach <本地路径>`：复制进 `web_attachments/` 白名单目录，原始路径不进入 Agent
- `/attach` 查看暂存，`/attach clear` 清空
- 发送消息时只注入预解析文本

### Non-blocking parsing
- 附件解析在后台线程执行，UI 显示进度并保持响应
- 解析完成后自动发送；失败显示错误并恢复输入

## Tests

- Textual headless UI 测试覆盖：卡片、重命名 / 删除 modal、附件流程、阻塞解析时 UI 仍响应
- 完整 pytest：**510 passed**

## Notes

- 暑假期间未做实机 Canvas/DDL 验证，命令卡片数据来自共享命令层的 mock 测试。
