### PR TITLE
feat(daemons): add sjtu-agent daemons restart (#149-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## Unreleased
+- 🔄 新增 `sjtu-agent daemons restart`：一键重启后台服务（停止 → 按安装清单参数重建并启动），支持 `--services` 子集选择（issue #149-5）
+
 ## v0.20.1 (2026-08-20)
 - ⏱️ 飞书 Bot 请求超时阈值放宽并可配置：`feishu_capture_timeout`（默认 600 秒，设 0 不限时，与 Telegram 等端一致）替代旧的固定 120 秒；等待期间每 `feishu_progress_interval` 秒（默认 120 秒，最多 3 条）发送"仍在处理中"心跳
 - 🔌 超时后自动做 15 秒 API 健康探测，区分"密钥失效/服务不可用"与"模型只是慢/任务复杂"，并给出对应处理建议；日志记录超时任务的实际完成耗时，便于判断阈值是否需要继续调大

--- a/sjtu_agent/cli.py
+++ b/sjtu_agent/cli.py
@@ -16,6 +16,7 @@ from sjtu_agent.scheduler import (
     install_daemons,
     list_deployments,
     resync_daemons,
+    restart_daemons,
     uninstall_daemons,
 )
 from sjtu_agent.setup_wizard import register_setup_parser
@@ -568,6 +569,20 @@ def _cmd_daemons_resync(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_daemons_restart(args: argparse.Namespace) -> int:
+    try:
+        payload = restart_daemons(
+            service_names=tuple(args.services) if args.services else None,
+            backend=args.backend,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    print_json(payload)
+    failed = [r for r in payload.get("results", []) if not r.get("restarted")]
+    return 1 if failed else 0
+
+
 def _prompt_config_password(confirm: bool) -> str:
     """交互式读取配置归档密码；无 TTY 时从 SJTU_AGENT_CONFIG_PASSWORD 读取。"""
     from sjtu_agent.config_transfer import password_from_env
@@ -978,6 +993,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="python executable to use (default: current interpreter)",
     )
     daemons_resync_parser.set_defaults(func=_cmd_daemons_resync)
+
+    daemons_restart_parser = daemons_sub.add_parser(
+        "restart",
+        help="restart background services (stop + reinstall, preserving manifest settings)",
+    )
+    daemons_restart_parser.add_argument(
+        "--services",
+        nargs="+",
+        choices=available_service_names(),
+        help="subset of services to restart (default: all installed)",
+    )
+    daemons_restart_parser.add_argument(
+        "--backend",
+        choices=["taskschd", "psmux"],
+        default="taskschd",
+        help="(Windows) 后端选择，用于从未安装过的服务首次安装：taskschd 或 psmux",
+    )
+    daemons_restart_parser.set_defaults(func=_cmd_daemons_restart)
 
     export_config_parser = subparsers.add_parser(
         "export-config",

--- a/sjtu_agent/scheduler/__init__.py
+++ b/sjtu_agent/scheduler/__init__.py
@@ -180,6 +180,107 @@ def daemon_status(
     return _status(service_names=service_names, **platform_kwargs)
 
 
+def restart_daemons(
+    service_names: tuple[str, ...] | None = None,
+    python_executable: Path | None = None,
+    backend: str = "taskschd",
+    **platform_kwargs,
+) -> dict:
+    """
+    重启后台守护进程：先停止（uninstall）再按清单参数重建并启动（install）。
+
+    后端没有独立的 stop/start 原语（launchd/psmux/taskschd/systemd 都只暴露
+    install/uninstall/status），因此 restart 通用实现为 uninstall→install，
+    语义等价于"停掉旧进程 → 用记录的参数重新注册并拉起"。
+
+    参数：
+        service_names       要重启的服务子集；None 表示重启清单里的全部服务
+        python_executable   使用的 Python 解释器路径，默认当前解释器
+        backend             请求的服务从未安装过时的后端（Windows: taskschd/psmux）
+
+    已安装过的服务会保留清单中的 daily_report_time / remind_interval /
+    telegram_throttle / output_dir 等参数；未安装过的服务按默认参数安装。
+    """
+    current_py = str(python_executable or sys.executable)
+    selected = set(service_names or ())
+    results: list[dict] = []
+
+    for deployment in list_deployments():
+        dep_backend = deployment["backend"]
+        dep_services = tuple(deployment["services"])
+        if selected:
+            wanted = tuple(sorted(set(dep_services) & selected))
+            if not wanted:
+                continue
+        else:
+            wanted = dep_services
+        if not wanted:
+            continue
+
+        kwargs: dict = {
+            "daily_report_time": tuple(deployment.get("daily_report_time") or (22, 0)),
+            "remind_interval": int(deployment.get("remind_interval") or 60),
+            "telegram_throttle": int(deployment.get("telegram_throttle") or 10),
+        }
+        output_dir = deployment.get("output_dir")
+        if output_dir:
+            kwargs["output_dir"] = Path(output_dir)
+        else:
+            kwargs["output_dir"] = platform_kwargs.get("output_dir")
+
+        try:
+            uninstall_daemons(service_names=wanted, backend=dep_backend)
+            install_daemons(
+                service_names=wanted,
+                python_executable=Path(current_py),
+                backend=dep_backend,
+                **kwargs,
+            )
+            results.append({
+                "backend": dep_backend,
+                "services": list(wanted),
+                "restarted": True,
+            })
+        except Exception as exc:
+            results.append({
+                "backend": dep_backend,
+                "services": list(wanted),
+                "restarted": False,
+                "error": str(exc),
+            })
+        selected -= set(wanted)
+
+    # 请求的服务从未安装过 → 直接按默认参数安装（等价首次安装并启动）
+    if selected:
+        try:
+            install_daemons(
+                service_names=tuple(sorted(selected)),
+                python_executable=Path(current_py),
+                backend=backend,
+                **platform_kwargs,
+            )
+            results.append({
+                "backend": backend,
+                "services": sorted(selected),
+                "restarted": True,
+            })
+        except Exception as exc:
+            results.append({
+                "backend": backend,
+                "services": sorted(selected),
+                "restarted": False,
+                "error": str(exc),
+            })
+
+    return {
+        "platform": current_platform_name(),
+        "python_executable": current_py,
+        "manifest_path": str(DAEMON_MANIFEST_PATH),
+        "results": results,
+        "any_restarted": any(r.get("restarted") for r in results),
+    }
+
+
 def resync_daemons(python_executable: Path | None = None) -> dict:
     """
     根据安装清单恢复此前安装过的后台服务。

--- a/tests/test_scheduler_restart.py
+++ b/tests/test_scheduler_restart.py
@@ -1,0 +1,177 @@
+"""tests/test_scheduler_restart.py — restart_daemons 单元测试（facade 层）。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from sjtu_agent.scheduler import restart_daemons
+
+
+def _deployment(backend="taskschd", services=("feishu-bot",), **extra):
+    dep = {
+        "backend": backend,
+        "services": list(services),
+        "python_executable": Path("python").resolve(),
+        "daily_report_time": (22, 0),
+        "remind_interval": 60,
+        "telegram_throttle": 10,
+        "output_dir": "",
+    }
+    dep.update(extra)
+    return dep
+
+
+def test_restart_stops_then_reinstalls_with_manifest_params(monkeypatch):
+    """restart = 先 uninstall（停止）再按清单参数 install（重建并启动）。"""
+    dep = _deployment(daily_report_time=(21, 30), remind_interval=120)
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [dep])
+
+    calls = {"uninstall": [], "install": []}
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.uninstall_daemons",
+        lambda **kw: calls["uninstall"].append(kw) or {"removed": []},
+    )
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kw: calls["install"].append(kw) or {},
+    )
+
+    payload = restart_daemons()
+    assert payload["any_restarted"] is True
+    assert calls["uninstall"][0]["service_names"] == ("feishu-bot",)
+    inst = calls["install"][0]
+    assert inst["service_names"] == ("feishu-bot",)
+    assert inst["daily_report_time"] == (21, 30)   # 清单参数被保留
+    assert inst["remind_interval"] == 120
+
+
+def test_restart_uses_deployment_backend(monkeypatch):
+    """按清单记录的 backend（如 psmux）重启，而不是 Windows 默认 taskschd。"""
+    dep = _deployment(backend="psmux")
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [dep])
+    calls = {"uninstall": [], "install": []}
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.uninstall_daemons",
+        lambda **kw: calls["uninstall"].append(kw) or {},
+    )
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kw: calls["install"].append(kw) or {},
+    )
+
+    restart_daemons()
+    assert calls["uninstall"][0]["backend"] == "psmux"
+    assert calls["install"][0]["backend"] == "psmux"
+
+
+def test_restart_selected_subset_of_deployment(monkeypatch):
+    """--services 只重启清单里匹配的子集，未选中的服务不动。"""
+    dep = _deployment(services=("feishu-bot", "web"))
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [dep])
+    calls = {"uninstall": [], "install": []}
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.uninstall_daemons",
+        lambda **kw: calls["uninstall"].append(kw) or {},
+    )
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kw: calls["install"].append(kw) or {},
+    )
+
+    restart_daemons(service_names=("web",))
+    assert calls["uninstall"][0]["service_names"] == ("web",)
+    assert calls["install"][0]["service_names"] == ("web",)
+
+
+def test_restart_uninstalled_service_installs_fresh(monkeypatch):
+    """请求的服务从未安装过 → 直接按默认参数安装（等价首次安装并启动）。"""
+    monkeypatch.setattr("sjtu_agent.scheduler.list_deployments", lambda: [])
+    calls = []
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.install_daemons",
+        lambda **kw: calls.append(kw) or {},
+    )
+
+    payload = restart_daemons(service_names=("remind-check",), backend="psmux")
+    assert calls, "未安装的服务也应触发安装"
+    assert calls[0]["service_names"] == ("remind-check",)
+    assert calls[0]["backend"] == "psmux"
+    assert payload["any_restarted"] is True
+
+
+def test_restart_reports_errors_per_deployment(monkeypatch):
+    """单个部署重启失败不阻断其他部署，错误信息透出。"""
+    dep_ok = _deployment(services=("feishu-bot",))
+    dep_bad = _deployment(backend="systemd", services=("remind-check",))
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.list_deployments", lambda: [dep_ok, dep_bad]
+    )
+    monkeypatch.setattr(
+        "sjtu_agent.scheduler.uninstall_daemons", lambda **kw: {}
+    )
+
+    def _bad_install(**kw):
+        if kw.get("service_names") == ("remind-check",):
+            raise RuntimeError("systemctl unavailable")
+        return {}
+
+    monkeypatch.setattr("sjtu_agent.scheduler.install_daemons", _bad_install)
+
+    payload = restart_daemons()
+    assert payload["any_restarted"] is True  # 至少一个成功
+    by_name = {r["services"][0]: r for r in payload["results"]}
+    assert by_name["feishu-bot"]["restarted"] is True
+    assert by_name["remind-check"]["restarted"] is False
+    assert "systemctl unavailable" in by_name["remind-check"]["error"]
+
+
+# ── CLI 层：sjtu-agent daemons restart ──────────────────────────────────────
+
+def test_cmd_daemons_restart_forwards_services_backend(monkeypatch, capsys):
+    import argparse
+
+    import sjtu_agent.cli as cli
+
+    seen = {}
+
+    def fake_restart(service_names=None, backend="taskschd", **kw):
+        seen["service_names"] = service_names
+        seen["backend"] = backend
+        return {
+            "platform": "test",
+            "python_executable": "py",
+            "manifest_path": "x",
+            "results": [
+                {"backend": backend, "services": list(service_names or []), "restarted": True},
+            ],
+            "any_restarted": True,
+        }
+
+    monkeypatch.setattr(cli, "restart_daemons", fake_restart)
+    monkeypatch.setattr(cli, "print_json", lambda payload: None)
+
+    args = argparse.Namespace(services=["feishu-bot"], backend="psmux")
+    rc = cli._cmd_daemons_restart(args)
+    assert rc == 0
+    assert seen == {"service_names": ("feishu-bot",), "backend": "psmux"}
+
+
+def test_cmd_daemons_restart_returns_failure_code_on_error(monkeypatch):
+    import argparse
+
+    import sjtu_agent.cli as cli
+
+    def fake_restart(service_names=None, backend="taskschd", **kw):
+        return {
+            "results": [
+                {"backend": backend, "services": ["remind-check"], "restarted": False,
+                 "error": "boom"},
+            ],
+            "any_restarted": False,
+        }
+
+    monkeypatch.setattr(cli, "restart_daemons", fake_restart)
+    monkeypatch.setattr(cli, "print_json", lambda payload: None)
+
+    rc = cli._cmd_daemons_restart(argparse.Namespace(services=["remind-check"], backend="taskschd"))
+    assert rc == 1


### PR DESCRIPTION
feat(daemons): add `sjtu-agent daemons restart`

One-key restart for background services (issue #149-5). Previously the only
options were install-daemons / daemons status|uninstall|resync — users hosting
bots on servers had no obvious way to restart a service the bot told them to
restart.

- scheduler.restart_daemons(): stop (uninstall) then reinstall+start using the
  recorded manifest parameters (daily_report_time / remind_interval /
  telegram_throttle / output_dir / backend); services never installed before
  fall back to default install so the command is also an idempotent upsert.
- CLI: `sjtu-agent daemons restart [--services ...] [--backend taskschd|psmux]`;
  exits non-zero when any selected service fails to restart (errors surfaced).
- CHANGELOG entry.

Tests (TDD):
- tests/test_scheduler_restart.py: manifest params preserved, per-deployment
  backend respected, subset selection, never-installed services install fresh,
  per-deployment error isolation + error surfacing, CLI forwarding and exit
  codes (7 new tests).
- Full suite: 563 passed.

Part of the #149 follow-up plan (item 5).