### PR TITLE
fix(feishu): allow parse of feishu_media staging dir (路径越权)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 本文件记录各版本的用户可见变化。Agent 通过 `get_recent_updates` 读取（问「最近更新了什么」时），不写入 system prompt。
 
 ## Unreleased
+- 🩹 修复飞书媒体"路径越权"：`parse_local_file` / `read_assignment_file` 允许根目录新增 `DATA_DIR/feishu_media`（bot 下载的图片/文件在此，之前校验越权导致 bot 读不到通讯软件发来的图/附件）
 - 📖 文档：README 中英 / `.env.example` 补充致远一号官方调用指南链接（claw.sjtu.edu.cn/guide/sjtu-api，调用名/限流/校园网要求以官方为准）
 
 ## v0.21.3 (2026-08-21)

--- a/sjtu_agent/agent/tools/_core.py
+++ b/sjtu_agent/agent/tools/_core.py
@@ -3430,7 +3430,9 @@ def tool_list_assignment_files(
 def _resolve_allowed_local_file(file_path: str) -> Path | None:
     """把用户给的文件路径解析到允许读取的根目录内。
 
-    允许：仓库目录、SJTU_HOMEWORK_DIR / assignments、Web GUI 上传目录。
+    允许：仓库目录、SJTU_HOMEWORK_DIR / assignments、Web GUI 上传目录、
+    飞书媒体暂存目录（feishu_media —— bot 下载的图片/文件放这里，
+    不放开会导致 bot 解析附件报"路径越权"）。
     不允许读取运行时目录中的 .env / config.json 等凭据文件。
     """
     raw = Path(file_path)
@@ -3439,6 +3441,7 @@ def _resolve_allowed_local_file(file_path: str) -> Path | None:
         ROOT.resolve(),
         Path(ASSIGNMENTS_DIR).resolve(),
         (Path(DATA_DIR) / "web_attachments").resolve(),
+        (Path(DATA_DIR) / "feishu_media").resolve(),
     )
     if any(path.is_relative_to(root) for root in allowed_roots):
         return path

--- a/tests/test_parse_local_paths.py
+++ b/tests/test_parse_local_paths.py
@@ -25,3 +25,35 @@ def test_runtime_credentials_are_still_rejected(monkeypatch, tmp_path):
 
     assert core._resolve_allowed_local_file(str(data_dir / "config.json")) is None
     assert core._resolve_allowed_local_file(str(data_dir / ".env")) is None
+
+
+def test_feishu_media_path_is_allowed(monkeypatch, tmp_path):
+    """飞书媒体暂存目录必须可读（否则 bot 解析图片/文件会'路径越权'）。"""
+    root = tmp_path / "repo"
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(core, "ROOT", root)
+    monkeypatch.setattr(core, "ASSIGNMENTS_DIR", root / "assignments")
+    monkeypatch.setattr(core, "DATA_DIR", data_dir)
+
+    allowed = core._resolve_allowed_local_file(str(data_dir / "feishu_media" / "img_xxx.jpg"))
+    assert allowed == (data_dir / "feishu_media" / "img_xxx.jpg").resolve()
+
+
+def test_feishu_media_parse_via_tool_ok(monkeypatch, tmp_path):
+    """飞书媒体目录中的文件能被 tool_parse_local_file 正常解析（回归：越权修复）。"""
+    root = tmp_path / "repo"
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(core, "ROOT", root)
+    monkeypatch.setattr(core, "ASSIGNMENTS_DIR", root / "assignments")
+    monkeypatch.setattr(core, "DATA_DIR", data_dir)
+
+    media_dir = data_dir / "feishu_media"
+    media_dir.mkdir(parents=True)
+    f = media_dir / "note.txt"
+    f.write_text("hello media", encoding="utf-8")
+
+    from sjtu_agent.agent.tools import tool_parse_local_file
+
+    r = tool_parse_local_file(str(f), max_chars=200, strategy="auto")
+    assert "路径越权" not in str(r)
+    assert "hello media" in str(r)


### PR DESCRIPTION
fix(feishu): allow parse of feishu_media staging dir — real 路径越权 root cause