### PR TITLE
fix(web): align chat client config with CLI (provider default base_url/model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
+## Unreleased
+- 🖥 WebUI 修复：聊天客户端与 CLI 对齐——只有 `.env` 的 API Key（如 `ZHIYUAN_API_KEY`）、没有 `agent_config.json` 时，按 provider 预设补默认 `base_url` / `model`，不再默认走 api.openai.com（校园外"WebUI timed out、CLI 正常"的根因）
+
 ## v0.21.0 (2026-08-20)
 - 📘 服务器部署文档补全：定时推送（remind-check 守护进程）生效链路与排查 + 工作区（`SJTU_AGENT_HOME` / `SJTU_HOMEWORK_DIR`）跨机器三种方案（SSHFS / rsync / 各自独立）（issue #149-3、#149-6）
 - 🩹 附件解析失败如实透出 + 防幻觉：失败上下文携带真实原因，并明确禁止模型编造"权限不足/白名单/沙箱限制"等不实说法（issue #149-4）

--- a/sjtu_agent/web/server.py
+++ b/sjtu_agent/web/server.py
@@ -409,15 +409,31 @@ def _build_history(_agent, session_id: str | None) -> list[dict]:
 
 def _get_chat_client():
     """根据当前配置创建客户端。
-    与 agent.py 的 _make_client 保持一致：
+    与 agent.py / chat_loop.load_agent_config 保持一致：
+    - agent_config.json 显式配置优先；
+    - 只有 .env 的 API Key 时，按 provider 预设补默认 base_url / model
+      （修复：Web 侧之前缺这一步，导致没有 agent_config.json、只配了
+      ZHIYUAN_API_KEY 在 .env 的部署里，WebUI 默认走 api.openai.com，
+      校园外连不上就 timed out，而 CLI 正常）；
     - claude 模型 → Anthropic SDK（带 claude-cli UA，兼容中转代理）
     - 其他模型   → OpenAI SDK
     """
     agent_cfg = _read_agent_config()
     env = _read_env()
     provider = str(agent_cfg.get("provider", "") or "").strip().lower()
-    base_url = agent_cfg.get("base_url") or None
-    model = agent_cfg.get("model", "deepseek-chat")
+    if not provider:
+        # 由 .env 反推 provider（与 _get_status 的推断保持一致）
+        if env.get("ANTHROPIC_API_KEY"):
+            provider = "anthropic"
+        elif env.get("ZHIYUAN_API_KEY"):
+            provider = "zhiyuan"
+        elif env.get("DEEPSEEK_API_KEY"):
+            provider = "deepseek"
+        elif env.get("OPENAI_API_KEY"):
+            provider = "openai"
+    preset = PRESETS.get(provider, {})
+    base_url = (agent_cfg.get("base_url") or preset.get("base_url") or None) or None
+    model = agent_cfg.get("model") or preset.get("model") or "deepseek-chat"
     ua = agent_cfg.get("user_agent", "claude-cli/1.0.57")
     api_key = agent_cfg.get("api_key", "")
 

--- a/tests/test_web_chat_client.py
+++ b/tests/test_web_chat_client.py
@@ -1,0 +1,78 @@
+"""tests/test_web_chat_client.py — WebUI 聊天客户端配置解析。
+
+回归：WebUI 与 CLI 的 LLM 配置不一致 bug（同学反馈"CLI 能通、WebUI timed out"）。
+CLI 的 load_agent_config() 在只有 `.env` 的 ZHIYUAN_API_KEY、没有 agent_config.json
+时会把 base_url 默认补成 https://models.sjtu.edu.cn/api/v1；而 Web 的
+_get_chat_client() 缺这一步 → base_url=None → OpenAI 客户端默认走
+api.openai.com，校外连不上就 timed out。这里锁住修复后的行为。
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    """每个测试后清空模块缓存状态（如有）。"""
+    yield
+
+
+def _get_chat_client(monkeypatch, agent_cfg=None, env=None):
+    from sjtu_agent.web import server
+
+    monkeypatch.setattr(server, "_read_agent_config", lambda: dict(agent_cfg or {}))
+    monkeypatch.setattr(server, "_read_env", lambda: dict(env or {}))
+    return server._get_chat_client()
+
+
+def test_zhiyuan_env_only_defaults_base_url(monkeypatch):
+    """只有 .env 的 ZHIYUAN_API_KEY、无 agent_config.json：应默认致远一号端点。"""
+    client, model, proto = _get_chat_client(
+        monkeypatch,
+        agent_cfg={},
+        env={"ZHIYUAN_API_KEY": "sk-zhiyuan-test"},
+    )
+    assert proto == "openai"
+    assert model == "deepseek-chat"
+    assert "models.sjtu.edu.cn" in str(client.base_url)
+    assert client.api_key == "sk-zhiyuan-test"
+
+
+def test_explicit_base_url_wins_over_preset(monkeypatch):
+    """agent_config.json 显式给了 base_url 时，以它为准（不覆盖用户配置）。"""
+    client, model, proto = _get_chat_client(
+        monkeypatch,
+        agent_cfg={
+            "provider": "custom",
+            "base_url": "https://my-gateway.example.com/v1",
+            "api_key": "k2",
+            "model": "some-model",
+        },
+        env={},
+    )
+    assert proto == "openai"
+    assert model == "some-model"
+    assert "my-gateway.example.com" in str(client.base_url)
+
+
+def test_anthropic_provider_defaults_from_preset(monkeypatch):
+    """provider 已知且只有 env key：用预设的终点与 claude 模型。"""
+    client, model, proto = _get_chat_client(
+        monkeypatch,
+        agent_cfg={},
+        env={"ANTHROPIC_API_KEY": "sk-ant"},
+    )
+    assert proto == "anthropic"
+    assert model.startswith("claude")
+    assert "api.anthropic.com" in str(client.base_url)
+
+
+def test_env_key_fallback_when_agent_cfg_has_provider_only(monkeypatch):
+    """agent_config.json 只有 provider、key 来自 env：能拿到 key 并补默认端点。"""
+    client, model, proto = _get_chat_client(
+        monkeypatch,
+        agent_cfg={"provider": "zhiyuan"},
+        env={"ZHIYUAN_API_KEY": "sk-fallback"},
+    )
+    assert proto == "openai"
+    assert "models.sjtu.edu.cn" in str(client.base_url)
+    assert client.api_key == "sk-fallback"


### PR DESCRIPTION
fix(web): align chat client config with CLI — apply provider default base_url/model