### PR TITLE
ci: make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes-file release_notes.md \
-            dist/*
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, skipping creation."
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file release_notes.md \
+              dist/*
+          fi


### PR DESCRIPTION
ci: make release workflow idempotent

When a release was created manually ahead of pushing the tag, the tag push
workflow's `gh release create` failed with "a release with the same tag name
already exists", leaving a red CI run. Skip creation when the release exists.

Fixes the failing "Release v0.20.1" run.