### PR TITLE
chore: bump version to v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
-## Unreleased
+## v0.21.1 (2026-08-21)
 - 🤖 默认模型切换：`deepseek-v4-flash` 取代已弃用的 `deepseek-chat`（Zhiyuan/DeepSeek 预设、CLI/Web/各 bot 的默认模型、setup 向导提示与文档同步更新）
 - 🖥 WebUI 修复：聊天客户端与 CLI 对齐——只有 `.env` 的 API Key（如 `ZHIYUAN_API_KEY`）、没有 `agent_config.json` 时，按 provider 预设补默认 `base_url` / `model`，不再默认走 api.openai.com（校园外"WebUI timed out、CLI 正常"的根因）
 

--- a/README.md
+++ b/README.md
@@ -368,4 +368,4 @@ npm run docs:build           # 构建文档站
 
 ## 版本
 
-当前版本：**v0.21.0**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。
+当前版本：**v0.21.1**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -632,7 +632,7 @@ The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on 
 
 ## Version
 
-Current version: **v0.21.0**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
+Current version: **v0.21.1**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
 
 ## Release Notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.21.0"
+version = "0.21.1"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.11, <4.0"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"


### PR DESCRIPTION
chore: bump version to v0.21.1（默认模型 deepseek-v4-flash + WebUI 配置对齐修复）