### PR TITLE
fix(wechat): update iLink protocol validation

### DIFF
--- a/scripts/wechat_bot.py
+++ b/scripts/wechat_bot.py
@@ -74,6 +74,9 @@ _logger = get_logger("wechat_bot")
 # ── ilink 接口常量 ─────────────────────────────────────────────────────────────
 
 ILINK_BASE = "https://ilinkai.weixin.qq.com"
+ILINK_CHANNEL_VERSION = "1.0.3"
+# iLink encodes 1.0.3 as major << 16 | minor << 8 | patch.
+ILINK_APP_CLIENT_VERSION = "65539"
 
 _ANSI_RE = re.compile(r'\x1b\[[0-9;]*[mKABCDEFGHJKST]')
 _TMP_DIR = Path(tempfile.mkdtemp(prefix="sjtu_wechat_"))
@@ -99,11 +102,13 @@ class ILinkClient:
             "AuthorizationType": "ilink_bot_token",
             "Authorization": f"Bearer {self.token}",
             "X-WECHAT-UIN": uin,
+            "iLink-App-Id": "bot",
+            "iLink-App-ClientVersion": ILINK_APP_CLIENT_VERSION,
         }
 
     def _post(self, endpoint: str, body: dict) -> dict:
         """POST 到 ilink bot 接口，自动注入 base_info 和 Content-Length。"""
-        body["base_info"] = {"channel_version": "1.0.3"}
+        body["base_info"] = {"channel_version": ILINK_CHANNEL_VERSION}
         raw = json.dumps(body, ensure_ascii=False).encode("utf-8")
         headers = self._headers()
         headers["Content-Length"] = str(len(raw))
@@ -113,9 +118,17 @@ class ILinkClient:
             headers=headers,
             timeout=35,
         )
+        resp.raise_for_status()
         text = resp.text.strip()
         if text and text != "{}":
-            return resp.json()
+            data = resp.json()
+            ret = data.get("ret", 0)
+            errcode = data.get("errcode", 0)
+            if ret not in (None, 0) or errcode not in (None, 0):
+                code = errcode or ret
+                errmsg = data.get("errmsg") or "unknown error"
+                raise RuntimeError(f"iLink {endpoint} failed ({code}): {errmsg}")
+            return data
         return {"ret": 0}
 
     # ---- 消息接收 -------------------------------------------------------------

--- a/tests/test_wechat_ilink_protocol.py
+++ b/tests/test_wechat_ilink_protocol.py
@@ -1,0 +1,54 @@
+"""Protocol compatibility tests for the WeChat iLink client."""
+
+import json
+
+import pytest
+
+from scripts import wechat_bot
+from scripts.wechat_bot import ILinkClient
+
+
+def test_ilink_headers_identify_the_bot_client():
+    headers = ILinkClient("test-token")._headers()
+
+    assert headers["iLink-App-Id"] == "bot"
+    assert headers["iLink-App-ClientVersion"] == "65539"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"ret": -14, "errmsg": "session timeout"},
+        {"ret": 0, "errcode": -14, "errmsg": "session timeout"},
+    ],
+    ids=["ret", "errcode"],
+)
+def test_get_updates_rejects_each_ilink_error_code(monkeypatch, payload):
+    class FakeResponse:
+        status_code = 200
+        text = json.dumps(payload)
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return payload
+
+    monkeypatch.setattr(wechat_bot.httpx, "post", lambda *args, **kwargs: FakeResponse())
+
+    with pytest.raises(RuntimeError, match="session timeout"):
+        ILinkClient("expired-token").get_updates()
+
+
+def test_get_updates_rejects_http_error_response(monkeypatch):
+    class FakeResponse:
+        status_code = 502
+        text = "{}"
+
+        def raise_for_status(self):
+            raise RuntimeError("HTTP 502")
+
+    monkeypatch.setattr(wechat_bot.httpx, "post", lambda *args, **kwargs: FakeResponse())
+
+    with pytest.raises(RuntimeError, match="HTTP 502"):
+        ILinkClient("test-token").get_updates()


### PR DESCRIPTION
## Summary

- Add the current iLink client identity headers (`iLink-App-Id: bot` and encoded client version `65539` for protocol `1.0.3`).
- Raise HTTP and iLink `ret` / `errcode` failures instead of silently treating them as an empty successful poll.
- Add regression coverage for required headers, `ret`-only errors, `errcode`-only errors, and HTTP failures.

## Root cause

The WeChat client omitted application identity headers now sent by Tencent's reference implementation. It also ignored non-zero iLink protocol responses, so `wechat-bot --test` could report a valid token with zero messages even when the backend returned a session error such as `-14`.

## Tests

- `python -m pytest -q`
- Result: `584 passed, 1 skipped`
- Mutation check: removing the `ret` validation makes the dedicated `ret` regression case fail.

## Scope

This PR changes only the WeChat iLink HTTP boundary and its tests. It does not include credentials, runtime configuration, or unrelated local changes.

Implementation and tests were completed with Codex assistance, followed by a read-only code review and the full project test suite.