### PR TITLE
fix(mcp): deliver MCP tools to runner + surface server failures (#149-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
 ## Unreleased
+- 🔌 MCP 修复：runner 工具列表真正聚合 MCP 服务器动态工具（之前 add_mcp_server 写入的配置永远不会下发到模型）；单个 server 连接/发现超时产出可调用状态工具（不再拖死整轮）；`add_mcp_server` 返回带正确配置路径 + 依赖 venv + `daemons restart` 指引（issue #149-2）
 - 🔄 新增 `sjtu-agent daemons restart`：一键重启后台服务（停止 → 按安装清单参数重建并启动），支持 `--services` 子集选择（issue #149-5）
 
 ## v0.20.1 (2026-08-20)

--- a/sjtu_agent/agent/runner.py
+++ b/sjtu_agent/agent/runner.py
@@ -30,9 +30,15 @@ _MAX_NETWORK_RETRIES = 2   # 网络/超时重试上限
 
 
 def _get_tools():
-    """Lazy import TOOLS，避免 runner ↔ tools 循环依赖。"""
-    from sjtu_agent.agent.tools import TOOLS
-    return TOOLS
+    """Lazy import：内置工具 + MCP 服务器动态工具（registry 聚合）。
+
+    修复（issue #149-2）：之前只返回静态 TOOLS，add_mcp_server 写入的
+    MCP 服务器工具永远不会进入发给模型的工具列表（配置写了、bot 也重启了，
+    但工具列表里始终没有 mcp__*）。registry.get_available_tools 自带 60s
+    TTL 缓存 + 坏 server 状态工具，不会每轮重复连接。
+    """
+    from sjtu_agent.extensions.registry import get_available_tools
+    return get_available_tools()
 
 
 def _get_run_tool():

--- a/sjtu_agent/agent/tools/_mcp_skills.py
+++ b/sjtu_agent/agent/tools/_mcp_skills.py
@@ -257,7 +257,18 @@ def tool_add_mcp_server(
         "server_id": server_id,
         "config": server_cfg,
         "tool_prefix": f"mcp__{server_id}__",
-        "next_action": "Restart or continue the conversation; MCP tools will be rediscovered automatically.",
+        "config_path": str(CONFIG_PATH),
+        "next_action": (
+            "MCP tools are now registered. Tell the user: 配置已写入 "
+            f"`{CONFIG_PATH}`（mcp_servers 键）。工具会在下一次工具列表刷新（约 60 秒内）"
+            "自动下发，无需重启会话；但若依赖未装齐，需要把依赖安装进「运行 bot 的进程」所在 "
+            "venv（不是交互式 sjtu-agent 的 venv），然后重启对应的后台服务。"
+        ),
+        "checklist": [
+            "依赖安装进 bot 进程所在 venv，例如: cd 项目目录 && source .venv/bin/activate && pip install <包>",
+            "重启后台服务: sjtu-agent daemons restart --services feishu-bot  （或其他 bot，Windows 加 --backend psmux 视部署而定）",
+            "重启后若工具仍不出现，直接调用 mcp__<server_id>__status 查看失败原因",
+        ],
     }
 
 

--- a/sjtu_agent/extensions/mcp_client.py
+++ b/sjtu_agent/extensions/mcp_client.py
@@ -21,6 +21,7 @@ from sjtu_agent.paths import CONFIG_PATH, read_json_safe
 
 
 _CACHE_TTL_SECONDS = 60
+_DEFAULT_DISCOVERY_TIMEOUT = 15.0  # 单个 MCP server 发现（连接+列工具）超时，防止坏 server 拖死每轮工具列表
 _TOOLS_CACHE: dict[str, Any] = {"ts": 0.0, "tools": [], "map": {}}
 _NAME_RE = re.compile(r"[^a-zA-Z0-9_]")
 
@@ -180,31 +181,48 @@ async def _list_tools_async() -> tuple[list[dict], dict[str, dict]]:
     used_names: set[str] = set()
     for server_id, server_cfg in _enabled_servers().items():
         try:
-            async with _open_session(server_cfg) as session:
-                result = await session.list_tools()
+            _timeout = float(server_cfg.get("discovery_timeout", _DEFAULT_DISCOVERY_TIMEOUT))
+
+            async def _discover(cfg=server_cfg):
+                async with _open_session(cfg) as session:
+                    return await session.list_tools()
+
+            result = await asyncio.wait_for(_discover(), timeout=_timeout)
+        except asyncio.TimeoutError:
+            reason = (
+                f"MCP server 连接/发现超时（>{_timeout:.0f}s）。请检查命令/URL 是否可达、"
+                f"依赖是否安装在 bot 进程所在 venv，然后用 sjtu-agent daemons restart 重启后台服务。"
+            )
         except Exception as exc:
-            public_name = _unique_name(f"mcp__{_sanitize(server_id)}__status", used_names)
-            tools.append({
-                "type": "function",
-                "function": {
-                    "name": public_name,
-                    "description": f"[MCP:{server_id}] Report why this MCP server is unavailable.",
-                    "parameters": {"type": "object", "properties": {}, "required": []},
-                },
-            })
-            name_map[public_name] = {
-                "server_id": server_id,
-                "tool_name": "__status__",
-                "error": str(exc),
-            }
+            reason = str(exc)
+        else:
+            for idx, tool_obj in enumerate(getattr(result, "tools", []) or []):
+                tool, meta = _tool_to_openai(server_id, tool_obj, idx)
+                public_name = _unique_name(meta["public_name"], used_names)
+                tool["function"]["name"] = public_name
+                meta["public_name"] = public_name
+                tools.append(tool)
+                name_map[meta["public_name"]] = meta
             continue
-        for idx, tool_obj in enumerate(getattr(result, "tools", []) or []):
-            tool, meta = _tool_to_openai(server_id, tool_obj, idx)
-            public_name = _unique_name(meta["public_name"], used_names)
-            tool["function"]["name"] = public_name
-            meta["public_name"] = public_name
-            tools.append(tool)
-            name_map[meta["public_name"]] = meta
+
+        # 连接/发现失败：注入一个可调用的状态工具，让模型能看到失败原因
+        public_name = _unique_name(f"mcp__{_sanitize(server_id)}__status", used_names)
+        tools.append({
+            "type": "function",
+            "function": {
+                "name": public_name,
+                "description": (
+                    f"[MCP:{server_id}] 该 MCP server 当前不可用，原因：{reason}。"
+                    f"调用（无需参数）以获取完整错误信息。"
+                ),
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        })
+        name_map[public_name] = {
+            "server_id": server_id,
+            "tool_name": "__status__",
+            "error": reason,
+        }
     return tools, name_map
 
 

--- a/tests/test_mcp_runner_integration.py
+++ b/tests/test_mcp_runner_integration.py
@@ -1,0 +1,94 @@
+"""tests/test_mcp_runner_integration.py — MCP 工具真正下发到 runner 的契约。
+
+根因（issue #149-2）：runner 的 _get_tools() 只返回静态 TOOLS，add_mcp_server
+写入的 MCP 服务器工具从未进入发给模型的工具列表。这里锁住修复后的契约。
+"""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+
+
+class _SlowSession:
+    async def list_tools(self):
+        await asyncio.sleep(30)
+        return None
+
+
+async def _slow_wait_for_ever_ctx():  # pragma: no cover - 仅在测试中作为挂起连接替身
+    await asyncio.sleep(30)
+
+
+@asynccontextmanager
+async def slow_open_session(server_cfg):  # pragma: no cover
+    """模拟永远挂起的 MCP 连接。"""
+    await asyncio.sleep(30)
+    yield _SlowSession()
+
+
+def _write_config(tmp_path, servers):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"mcp_servers": servers}), encoding="utf-8")
+    return config_path
+
+
+def test_runner_get_tools_includes_registry_mcp_tools(monkeypatch):
+    """runner 的工具列表 = 内置 + MCP 动态工具（registry 聚合）。"""
+    from sjtu_agent.agent import runner
+    from sjtu_agent.extensions import registry
+
+    fake_tools = [
+        {"type": "function", "function": {"name": "get_ddls"}},
+        {"type": "function", "function": {"name": "mcp__demo__echo"}},
+    ]
+    monkeypatch.setattr(
+        registry, "get_available_tools", lambda force_refresh=False: list(fake_tools)
+    )
+
+    tools = runner._get_tools()
+    names = [t["function"]["name"] for t in tools]
+    assert "get_ddls" in names
+    assert "mcp__demo__echo" in names
+
+
+def test_mcp_discovery_timeout_yields_status_tool(tmp_path, monkeypatch):
+    """某个 server 连接挂起时，发现超时应产出可调用的状态工具而非阻塞整轮。"""
+    from sjtu_agent.extensions import mcp_client
+
+    config_path = _write_config(tmp_path, {
+        "demo": {"enabled": True, "transport": "stdio", "command": "python",
+                 "args": ["server.py"], "discovery_timeout": 0.05},
+    })
+    monkeypatch.setattr(mcp_client, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(mcp_client, "_open_session", slow_open_session)
+    mcp_client._TOOLS_CACHE.update({"ts": 0.0, "tools": [], "map": {}})
+
+    tools = mcp_client.list_openai_tools(force_refresh=True)
+    status = [t for t in tools if t["function"]["name"].endswith("__status")]
+    assert status, "挂起的 server 应产出 __status 工具而不是拖死发现流程"
+    desc = status[0]["function"]["description"]
+    assert ("timeout" in desc.lower() or "unavailable" in desc.lower()
+            or "超时" in desc or "不可用" in desc)
+
+
+def test_add_mcp_server_returns_config_path_and_restart_guidance(tmp_path, monkeypatch):
+    """add_mcp_server 成功返回值应包含正确配置路径与重启指引。"""
+    from sjtu_agent.agent import tools
+    from sjtu_agent.extensions import mcp_client
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(tools._mcp_skills, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(mcp_client, "list_openai_tools", lambda force_refresh=False: [])
+
+    result = tools.tool_add_mcp_server(
+        server_id="demo",
+        transport="sse",
+        url="http://127.0.0.1:8765/sse",
+        acknowledge_external_mcp=True,
+    )
+    assert result["ok"] is True
+    assert result["config_path"] == str(config_path)
+    guidance = str(result.get("next_action", "")) + str(result.get("checklist", ""))
+    assert "daemons restart" in guidance
+    assert "重启" in guidance


### PR DESCRIPTION
fix(mcp): deliver MCP tools to the runner + surface server failures (issue #149-2)

Root cause from the reported chat screenshots: add_mcp_server wrote the
config and the user restarted things, but `mcp__*` tools never appeared.
That's because runner._get_tools() returned only the static TOOLS list —
get_available_tools() (builtin + dynamic MCP) was exported but never
consumed by the actual request path.

Changes:
- runner._get_tools() now lazy-imports registry.get_available_tools(), so
  MCP server tools are actually included in what is sent to the model
  (60s TTL cache; no per-turn reconnect).
- mcp_client: per-server discovery timeout (default 15s, configurable via
  server "discovery_timeout") so a hung/unreachable server degrades to a
  callable `mcp__<id>__status` tool instead of stalling every turn; the
  status tool description now carries the concrete failure reason + fix
  hints (venv deps + daemons restart).
- tool_add_mcp_server returns config_path + a checklist (install deps into
  the bot process venv, `sjtu-agent daemons restart --services ...`), fixing
  the wrong-path/wrong-restart guidance from the report.

Tests (TDD):
- tests/test_mcp_runner_integration.py: runner includes MCP tools via
  registry; discovery timeout yields a status tool; add_mcp_server guidance
  contains config path + restart command (3 new tests).
- Full suite: 566 passed.

Part of the #149 follow-up plan (item 2).