### PR TITLE
chore: bump version to v0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
-## Unreleased
+## v0.21.3 (2026-08-21)
 - 🤖 致远一号默认模型按平台文档定回 **`deepseek-chat`**（DeepSeek V4 Flash 常规模式调用名；`deepseek-reasoner` 为思考模式、`minimax`、`qwen` 亦可用），`public-models` 作为团队受限（403）时的公共池备选；引导向导与示例配置同步列出真实调用名
 
 ## v0.21.2 (2026-08-21)

--- a/README.md
+++ b/README.md
@@ -368,4 +368,4 @@ npm run docs:build           # 构建文档站
 
 ## 版本
 
-当前版本：**v0.21.2**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。
+当前版本：**v0.21.3**。发布历史见 [Releases](https://github.com/kuan-er/sjtu-agent/releases)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -632,7 +632,7 @@ The Feishu Bot self-checks credentials, ChromaDB, and Agent API connectivity on 
 
 ## Version
 
-Current version: **v0.21.2**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
+Current version: **v0.21.3**. Release history: [Releases](https://github.com/kuan-er/sjtu-agent/releases).
 
 ## Release Notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sjtu-agent"
-version = "0.21.2"
+version = "0.21.3"
 description = "Deployable SJTU campus agent with CLI, multi-platform bots (Feishu/Telegram/WeChat/QQ), and MCP server."
 readme = "README.md"
 requires-python = ">=3.11, <4.0"

--- a/sjtu_agent/__init__.py
+++ b/sjtu_agent/__init__.py
@@ -16,4 +16,4 @@ if sys.stderr is None:
 
 __all__ = ["__version__"]
 
-__version__ = "0.21.2"
+__version__ = "0.21.3"


### PR DESCRIPTION
chore: bump version to v0.21.3（致远一号调用名 deepseek-chat 修正）